### PR TITLE
SimpLL: RemoveUnusedReturnValuesPass: Skip all functions without a body.

### DIFF
--- a/diffkemp/simpll/passes/RemoveUnusedReturnValuesPass.cpp
+++ b/diffkemp/simpll/passes/RemoveUnusedReturnValuesPass.cpp
@@ -47,13 +47,13 @@ PreservedAnalyses RemoveUnusedReturnValuesPass::run(
         if (Fun.getIntrinsicID() != llvm::Intrinsic::not_intrinsic)
             continue;
 
-        if (Fun.getLinkage() != GlobalValue::LinkageTypes::ExternalLinkage)
+        if (!Fun.isDeclaration())
             continue;
 
         if (Fun.getReturnType()->isVoidTy())
             continue;
 
-        if (CalledFuns.find(&Fun) == CalledFuns.end())
+        if (&Fun == Main || CalledFuns.find(&Fun) == CalledFuns.end())
             continue;
 
         bool can_replace = true;


### PR DESCRIPTION
Checking whether the function has a body using `GlobalValue::LinkageTypes::ExternalLinkage` is unreliable; for example when run on simple programs it replaces the return type of the main function, making it incomparable by `DifferentialFunctionComparator`, which compares the deleted old function instead.

This bug didn't appear until the `callsTransitively` check was replaced by a function list, because the old method excluded the main function.

The proposed fix is to actually check the number of basic blocks in the function, and if it's not zero, then skip the function.
