### PR TITLE
Added test for better cmpGEPs in SimpLL.

### DIFF
--- a/tests/regression/test_specs/wm97xx_ts.yaml
+++ b/tests/regression/test_specs/wm97xx_ts.yaml
@@ -8,6 +8,5 @@ params:
   - param: pil
     functions:
       wm9705_phy_init: equal
-      wm9705_poll_touch: timeout
-      wm9705_acc_enable: timeout
-
+      wm9705_poll_touch: equal
+      wm9705_acc_enable: equal


### PR DESCRIPTION
Functions wm9705_poll_touch and wm9705_acc_enable are now declared equal by SimpLL, so they no longer timeout. This can be used as a test whether the better cmpGEPs is working in this case.
(This is the case on line 15 in the spreadsheet.)