### PR TITLE
SimpLL: Assign the same number in DifferentialGlobalNumberState to di…

### DIFF
--- a/diffkemp/simpll/DifferentialGlobalNumberState.h
+++ b/diffkemp/simpll/DifferentialGlobalNumberState.h
@@ -43,7 +43,7 @@ class DifferentialGlobalNumberState : public GlobalNumberState {
     using IntegerMap = std::map<APInt, uint64_t, cmpConstants>;
     IntegerMap Constants{IntegerMap(cmpConstants())};
 
-    StringRef PrintFunctionList[5] = {"printk", "dev_warn", "dev_err",
+    std::vector<StringRef> PrintFunctionList = {"printk", "dev_warn", "dev_err",
         "_dev_info", "sprintf"};
 
     Module *First;

--- a/diffkemp/simpll/passes/SimplifyKernelFunctionCallsPass.cpp
+++ b/diffkemp/simpll/passes/SimplifyKernelFunctionCallsPass.cpp
@@ -60,9 +60,13 @@ PreservedAnalyses SimplifyKernelFunctionCallsPass::run(
                     // Functions with 1 mandatory argument
                     auto OpType = dyn_cast<PointerType>(
                             CallInstr->getOperand(0)->getType());
+                    // An additional void pointer is added to the operand list
+                    // so the instruction can be compared as equal even when the
+                    // other one is one of the functions listed in the other if
                     auto newCall = CallInst::Create(
                             CalledFun,
-                            {ConstantPointerNull::get(OpType)},
+                            {ConstantPointerNull::get(OpType),
+                             ConstantPointerNull::get(OpType)},
                             "", &Instr);
                     newCall->setDebugLoc(CallInstr->getDebugLoc());
                     CallInstr->replaceAllUsesWith(newCall);


### PR DESCRIPTION
…fferent

print functions in the kernel.

Also modifies the behaviour of SimplifyKernelFunctionCallsPass to replace
arguments of printk with two null pointers instead of one so the calls of
printk and the other print functions can be compared as equal.