### PR TITLE
SimpLL: RemoveUnunsedReturnValuesPass: Replace only functions that are of void type in the other module.

### DIFF
--- a/diffkemp/simpll/Transforms.cpp
+++ b/diffkemp/simpll/Transforms.cpp
@@ -92,10 +92,11 @@ void simplifyModulesDiff(Config &config) {
                                                          config.SecondFun));
 
     // Module passes
-    PassManager<Module, AnalysisManager<Module, Function *>, Function *> mpm;
+    PassManager<Module, AnalysisManager<Module, Function *>, Function *,
+        Module *> mpm;
     mpm.addPass(RemoveUnusedReturnValuesPass {});
-    mpm.run(*config.First, mam, config.FirstFun);
-    mpm.run(*config.Second, mam, config.SecondFun);
+    mpm.run(*config.First, mam, config.FirstFun, config.Second.get());
+    mpm.run(*config.Second, mam, config.SecondFun, config.First.get());
 
     DebugInfo(*config.First, *config.Second,
               config.FirstFun, config.SecondFun,

--- a/diffkemp/simpll/passes/RemoveUnusedReturnValuesPass.cpp
+++ b/diffkemp/simpll/passes/RemoveUnusedReturnValuesPass.cpp
@@ -19,7 +19,8 @@
 PreservedAnalyses RemoveUnusedReturnValuesPass::run(
         Module &Mod,
         AnalysisManager<Module, Function *> &mam,
-        Function *Main) {
+        Function *Main,
+        Module *ModOther) {
 
     // These attributes are invalid for void functions
     Attribute::AttrKind badAttributes[] = {
@@ -51,6 +52,12 @@ PreservedAnalyses RemoveUnusedReturnValuesPass::run(
             continue;
 
         if (Fun.getReturnType()->isVoidTy())
+            continue;
+
+        if (!ModOther->getFunction(Fun.getName()))
+            continue;
+
+        if (!ModOther->getFunction(Fun.getName())->getReturnType()->isVoidTy())
             continue;
 
         if (&Fun == Main || CalledFuns.find(&Fun) == CalledFuns.end())

--- a/diffkemp/simpll/passes/RemoveUnusedReturnValuesPass.h
+++ b/diffkemp/simpll/passes/RemoveUnusedReturnValuesPass.h
@@ -24,7 +24,7 @@ class RemoveUnusedReturnValuesPass
         : public PassInfoMixin<RemoveUnusedReturnValuesPass> {
   public:
     PreservedAnalyses run(Module &Mod, AnalysisManager<Module, Function *> &mam,
-                          Function *Main);
+                          Function *Main, Module *ModOther);
 };
 
 #endif //DIFFKEMP_SIMPLL_REMOVEUNUSEDRETURNVALUESPASS_H


### PR DESCRIPTION
The optimization of RemoveUnunsedReturnValuesPass, checking whether the function is void in the other module, in case it is not (or does not exist in the other module), skip it.