### PR TITLE
diffsysctl tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -88,5 +88,9 @@ cmake-build-debug/
 # compilation at all
 tests/regression/diffkabi/kernel_modules
 
+# All files in kernel_modules from diffsysctl - they are not used in the test
+# compilation at all
+tests/regression/diffsysctl/kernel_modules
+
 # Kernel sources directory
 kernel/

--- a/diffkemp/llvm_ir/llvm_sysctl_module.py
+++ b/diffkemp/llvm_ir/llvm_sysctl_module.py
@@ -106,7 +106,8 @@ class LlvmSysctlModule:
                         all_constant = False
                 if all_constant:
                     data = data.get_operand(0)
-            if data.get_const_opcode() == Opcode['BitCast']:
+            if (data.get_kind() == ConstantExprValueKind and
+                data.get_const_opcode() == Opcode['BitCast']):
                 # Address is typed to "void *", we need to get rid of the
                 # bitcast operator.
                 data = data.get_operand(0)

--- a/diffkemp/llvm_ir/llvm_sysctl_module.py
+++ b/diffkemp/llvm_ir/llvm_sysctl_module.py
@@ -107,7 +107,7 @@ class LlvmSysctlModule:
                 if all_constant:
                     data = data.get_operand(0)
             if (data.get_kind() == ConstantExprValueKind and
-                data.get_const_opcode() == Opcode['BitCast']):
+                    data.get_const_opcode() == Opcode['BitCast']):
                 # Address is typed to "void *", we need to get rid of the
                 # bitcast operator.
                 data = data.get_operand(0)

--- a/diffkemp/llvm_ir/llvm_sysctl_module.py
+++ b/diffkemp/llvm_ir/llvm_sysctl_module.py
@@ -94,23 +94,23 @@ class LlvmSysctlModule:
         data = sysctl.get_operand(1)
         if data.is_null():
             return None
-        if data.get_kind() == ConstantExprValueKind:
-            if data.get_const_opcode() == Opcode['GetElementPtr']:
-                # Address is a GEP, we have to extract the actual variable.
-                all_constant = True
-                indices = list()
-                # Look whether are all indices constant.
-                for i in range(1, data.get_num_operands()):
-                    indices.append(data.get_operand(i).const_int_get_z_ext())
-                    if not data.get_operand(i).is_constant():
-                        all_constant = False
-                if all_constant:
-                    data = data.get_operand(0)
-            if (data.get_kind() == ConstantExprValueKind and
-                    data.get_const_opcode() == Opcode['BitCast']):
-                # Address is typed to "void *", we need to get rid of the
-                # bitcast operator.
+        if (data.get_kind() == ConstantExprValueKind and
+                data.get_const_opcode() == Opcode['GetElementPtr']):
+            # Address is a GEP, we have to extract the actual variable.
+            all_constant = True
+            indices = list()
+            # Look whether are all indices constant.
+            for i in range(1, data.get_num_operands()):
+                indices.append(data.get_operand(i).const_int_get_z_ext())
+                if not data.get_operand(i).is_constant():
+                    all_constant = False
+            if all_constant:
                 data = data.get_operand(0)
+        if (data.get_kind() == ConstantExprValueKind and
+                data.get_const_opcode() == Opcode['BitCast']):
+            # Address is typed to "void *", we need to get rid of the
+            # bitcast operator.
+            data = data.get_operand(0)
         if data.get_kind() == GlobalVariableValueKind:
             data = data.get_name()
             return KernelParam(data, indices)

--- a/tests/regression/diffsysctl/diffsysctl_test.py
+++ b/tests/regression/diffsysctl/diffsysctl_test.py
@@ -106,8 +106,8 @@ def prepare_task(spec):
 
     # Build the modules
     for function in function_list:
-        old_module = first_builder.build_file_for_function(function.name)
-        new_module = second_builder.build_file_for_function(function.name)
+        old_module = first_builder.build_file_for_symbol(function.name)
+        new_module = second_builder.build_file_for_symbol(function.name)
 
         # The modules were already built when finding their sources.
         # Now the files need only to be copied to the right place.

--- a/tests/regression/diffsysctl/diffsysctl_test.py
+++ b/tests/regression/diffsysctl/diffsysctl_test.py
@@ -189,7 +189,7 @@ class TestClass(object):
         speed.
         """
         if (task_spec.proc_handler.result != Result.TIMEOUT
-                and task_spec.proc_handler.result != "skipped"):
+                and task_spec.proc_handler.result != "generic"):
             result = functions_diff(task_spec.proc_handler.old_module,
                                     task_spec.proc_handler.new_module,
                                     task_spec.proc_handler.name,

--- a/tests/regression/diffsysctl/diffsysctl_test.py
+++ b/tests/regression/diffsysctl/diffsysctl_test.py
@@ -17,6 +17,20 @@ import os
 import pytest
 import yaml
 
+
+class FunctionSpec:
+    """"
+    Specification of a function in kernel along the modules/source files where
+    it is located and the expected result of the function comparison between
+    two kernel versions.
+    """
+    def __init__(self, name, result, old_module=None, new_module=None):
+        self.name = name
+        self.old_module = old_module
+        self.new_module = new_module
+        self.result = result
+
+
 specs_path = "tests/regression/diffsysctl/test_specs"
 tasks_path = "tests/regression/diffsysctl/kernel_modules"
 
@@ -34,33 +48,18 @@ def collect_task_specs():
             if "disabled" in spec_yaml and spec_yaml["disabled"] is True:
                 continue
             for sysctl in spec_yaml["sysctls"]:
-                # First handle the proc handler function
-                for function, desc in sysctl["proc_handler"].iteritems():
-                    if desc == "skipped":
-                        continue
-
-                    spec = dict(spec_yaml)
-                    spec["sysctl"] = sysctl["sysctl"]
-                    spec["data"] = None
-                    spec["function"] = function
-                    spec["expected_result"] = desc
-
-                    spec_id = os.path.splitext(spec_file_path)[0] + "_" + \
-                        sysctl["sysctl"] + "-" + function
-                    result.append((spec_id, spec))
-                # Then process the data variable
+                proc_yaml = sysctl["proc_handler"]
                 data_yaml = sysctl["data_variable"]
-                for function, desc in data_yaml["functions"].iteritems():
-                    spec = dict(spec_yaml)
-                    spec["sysctl"] = sysctl["sysctl"]
-                    spec["data"] = data_yaml["name"]
-                    spec["function"] = function
-                    spec["expected_result"] = desc
 
-                    spec_id = os.path.splitext(spec_file_path)[0] + "_" + \
-                        sysctl["sysctl"] + "-" + data_yaml["name"] + "-" + \
-                        function
-                    result.append((spec_id, spec))
+                spec = dict(spec_yaml)
+                spec["sysctl"] = sysctl["sysctl"]
+                spec["data"] = data_yaml["name"]
+                spec["data_functions"] = data_yaml["functions"]
+                spec["proc_handler"] = proc_yaml
+
+                spec_id = os.path.splitext(spec_file_path)[0] + "_" + \
+                    sysctl["sysctl"]
+                result.append((spec_id, spec))
 
     os.chdir(cwd)
     return result
@@ -71,9 +70,7 @@ specs = collect_task_specs()
 
 class TaskSpec:
     """
-    Task specification representing one testing scenario (one function - in
-    case the function is one of the functions using the data variable, this
-    also contains the data variable as the parameter).
+    Task specification representing one testing scenario (one sysctl parameter)
     """
     def __init__(self, spec):
         # Values from the YAML file
@@ -81,13 +78,17 @@ class TaskSpec:
         self.new_kernel = spec["new_kernel"]
         self.sysctl = spec["sysctl"]
         self.data = spec["data"]
+        self.data_functions = list()
+        for function, result in spec["data_functions"].iteritems():
+            self.data_functions.append(FunctionSpec(function, result))
+        self.proc_handler = list()
+        for function, result in spec["proc_handler"].iteritems():
+            self.proc_handler.append(FunctionSpec(function, result))
         if "control_flow_only" in spec:
             self.control_flow_only = spec["control_flow_only"]
         else:
             self.control_flow_only = False
         self.debug = spec["debug"] if "debug" in spec else False
-        self.function = spec["function"]
-        self.expected_result = spec["expected_result"]
 
 
 def prepare_task(spec):
@@ -95,51 +96,50 @@ def prepare_task(spec):
     Prepare testing task (scenario). Build old and new modules and copy
     created files.
     """
+    function_list = spec.proc_handler + spec.data_functions
+
     # Find the modules
     first_builder = LlvmKernelBuilder(spec.old_kernel, None,
                                       debug=spec.debug)
     second_builder = LlvmKernelBuilder(spec.new_kernel, None,
                                        debug=spec.debug)
 
-    # Build the modules
-    old_module = first_builder.build_file_for_function(spec.function)
-    new_module = second_builder.build_file_for_function(spec.function)
-
     sysctl_module = first_builder.build_sysctl_module(spec.sysctl)
-    if spec.data is not None:
-        # Create the data variable KernelParam object
-        spec.param = sysctl_module.get_data(spec.sysctl)
-    else:
-        # Get the name of the proc handler
-        spec.param = None
-        spec.proc_handler = sysctl_module.get_proc_fun(spec.sysctl)
+    spec.data_diffsysctl = sysctl_module.get_data(spec.sysctl)
+    spec.proc_handler_diffsysctl = \
+        sysctl_module.get_proc_fun(spec.sysctl)
 
-    # The modules were already built when finding their sources.
-    # Now the files need only to be copied to the right place.
-    #
-    # Note: the files are copied to the task directory for reference only.
-    # The exact name of the module is not known before building the
-    # function, therefore building from module sources in kernel_modules or
-    # using already built LLVM IR files is not possible.
-    mod_old = os.path.basename(old_module.name)
-    mod_new = os.path.basename(new_module.name)
-    spec.task_dir = os.path.join(tasks_path, spec.function)
-    if not os.path.isdir(spec.task_dir):
-        os.mkdir(spec.task_dir)
-    spec.old_src = os.path.join(spec.task_dir, mod_old + "_old.c")
-    spec.new_src = os.path.join(spec.task_dir, mod_new + "_new.c")
-    spec.old_module = os.path.join(spec.task_dir, mod_old + "_old.ll")
-    spec.new_module = os.path.join(spec.task_dir, mod_new + "_new.ll")
-    spec.old_simpl = os.path.join(spec.task_dir, mod_old + "_old-simpl.ll")
-    spec.new_simpl = os.path.join(spec.task_dir, mod_new + "_new-simpl.ll")
+    # Build the modules
+    for function in function_list:
+        old_module = first_builder.build_file_for_function(function.name)
+        new_module = second_builder.build_file_for_function(function.name)
 
-    prepare_module(os.path.dirname(old_module.llvm), mod_old, mod_old + ".c",
-                   spec.old_kernel, spec.old_module, spec.old_simpl,
-                   spec.old_src, spec.debug, build_module=False)
+        # The modules were already built when finding their sources.
+        # Now the files need only to be copied to the right place.
+        #
+        # Note: the files are copied to the task directory for reference only.
+        # The exact name of the module is not known before building the
+        # function, therefore building from module sources in kernel_modules or
+        # using already built LLVM IR files is not possible.
+        mod_old = os.path.basename(old_module.name)
+        mod_new = os.path.basename(new_module.name)
+        spec.task_dir = os.path.join(tasks_path, function.name)
+        if not os.path.isdir(spec.task_dir):
+            os.mkdir(spec.task_dir)
+        old_src = os.path.join(spec.task_dir, mod_old + "_old.c")
+        new_src = os.path.join(spec.task_dir, mod_new + "_new.c")
+        function.old_module = os.path.join(spec.task_dir, mod_old + "_old.ll")
+        function.new_module = os.path.join(spec.task_dir, mod_new + "_new.ll")
+        old_simpl = os.path.join(spec.task_dir, mod_old + "_old-simpl.ll")
+        new_simpl = os.path.join(spec.task_dir, mod_new + "_new-simpl.ll")
 
-    prepare_module(os.path.dirname(new_module.llvm), mod_new, mod_new + ".c",
-                   spec.new_kernel, spec.new_module, spec.new_simpl,
-                   spec.new_src, spec.debug, build_module=False)
+        prepare_module(os.path.dirname(old_module.llvm), mod_old,
+                       mod_old + ".c", spec.old_kernel, function.old_module,
+                       old_simpl, old_src, spec.debug, build_module=False)
+
+        prepare_module(os.path.dirname(new_module.llvm), mod_new,
+                       mod_new + ".c", spec.new_kernel, function.new_module,
+                       new_simpl, new_src, spec.debug, build_module=False)
 
 
 @pytest.fixture(params=[x[1] for x in specs],
@@ -164,19 +164,19 @@ class TestClass(object):
         Looks whether the data variable and the proc handler function were
         determined correctly.
         """
-        if task_spec.data is not None:
-            # Data variable function
-            if "." in task_spec.data:
-                # Structure attribute
-                assert task_spec.data.split(".")[0] == task_spec.param.name
-            else:
-                # Standard variable
-                assert task_spec.data == task_spec.param.name
+        # Data variable function
+        if "." in task_spec.data:
+            # Structure attribute
+            assert task_spec.data.split(".")[0] == \
+                   task_spec.data_diffsysctl.name
         else:
-            # Proc handler function
-            assert task_spec.function == task_spec.proc_handler
+            # Standard variable
+            assert task_spec.data == task_spec.data_diffsysctl.name
+        # Proc handler function
+        assert (task_spec.proc_handler_diffsysctl ==
+                task_spec.proc_handler[0].name)
 
-    def test_diffsysctl(self, task_spec):
+    def test_proc_handler(self, task_spec):
         """
         Test comparison of semantic difference of both functions using the data
         variable associated with the sysctl parameter and the proc_handler
@@ -187,9 +187,34 @@ class TestClass(object):
         If timeout is expected, the analysis is not run to increase testing
         speed.
         """
-        if task_spec.expected_result != Result.TIMEOUT:
-            result = functions_diff(task_spec.old_module, task_spec.new_module,
-                                    task_spec.function, task_spec.function,
-                                    task_spec.param, 120, False,
-                                    task_spec.control_flow_only)
-            assert result == Result[task_spec.expected_result.upper()]
+        for function in task_spec.proc_handler:
+            if function.result != Result.TIMEOUT and \
+               function.result != "skipped":
+                result = functions_diff(function.old_module,
+                                        function.new_module,
+                                        function.name, function.name,
+                                        None, 120, False,
+                                        task_spec.control_flow_only)
+
+                assert result == Result[function.result.upper()]
+
+    def test_data_functions(self, task_spec):
+        """
+        Test comparison of semantic difference of both functions using the data
+        variable associated with the sysctl parameter and the proc_handler
+        function.
+        For each compared function, the module is first simplified using the
+        SimpLL tool and then the actual analysis is run. Compares the obtained
+        result with the expected one.
+        If timeout is expected, the analysis is not run to increase testing
+        speed.
+        """
+        for function in task_spec.data_functions:
+            if function.result != Result.TIMEOUT:
+                result = functions_diff(function.old_module,
+                                        function.new_module,
+                                        function.name, function.name,
+                                        task_spec.data_diffsysctl,
+                                        120, False,
+                                        task_spec.control_flow_only)
+                assert result == Result[function.result.upper()]

--- a/tests/regression/diffsysctl/diffsysctl_test.py
+++ b/tests/regression/diffsysctl/diffsysctl_test.py
@@ -10,7 +10,6 @@ pytest.
 """
 
 from diffkemp.llvm_ir.build_llvm import LlvmKernelBuilder
-from diffkemp.llvm_ir.kernel_module import KernelParam
 from diffkemp.semdiff.function_diff import functions_diff, Result
 from tests.regression.module_tools import prepare_module
 import glob
@@ -115,7 +114,6 @@ def prepare_task(spec):
         spec.param = None
         spec.proc_handler = sysctl_module.get_proc_fun(spec.sysctl)
 
-
     # The modules were already built when finding their sources.
     # Now the files need only to be copied to the right place.
     #
@@ -177,7 +175,6 @@ class TestClass(object):
         else:
             # Proc handler function
             assert task_spec.function == task_spec.proc_handler
-
 
     def test_diffsysctl(self, task_spec):
         """

--- a/tests/regression/diffsysctl/diffsysctl_test.py
+++ b/tests/regression/diffsysctl/diffsysctl_test.py
@@ -42,7 +42,7 @@ def collect_task_specs():
                     spec["expected_result"] = desc
 
                     spec_id = os.path.splitext(spec_file_path)[0] + "_" + \
-                              sysctl["sysctl"] + "-" + function
+                        sysctl["sysctl"] + "-" + function
                     result.append((spec_id, spec))
                 # Then process the data variable
                 data_yaml = sysctl["data_variable"]
@@ -53,8 +53,8 @@ def collect_task_specs():
                     spec["expected_result"] = desc
 
                     spec_id = os.path.splitext(spec_file_path)[0] + "_" + \
-                              sysctl["sysctl"] + "-" + data_yaml["name"] + \
-                              "-" + function
+                        sysctl["sysctl"] + "-" + data_yaml["name"] + "-" + \
+                        function
                     result.append((spec_id, spec))
 
     os.chdir(cwd)

--- a/tests/regression/diffsysctl/test_specs/rhel-75-76.yaml
+++ b/tests/regression/diffsysctl/test_specs/rhel-75-76.yaml
@@ -1,0 +1,15 @@
+old_kernel: 3.10.0-862
+new_kernel: 3.10.0-957
+
+debug: true
+control_flow_only: true
+
+sysctls:
+  - sysctl: net.core.netdev_rss_key
+    proc_handler:
+      proc_do_rss_key: equal_syntax
+    data_variable:
+      name: netdev_rss_key
+      functions:
+        netdev_rss_key_fill: equal_syntax
+        proc_do_rss_key: equal_syntax

--- a/tests/regression/diffsysctl/test_specs/rhel-75-76.yaml
+++ b/tests/regression/diffsysctl/test_specs/rhel-75-76.yaml
@@ -12,7 +12,7 @@ sysctls:
         proc_do_rss_key: equal_syntax
   - sysctl: net.core.message_burst
     proc_handler:
-      proc_dointvec: skipped
+      proc_dointvec: generic
     data_variable:
       name: net_ratelimit_state.burst
       functions:

--- a/tests/regression/diffsysctl/test_specs/rhel-75-76.yaml
+++ b/tests/regression/diffsysctl/test_specs/rhel-75-76.yaml
@@ -1,9 +1,6 @@
 old_kernel: 3.10.0-862
 new_kernel: 3.10.0-957
 
-debug: true
-control_flow_only: true
-
 sysctls:
   - sysctl: net.core.netdev_rss_key
     proc_handler:
@@ -13,3 +10,10 @@ sysctls:
       functions:
         netdev_rss_key_fill: equal_syntax
         proc_do_rss_key: equal_syntax
+  - sysctl: net.core.message_burst
+    proc_handler:
+      proc_dointvec: skipped
+    data_variable:
+      name: net_ratelimit_state.burst
+      functions:
+        net_ratelimit: equal_syntax

--- a/tests/unit_tests/build_llvm_test.py
+++ b/tests/unit_tests/build_llvm_test.py
@@ -146,6 +146,17 @@ def test_build_all_modules():
         assert os.path.isfile(m.llvm)
 
 
+def test_build_sysctl_module():
+    """
+    Building source containing definitions of a sysctl option.
+    """
+    builder = LlvmKernelBuilder("3.10.0-862", None)
+    module = builder.build_sysctl_module("net.core.message_burst")
+    assert module is not None
+    assert module.mod is not None
+    assert module.mod.name == "net/core/sysctl_net_core"
+
+
 def test_link_modules():
     """
     Linking dependent modules together.

--- a/tests/unit_tests/kernel_source_test.py
+++ b/tests/unit_tests/kernel_source_test.py
@@ -40,6 +40,11 @@ def test_build_cscope_database(builder):
         assert os.path.isfile(os.path.join("kernel/linux-3.10", file))
 
 
+def test_find_srcs_using_symbol(builder):
+    srcs = builder.source.find_srcs_using_symbol("net_ratelimit_state")
+    assert srcs == set(['net/core/utils.c'])
+
+
 def test_find_srcs_with_symbol_def(builder):
     srcs = builder.source.find_srcs_with_symbol_def("ipmi_set_gets_events")
     assert srcs == [

--- a/tests/unit_tests/llvm_sysctl_module_test.py
+++ b/tests/unit_tests/llvm_sysctl_module_test.py
@@ -24,4 +24,13 @@ def test_get_proc_fun(module):
 
 
 def test_get_data(module):
-    assert module.get_data("wmem_max") == "sysctl_wmem_max"
+    # Data variable with bitcast
+    assert module.get_data("netdev_budget").name == "netdev_budget"
+    # Data variable with GEP and bitcast
+    data = module.get_data("message_burst")
+    assert data.name == "net_ratelimit_state"
+    assert data.indices == [8L]
+    # Data variable with GEP (without bitcast)
+    data = module.get_data("netdev_rss_key")
+    assert data.name == "netdev_rss_key"
+    assert data.indices == [0L, 0L]

--- a/tests/unit_tests/llvm_sysctl_module_test.py
+++ b/tests/unit_tests/llvm_sysctl_module_test.py
@@ -1,0 +1,27 @@
+"""Unit tests for working with sysctl modules."""
+
+import pytest
+from diffkemp.llvm_ir.build_llvm import LlvmKernelBuilder
+from diffkemp.llvm_ir.llvm_sysctl_module import LlvmSysctlModule
+
+
+@pytest.fixture(scope="module")
+def module():
+    # Builds sysctl source for net.core and uses it for creating a
+    # LlvmSysctlModule object
+    kernel_builder = LlvmKernelBuilder("3.10.0-862", "net/core")
+    kernel_module = kernel_builder.build_file("sysctl_net_core")
+    return LlvmSysctlModule(kernel_module, "net_core_table")
+
+
+def test_get_sysctl(module):
+    sysctl = module._get_sysctl("wmem_max")
+    assert sysctl.is_a_constant_struct()
+
+
+def test_get_proc_fun(module):
+    assert module.get_proc_fun("wmem_max") == "proc_dointvec_minmax"
+
+
+def test_get_data(module):
+    assert module.get_data("wmem_max") == "sysctl_wmem_max"


### PR DESCRIPTION
Added regression test support for diffsysctl and unit tests for the LlvmSysctlModule class.
Also fixed a bug in LlvmSysctlModule that caused processing GEPs without bitcats to lead to a type conversion error in LLVM (the function get_data attempted to get the const opcode of a non-ConstantExpr value).