### PR TITLE
SimpLL: Ignore additional null argument in function calls only if

### DIFF
--- a/diffkemp/simpll/DifferentialFunctionComparator.cpp
+++ b/diffkemp/simpll/DifferentialFunctionComparator.cpp
@@ -156,7 +156,7 @@ int DifferentialFunctionComparator::cmpOperations(
             if (CalledL->getName() == "kzalloc")
                 return cmpAllocs(CL, CR, needToCmpOperands);
 
-            if (Result &&
+            if (Result && controlFlowOnly &&
                     abs(CL->getNumOperands() - CR->getNumOperands()) == 1) {
                 needToCmpOperands = false;
                 return cmpCallsWithExtraArg(CL, CR);

--- a/diffkemp/simpll/DifferentialFunctionComparator.h
+++ b/diffkemp/simpll/DifferentialFunctionComparator.h
@@ -29,9 +29,11 @@ class DifferentialFunctionComparator : public FunctionComparator {
   public:
     DifferentialFunctionComparator(const Function *F1,
                                    const Function *F2,
+                                   bool controlFlowOnly,
                                    GlobalNumberState *GN,
                                    const DebugInfo *DI)
             : FunctionComparator(F1, F2, GN), DI(DI),
+              controlFlowOnly(controlFlowOnly),
               LayoutL(F1->getParent()->getDataLayout()),
               LayoutR(F2->getParent()->getDataLayout()) { }
 
@@ -58,6 +60,7 @@ class DifferentialFunctionComparator : public FunctionComparator {
 
   private:
     const DebugInfo *DI;
+    bool controlFlowOnly;
 
     const DataLayout &LayoutL, &LayoutR;
 };

--- a/diffkemp/simpll/ModuleComparator.cpp
+++ b/diffkemp/simpll/ModuleComparator.cpp
@@ -41,7 +41,8 @@ void ModuleComparator::compareFunctions(Function *FirstFun,
     }
 
     // Comparing functions with bodies using custom FunctionComparator.
-    DifferentialFunctionComparator fComp(FirstFun, SecondFun, &GS, DI);
+    DifferentialFunctionComparator fComp(FirstFun, SecondFun, controlFlowOnly,
+                                         &GS, DI);
     if (fComp.compare() == 0) {
 #ifdef DEBUG
         errs() << "Function " << FirstFun->getName()

--- a/diffkemp/simpll/ModuleComparator.h
+++ b/diffkemp/simpll/ModuleComparator.h
@@ -26,6 +26,7 @@ using namespace llvm;
 class ModuleComparator {
     Module &First;
     Module &Second;
+    bool controlFlowOnly;
 
   public:
     /// Possible results of syntactical function comparison.
@@ -36,10 +37,10 @@ class ModuleComparator {
     /// DebugInfo class storing results from analysing debug information
     const DebugInfo *DI;
 
-    ModuleComparator(Module &First, Module &Second,
+    ModuleComparator(Module &First, Module &Second, bool controlFlowOnly,
                      const DebugInfo *DI)
-            : First(First), Second(Second), GS(&First, &Second, this),
-            DI(DI) {}
+            : First(First), Second(Second), controlFlowOnly(controlFlowOnly),
+            GS(&First, &Second, this), DI(DI) {}
 
     /// Syntactically compare two functions.
     /// The result of the comparison is stored into the ComparedFuns map.

--- a/diffkemp/simpll/Transforms.cpp
+++ b/diffkemp/simpll/Transforms.cpp
@@ -128,7 +128,9 @@ std::vector<FunPair> simplifyModulesDiff(Config &config) {
 
     std::vector<FunPair> result;
     // Compare functions for syntactical equivalence
-    ModuleComparator modComp(*config.First, *config.Second, &DI);
+    ModuleComparator modComp(*config.First, *config.Second,
+                             config.ControlFlowOnly, &DI);
+
     if (config.FirstFun && config.SecondFun) {
         modComp.compareFunctions(config.FirstFun, config.SecondFun);
 


### PR DESCRIPTION
the switch -control-flow is active.