### PR TITLE
SimpLL: Compare struct GEPs by member names using debug information.

### DIFF
--- a/diffkemp/simpll/DebugInfo.cpp
+++ b/diffkemp/simpll/DebugInfo.cpp
@@ -59,6 +59,7 @@ DICompositeType *DebugInfo::getStructTypeInfo(const StringRef name,
                                               const Program prog) const {
     auto types = prog == Program::First ? DebugInfoFirst.types()
                                         : DebugInfoSecond.types();
+
     for (auto Type : types) {
         if (auto StructType = dyn_cast<DICompositeType>(Type)) {
             if (StructType->getName() == name)
@@ -160,7 +161,16 @@ void DebugInfo::calculateGEPIndexAlignments() {
                                         (unsigned) indexSecond,
                                         IndexConstant->getBitWidth(),
                                         ModFirst.getContext());
+
                                 GEP->dump();
+
+                                EINM.insert(
+                                    {{dyn_cast<StructType>(indexedType), indexFirst},
+                                                                elementName});
+                                EINM.insert(
+                                    {{ModSecond.getTypeByName(indexedType->getStructName()), indexSecond},
+                                                                elementName});
+
                                 errs() << "New index: " << indexSecond << "\n";
                             }
                         }

--- a/diffkemp/simpll/DebugInfo.cpp
+++ b/diffkemp/simpll/DebugInfo.cpp
@@ -164,12 +164,13 @@ void DebugInfo::calculateGEPIndexAlignments() {
 
                                 GEP->dump();
 
-                                EINM.insert(
-                                    {{dyn_cast<StructType>(indexedType), indexFirst},
-                                                                elementName});
-                                EINM.insert(
-                                    {{ModSecond.getTypeByName(indexedType->getStructName()), indexSecond},
-                                                                elementName});
+                                StructFieldNames.insert(
+                                    {{dyn_cast<StructType>(indexedType),
+                                        indexFirst}, elementName});
+                                StructFieldNames.insert(
+                                    {{ModSecond.getTypeByName(
+                                            indexedType->getStructName()),
+                                        indexSecond}, elementName});
 
                                 errs() << "New index: " << indexSecond << "\n";
                             }

--- a/diffkemp/simpll/DebugInfo.h
+++ b/diffkemp/simpll/DebugInfo.h
@@ -33,6 +33,9 @@ using namespace llvm;
 ///    different indices. This analysis matches fields with same name and saves
 ///    the index offset into the metadata of a GEP instruction.
 class DebugInfo {
+  using ElementIndexToNameMap = std::map<std::pair<StructType *, uint64_t>,
+                                    StringRef>;
+
   public:
     DebugInfo(Module &modFirst, Module &modSecond,
               Function *funFirst, Function *funSecond,
@@ -44,6 +47,9 @@ class DebugInfo {
         DebugInfoSecond.processModule(ModSecond);
         calculateGEPIndexAlignments();
     };
+
+    /// Maps structure type and index to struct member names
+    ElementIndexToNameMap EINM;
 
   private:
     Function *FunFirst;

--- a/diffkemp/simpll/DebugInfo.h
+++ b/diffkemp/simpll/DebugInfo.h
@@ -33,7 +33,7 @@ using namespace llvm;
 ///    different indices. This analysis matches fields with same name and saves
 ///    the index offset into the metadata of a GEP instruction.
 class DebugInfo {
-  using ElementIndexToNameMap = std::map<std::pair<StructType *, uint64_t>,
+  using StructFieldNamesMap = std::map<std::pair<StructType *, uint64_t>,
                                     StringRef>;
 
   public:
@@ -49,7 +49,7 @@ class DebugInfo {
     };
 
     /// Maps structure type and index to struct member names
-    ElementIndexToNameMap EINM;
+    StructFieldNamesMap StructFieldNames;
 
   private:
     Function *FunFirst;

--- a/diffkemp/simpll/DifferentialFunctionComparator.cpp
+++ b/diffkemp/simpll/DifferentialFunctionComparator.cpp
@@ -21,7 +21,7 @@
 /// Compare GEPs. This code is copied from FunctionComparator::cmpGEPs since it
 /// was not possible to simply call the original function.
 /// Handles offset between matching GEP indices in the compared modules.
-/// Uses data saved in ElementIndexToNameMap.
+/// Uses data saved in StructFieldNames.
 int DifferentialFunctionComparator::cmpGEPs(
         const GEPOperator *GEPL,
         const GEPOperator *GEPR) const {
@@ -91,7 +91,7 @@ int DifferentialFunctionComparator::cmpGEPs(
             }
 
             // The indexed type is a structure type - compare the names of the
-            // structure members from the ElementIndexToNameMap
+            // structure members from StructFieldNames.
             auto MemberNameL = DI->StructFieldNames.find(
                 {dyn_cast<StructType>(ValueTypeL),
                 NumericIndexL.getZExtValue()});

--- a/diffkemp/simpll/DifferentialFunctionComparator.h
+++ b/diffkemp/simpll/DifferentialFunctionComparator.h
@@ -23,12 +23,17 @@ using namespace llvm;
 /// Extension of FunctionComparator from LLVM designed to compare functions in
 /// different modules (original FunctionComparator assumes that both functions
 /// are in a single module).
+
+using ElementIndexToNameMap = std::map<std::pair<StructType *, uint64_t>,
+                                StringRef>;
+
 class DifferentialFunctionComparator : public FunctionComparator {
   public:
     DifferentialFunctionComparator(const Function *F1,
                                    const Function *F2,
-                                   GlobalNumberState *GN)
-            : FunctionComparator(F1, F2, GN) {}
+                                   GlobalNumberState *GN,
+                                   const ElementIndexToNameMap *EINM)
+            : FunctionComparator(F1, F2, GN), EINM(EINM) {};
 
   protected:
     /// Specific comparison of GEP instructions/operators.
@@ -39,6 +44,9 @@ class DifferentialFunctionComparator : public FunctionComparator {
     /// Specific comparison of attribute lists.
     /// Attributes that do not affect the semantics of functions are removed.
     int cmpAttrs(const AttributeList L, const AttributeList R) const override;
+
+  private:
+    const ElementIndexToNameMap *EINM;
 };
 
 #endif //DIFFKEMP_SIMPLL_DIFFERENTIALFUNCTIONCOMPARATOR_H

--- a/diffkemp/simpll/DifferentialFunctionComparator.h
+++ b/diffkemp/simpll/DifferentialFunctionComparator.h
@@ -16,6 +16,7 @@
 #ifndef DIFFKEMP_SIMPLL_DIFFERENTIALFUNCTIONCOMPARATOR_H
 #define DIFFKEMP_SIMPLL_DIFFERENTIALFUNCTIONCOMPARATOR_H
 
+#include "DebugInfo.h"
 #include <llvm/Transforms/Utils/FunctionComparator.h>
 
 using namespace llvm;
@@ -24,16 +25,13 @@ using namespace llvm;
 /// different modules (original FunctionComparator assumes that both functions
 /// are in a single module).
 
-using ElementIndexToNameMap = std::map<std::pair<StructType *, uint64_t>,
-                                StringRef>;
-
 class DifferentialFunctionComparator : public FunctionComparator {
   public:
     DifferentialFunctionComparator(const Function *F1,
                                    const Function *F2,
                                    GlobalNumberState *GN,
-                                   const ElementIndexToNameMap *EINM)
-            : FunctionComparator(F1, F2, GN), EINM(EINM) {};
+                                   const DebugInfo *DI)
+            : FunctionComparator(F1, F2, GN), DI(DI) {};
 
   protected:
     /// Specific comparison of GEP instructions/operators.
@@ -46,7 +44,7 @@ class DifferentialFunctionComparator : public FunctionComparator {
     int cmpAttrs(const AttributeList L, const AttributeList R) const override;
 
   private:
-    const ElementIndexToNameMap *EINM;
+    const DebugInfo *DI;
 };
 
 #endif //DIFFKEMP_SIMPLL_DIFFERENTIALFUNCTIONCOMPARATOR_H

--- a/diffkemp/simpll/ModuleComparator.cpp
+++ b/diffkemp/simpll/ModuleComparator.cpp
@@ -17,8 +17,6 @@
 #include "Utils.h"
 #include <llvm/Support/raw_ostream.h>
 
-#define DEBUG
-
 /// Syntactical comparison of functions.
 /// Function declarations are equal if they have the same name.
 /// Functions with body are compared using custom FunctionComparator that
@@ -43,7 +41,7 @@ void ModuleComparator::compareFunctions(Function *FirstFun,
     }
 
     // Comparing functions with bodies using custom FunctionComparator.
-    DifferentialFunctionComparator fComp(FirstFun, SecondFun, &GS);
+    DifferentialFunctionComparator fComp(FirstFun, SecondFun, &GS, &DI->EINM);
     if (fComp.compare() == 0) {
 #ifdef DEBUG
         errs() << "Function " << FirstFun->getName()

--- a/diffkemp/simpll/ModuleComparator.cpp
+++ b/diffkemp/simpll/ModuleComparator.cpp
@@ -41,7 +41,7 @@ void ModuleComparator::compareFunctions(Function *FirstFun,
     }
 
     // Comparing functions with bodies using custom FunctionComparator.
-    DifferentialFunctionComparator fComp(FirstFun, SecondFun, &GS, &DI->EINM);
+    DifferentialFunctionComparator fComp(FirstFun, SecondFun, &GS, DI);
     if (fComp.compare() == 0) {
 #ifdef DEBUG
         errs() << "Function " << FirstFun->getName()

--- a/diffkemp/simpll/ModuleComparator.h
+++ b/diffkemp/simpll/ModuleComparator.h
@@ -16,12 +16,16 @@
 #define DIFFKEMP_SIMPLL_MODULECOMPARATOR_H
 
 #include "DifferentialGlobalNumberState.h"
+#include "DebugInfo.h"
 #include <llvm/IR/Module.h>
 #include <set>
 
 using namespace llvm;
 
 class ModuleComparator {
+    using ElementIndexToNameMap =
+        std::map<std::pair<StructType *, uint64_t>, StringRef>;
+
     Module &First;
     Module &Second;
 
@@ -32,8 +36,13 @@ class ModuleComparator {
     using FunPair = std::pair<Function *, Function *>;
     std::map<FunPair, Result> ComparedFuns;
 
-    ModuleComparator(Module &First, Module &Second)
-            : First(First), Second(Second), GS(&First, &Second, this) {}
+    /// DebugInfo class storing results from analysing debug information
+    const DebugInfo *DI;
+
+    ModuleComparator(Module &First, Module &Second,
+                     const DebugInfo *DI)
+            : First(First), Second(Second), GS(&First, &Second, this),
+            DI(DI) {}
 
     /// Syntactically compare two functions.
     /// The result of the comparison is stored into the ComparedFuns map.

--- a/diffkemp/simpll/ModuleComparator.h
+++ b/diffkemp/simpll/ModuleComparator.h
@@ -15,17 +15,14 @@
 #ifndef DIFFKEMP_SIMPLL_MODULECOMPARATOR_H
 #define DIFFKEMP_SIMPLL_MODULECOMPARATOR_H
 
-#include "DifferentialGlobalNumberState.h"
 #include "DebugInfo.h"
+#include "DifferentialGlobalNumberState.h"
 #include <llvm/IR/Module.h>
 #include <set>
 
 using namespace llvm;
 
 class ModuleComparator {
-    using ElementIndexToNameMap =
-        std::map<std::pair<StructType *, uint64_t>, StringRef>;
-
     Module &First;
     Module &Second;
 

--- a/diffkemp/simpll/Transforms.cpp
+++ b/diffkemp/simpll/Transforms.cpp
@@ -98,13 +98,16 @@ void simplifyModulesDiff(Config &config) {
     mpm.run(*config.First, mam, config.FirstFun, config.Second.get());
     mpm.run(*config.Second, mam, config.SecondFun, config.First.get());
 
-    DebugInfo(*config.First, *config.Second,
+    DebugInfo DI(*config.First, *config.Second,
               config.FirstFun, config.SecondFun,
               mam.getResult<CalledFunctionsAnalysis>(*config.First,
                                                      config.FirstFun));
+#ifdef DEBUG
+    llvm::errs() << "EINM size: " << DI.EINM.size() << '\n';
+#endif
 
     // Compare functions for syntactical equivalence
-    ModuleComparator modComp(*config.First, *config.Second);
+    ModuleComparator modComp(*config.First, *config.Second, &DI);
     if (config.FirstFun && config.SecondFun) {
         modComp.compareFunctions(config.FirstFun, config.SecondFun);
     } else {
@@ -167,3 +170,4 @@ void postprocessModule(Module &Mod, Function *Main) {
     mpm.addPass(RemoveLifetimeCallsPass {});
     mpm.run(Mod, mam);
 }
+

--- a/diffkemp/simpll/Transforms.cpp
+++ b/diffkemp/simpll/Transforms.cpp
@@ -103,7 +103,8 @@ void simplifyModulesDiff(Config &config) {
                  mam.getResult<CalledFunctionsAnalysis>(*config.First,
                                                         config.FirstFun));
 #ifdef DEBUG
-    llvm::errs() << "StructFieldNames size: " << DI.StructFieldNames.size() << '\n';
+    llvm::errs() << "StructFieldNames size: " <<
+        DI.StructFieldNames.size() << '\n';
 #endif
 
     // Compare functions for syntactical equivalence

--- a/diffkemp/simpll/Transforms.cpp
+++ b/diffkemp/simpll/Transforms.cpp
@@ -99,11 +99,11 @@ void simplifyModulesDiff(Config &config) {
     mpm.run(*config.Second, mam, config.SecondFun, config.First.get());
 
     DebugInfo DI(*config.First, *config.Second,
-              config.FirstFun, config.SecondFun,
-              mam.getResult<CalledFunctionsAnalysis>(*config.First,
-                                                     config.FirstFun));
+                 config.FirstFun, config.SecondFun,
+                 mam.getResult<CalledFunctionsAnalysis>(*config.First,
+                                                        config.FirstFun));
 #ifdef DEBUG
-    llvm::errs() << "EINM size: " << DI.EINM.size() << '\n';
+    llvm::errs() << "StructFieldNames size: " << DI.StructFieldNames.size() << '\n';
 #endif
 
     // Compare functions for syntactical equivalence
@@ -170,4 +170,3 @@ void postprocessModule(Module &Mod, Function *Main) {
     mpm.addPass(RemoveLifetimeCallsPass {});
     mpm.run(Mod, mam);
 }
-


### PR DESCRIPTION
It should work (it works in the "ramoops" test case in the spreadsheet), but there are still problems (in some cases) with LLVM `DebugInfoFinder` class, which is not able to find all composite types.