### PR TITLE
SimpLL: Compare array types with the same element type as equal when comparing the control flow only

### DIFF
--- a/diffkemp/simpll/DifferentialFunctionComparator.cpp
+++ b/diffkemp/simpll/DifferentialFunctionComparator.cpp
@@ -271,7 +271,7 @@ int DifferentialFunctionComparator::cmpCallsWithExtraArg(
 /// Compares array types with equivalent element types as equal when
 /// comparing the control flow only.
 int DifferentialFunctionComparator::cmpTypes(Type *L, Type *R) const {
-    if(!L->isArrayTy() || !R->isArrayTy() || !controlFlowOnly)
+    if (!L->isArrayTy() || !R->isArrayTy() || !controlFlowOnly)
         return FunctionComparator::cmpTypes(L, R);
 
     ArrayType *AL = dyn_cast<ArrayType>(L);

--- a/diffkemp/simpll/DifferentialFunctionComparator.cpp
+++ b/diffkemp/simpll/DifferentialFunctionComparator.cpp
@@ -267,3 +267,15 @@ int DifferentialFunctionComparator::cmpCallsWithExtraArg(
     }
     return 1;
 }
+
+/// Compares array types with equivalent element types as equal when
+/// comparing the control flow only.
+int DifferentialFunctionComparator::cmpTypes(Type *L, Type *R) const {
+    if(!L->isArrayTy() || !R->isArrayTy() || !controlFlowOnly)
+        return FunctionComparator::cmpTypes(L, R);
+
+    ArrayType *AL = dyn_cast<ArrayType>(L);
+    ArrayType *AR = dyn_cast<ArrayType>(R);
+
+    return cmpTypes(AL->getElementType(), AR->getElementType());
+}

--- a/diffkemp/simpll/DifferentialFunctionComparator.h
+++ b/diffkemp/simpll/DifferentialFunctionComparator.h
@@ -59,7 +59,7 @@ class DifferentialFunctionComparator : public FunctionComparator {
     int cmpCallsWithExtraArg(const CallInst *CL, const CallInst *CR) const;
     /// Compares array types with equivalent element types as equal when
     /// comparing the control flow only.
-    int cmpTypes(Type *L, Type *R) const;
+    int cmpTypes(Type *L, Type *R) const override;
 
   private:
     const DebugInfo *DI;

--- a/diffkemp/simpll/DifferentialFunctionComparator.h
+++ b/diffkemp/simpll/DifferentialFunctionComparator.h
@@ -57,6 +57,9 @@ class DifferentialFunctionComparator : public FunctionComparator {
     /// Such calls are compared as equal if they only differ in the last
     /// argument which is 0 or NULL.
     int cmpCallsWithExtraArg(const CallInst *CL, const CallInst *CR) const;
+    /// Compares array types with equivalent element types as equal when
+    /// comparing the control flow only.
+    int cmpTypes(Type *L, Type *R) const;
 
   private:
     const DebugInfo *DI;

--- a/tests/regression/diffkabi/test_specs/rhel-75-76.yaml
+++ b/tests/regression/diffkabi/test_specs/rhel-75-76.yaml
@@ -15,3 +15,5 @@ functions:
         ip6_route_output: equal_syntax
         param_set_int: equal_syntax
         param_set_long: equal_syntax
+        free_pages: equal_syntax
+


### PR DESCRIPTION
This fixes one of the problems with empty diff.