### PR TITLE
SimpLL: Fixed comparing kzalloc instructions - now comparing

### DIFF
--- a/diffkemp/simpll/DifferentialFunctionComparator.cpp
+++ b/diffkemp/simpll/DifferentialFunctionComparator.cpp
@@ -175,10 +175,18 @@ int DifferentialFunctionComparator::cmpOperations(
 
     if (!isa<StructType>(PTyL->getElementType()) ||
         !isa<StructType>(PTyR->getElementType()))
-        return FunctionComparator::cmpValues(L, R);
+        return Result;
 
     StructType *STyL = dyn_cast<StructType>(PTyL->getElementType());
     StructType *STyR = dyn_cast<StructType>(PTyR->getElementType());
+
+    // Look whether the first argument of kzalloc corresponds to the type size.
+    int TypeSizeL = dyn_cast<ConstantInt>(L->getOperand(0))->getZExtValue();
+    int TypeSizeR = dyn_cast<ConstantInt>(R->getOperand(0))->getZExtValue();
+
+    if (TypeSizeL != LayoutL->getTypeStoreSize(STyL) ||
+        TypeSizeR != LayoutR->getTypeStoreSize(STyR))
+        return Result;
 
     // Look whether the types the memory is allocated for are the same.
     if (STyL->getName() != STyR->getName())

--- a/diffkemp/simpll/DifferentialFunctionComparator.h
+++ b/diffkemp/simpll/DifferentialFunctionComparator.h
@@ -31,7 +31,10 @@ class DifferentialFunctionComparator : public FunctionComparator {
                                    const Function *F2,
                                    GlobalNumberState *GN,
                                    const DebugInfo *DI)
-            : FunctionComparator(F1, F2, GN), DI(DI) {};
+            : FunctionComparator(F1, F2, GN), DI(DI) {
+        LayoutL = new DataLayout(F1->getParent());
+        LayoutR = new DataLayout(F2->getParent());
+   };
 
   protected:
     /// Specific comparison of GEP instructions/operators.
@@ -42,9 +45,15 @@ class DifferentialFunctionComparator : public FunctionComparator {
     /// Specific comparison of attribute lists.
     /// Attributes that do not affect the semantics of functions are removed.
     int cmpAttrs(const AttributeList L, const AttributeList R) const override;
+    /// Handle comparing of memory allocation function in cases where the size
+    /// of the composite type is different
+    int cmpOperations(const Instruction *L, const Instruction *R,
+                    bool &needToCmpOperands) const override;
 
   private:
     const DebugInfo *DI;
+
+    DataLayout *LayoutL, *LayoutR;
 };
 
 #endif //DIFFKEMP_SIMPLL_DIFFERENTIALFUNCTIONCOMPARATOR_H

--- a/diffkemp/simpll/DifferentialFunctionComparator.h
+++ b/diffkemp/simpll/DifferentialFunctionComparator.h
@@ -31,10 +31,9 @@ class DifferentialFunctionComparator : public FunctionComparator {
                                    const Function *F2,
                                    GlobalNumberState *GN,
                                    const DebugInfo *DI)
-            : FunctionComparator(F1, F2, GN), DI(DI) {
-        LayoutL = new DataLayout(F1->getParent());
-        LayoutR = new DataLayout(F2->getParent());
-   };
+            : FunctionComparator(F1, F2, GN), DI(DI),
+              LayoutL(F1->getParent()->getDataLayout()),
+              LayoutR(F2->getParent()->getDataLayout()) { }
 
   protected:
     /// Specific comparison of GEP instructions/operators.
@@ -48,12 +47,12 @@ class DifferentialFunctionComparator : public FunctionComparator {
     /// Handle comparing of memory allocation function in cases where the size
     /// of the composite type is different
     int cmpOperations(const Instruction *L, const Instruction *R,
-                    bool &needToCmpOperands) const override;
+                      bool &needToCmpOperands) const override;
 
   private:
     const DebugInfo *DI;
 
-    DataLayout *LayoutL, *LayoutR;
+    const DataLayout &LayoutL, &LayoutR;
 };
 
 #endif //DIFFKEMP_SIMPLL_DIFFERENTIALFUNCTIONCOMPARATOR_H


### PR DESCRIPTION
structure types by names instead of comparing allocated memory size by
the raw value.
(Currently ignores kzalloc flags.)

Note: I don't have a test case yet, because all cases in the spreadsheet have another difference beside the allocation function inaccuracy.