### PR TITLE
Fixed run-diffkabi.sh to be able to download the container from Docker Hub

### DIFF
--- a/docker/diffkemp/run-diffkabi.sh
+++ b/docker/diffkemp/run-diffkabi.sh
@@ -8,5 +8,5 @@ if [ -d kernel/$NEW_VER ]; then
     VOL2="-v $PWD/kernel/$NEW_VER:/diffkemp/kernel/$NEW_VER:Z"
 fi
 
-docker run -t $VOL1 $VOL2 -w /diffkemp -m 8g --cpus 3 diffkemp bin/diffkabi $@
+docker run -t $VOL1 $VOL2 -w /diffkemp -m 8g --cpus 3 viktormalik/diffkemp bin/diffkabi $@
 


### PR DESCRIPTION
Modified run-diffkabi.sh to include the full name of the Docker container in order for it to be able to download the container from Docker Hub in case it is not present on the machine.