### PR TITLE
kernel_source: Fixed two special cases when cscope fails because of the usage of a macro

### DIFF
--- a/diffkemp/llvm_ir/kernel_source.py
+++ b/diffkemp/llvm_ir/kernel_source.py
@@ -129,7 +129,7 @@ class KernelSource:
                 # fails because of the exact symbol being created by the
                 # preprocessor
                 if any([symbol.startswith(s) for s in
-                    ["param_get_", "param_set_", "param_ops_"]]):
+                        ["param_get_", "param_set_", "param_ops_"]]):
                     # Symbol param_* are created in kernel/params.c using a
                     # macro
                     cscope_defs = [os.path.join(self.kernel_path,

--- a/diffkemp/semdiff/function_diff.py
+++ b/diffkemp/semdiff/function_diff.py
@@ -58,11 +58,14 @@ class Statistics():
         errs = len(self.errors)
         total = eq + neq + unkwn + errs
         print "Total params: {}".format(total)
-        print "Equal:        {0} ({1:.0f}%)".format(eq, eq / total * 100)
-        print " same syntax: {0}".format(eq_syn)
-        print "Not equal:    {0} ({1:.0f}%)".format(neq, neq / total * 100)
-        print "Unknown:      {0} ({1:.0f}%)".format(unkwn, unkwn / total * 100)
-        print "Errors:       {0} ({1:.0f}%)".format(errs, errs / total * 100)
+        if total != 0:
+            print "Equal:        {0} ({1:.0f}%)".format(eq, eq / total * 100)
+            print " same syntax: {0}".format(eq_syn)
+            print "Not equal:    {0} ({1:.0f}%)".format(neq, neq / total * 100)
+            print "Unknown:      {0} ({1:.0f}%)".format(unkwn,
+                                                        unkwn / total * 100)
+            print "Errors:       {0} ({1:.0f}%)".format(errs,
+                                                        errs / total * 100)
 
     def overall_result(self):
         """Aggregate results for individual functions into one result."""

--- a/tests/regression/diffkabi/test_specs/rhel-75-76.yaml
+++ b/tests/regression/diffkabi/test_specs/rhel-75-76.yaml
@@ -14,3 +14,4 @@ functions:
         blk_execute_rq_nowait: equal_syntax
         ip6_route_output: equal_syntax
         param_set_int: equal_syntax
+        param_set_long: equal_syntax


### PR DESCRIPTION
Fixes #24 