### PR TITLE
SimpLL: Remove function sections when comparing the control flow only.

### DIFF
--- a/diffkemp/simpll/Transforms.cpp
+++ b/diffkemp/simpll/Transforms.cpp
@@ -21,6 +21,7 @@
 #include "passes/CalledFunctionsAnalysis.h"
 #include "passes/ControlFlowSlicer.h"
 #include "passes/FunctionAbstractionsGenerator.h"
+#include "passes/ReduceFunctionMetadataPass.h"
 #include "passes/RemoveLifetimeCallsPass.h"
 #include "passes/RemoveUnusedReturnValuesPass.h"
 #include "passes/SimplifyKernelFunctionCallsPass.h"
@@ -114,6 +115,8 @@ std::vector<FunPair> simplifyModulesDiff(Config &config) {
     PassManager<Module, AnalysisManager<Module, Function *>, Function *,
         Module *> mpm;
     mpm.addPass(RemoveUnusedReturnValuesPass {});
+    if (config.ControlFlowOnly)
+        mpm.addPass(ReduceFunctionMetadataPass {});
     mpm.run(*config.First, mam, config.FirstFun, config.Second.get());
     mpm.run(*config.Second, mam, config.SecondFun, config.First.get());
 

--- a/diffkemp/simpll/Transforms.cpp
+++ b/diffkemp/simpll/Transforms.cpp
@@ -73,6 +73,7 @@ void preprocessModule(Module &Mod,
     fpm.addPass(UnifyMemcpyPass {});
     fpm.addPass(DCEPass {});
     fpm.addPass(LowerExpectIntrinsicPass {});
+    fpm.addPass(ReduceFunctionMetadataPass {});
 
     for (auto &Fun : Mod)
         fpm.run(Fun, fam);
@@ -115,8 +116,6 @@ std::vector<FunPair> simplifyModulesDiff(Config &config) {
     PassManager<Module, AnalysisManager<Module, Function *>, Function *,
         Module *> mpm;
     mpm.addPass(RemoveUnusedReturnValuesPass {});
-    if (config.ControlFlowOnly)
-        mpm.addPass(ReduceFunctionMetadataPass {});
     mpm.run(*config.First, mam, config.FirstFun, config.Second.get());
     mpm.run(*config.Second, mam, config.SecondFun, config.First.get());
 

--- a/diffkemp/simpll/passes/ReduceFunctionMetadataPass.cpp
+++ b/diffkemp/simpll/passes/ReduceFunctionMetadataPass.cpp
@@ -11,10 +11,7 @@
 ///
 //===----------------------------------------------------------------------===//
 
-#include "CalledFunctionsAnalysis.h"
 #include "ReduceFunctionMetadataPass.h"
-#include "Utils.h"
-#include <llvm/IR/Instructions.h>
 
 /// Remove custom sections from functions (used when comparing the control flow
 /// only)

--- a/diffkemp/simpll/passes/ReduceFunctionMetadataPass.cpp
+++ b/diffkemp/simpll/passes/ReduceFunctionMetadataPass.cpp
@@ -1,0 +1,31 @@
+//===----  ReduceFunctionMetadataPass.h - Removes some function metadata --===//
+//
+//       SimpLL - Program simplifier for analysis of semantic difference      //
+//
+// This file is published under Apache 2.0 license. See LICENSE for details.
+// Author: Tomas Glozar, tglozar@gmail.com
+//===----------------------------------------------------------------------===//
+///
+/// \file
+/// This file contains the declaration of the ReduceFunctionMetadataPass pass.
+///
+//===----------------------------------------------------------------------===//
+
+#include "CalledFunctionsAnalysis.h"
+#include "ReduceFunctionMetadataPass.h"
+#include "Utils.h"
+#include <llvm/IR/Instructions.h>
+
+/// Remove custom sections from functions (used when comparing the control flow
+/// only)
+PreservedAnalyses ReduceFunctionMetadataPass::run(
+    Module &Mod, AnalysisManager<Module, Function *> &mam, Function *Main,
+    Module *ModOther) {
+    for(Function &F : Mod) {
+        // If the function has a custom section, remove it.
+        if (F.hasSection())
+            F.setSection("");
+    }
+
+    return PreservedAnalyses();
+}

--- a/diffkemp/simpll/passes/ReduceFunctionMetadataPass.cpp
+++ b/diffkemp/simpll/passes/ReduceFunctionMetadataPass.cpp
@@ -19,13 +19,10 @@
 /// Remove custom sections from functions (used when comparing the control flow
 /// only)
 PreservedAnalyses ReduceFunctionMetadataPass::run(
-    Module &Mod, AnalysisManager<Module, Function *> &mam, Function *Main,
-    Module *ModOther) {
-    for(Function &F : Mod) {
-        // If the function has a custom section, remove it.
-        if (F.hasSection())
-            F.setSection("");
-    }
+    Function &Fun, FunctionAnalysisManager &fam) {
+    // If the function has a custom section, remove it.
+    if (Fun.hasSection())
+        Fun.setSection("");
 
     return PreservedAnalyses();
 }

--- a/diffkemp/simpll/passes/ReduceFunctionMetadataPass.cpp
+++ b/diffkemp/simpll/passes/ReduceFunctionMetadataPass.cpp
@@ -1,4 +1,4 @@
-//===----  ReduceFunctionMetadataPass.h - Removes some function metadata --===//
+//===-- ReduceFunctionMetadataPass.cpp - Removes some function metadata ---===//
 //
 //       SimpLL - Program simplifier for analysis of semantic difference      //
 //
@@ -7,7 +7,8 @@
 //===----------------------------------------------------------------------===//
 ///
 /// \file
-/// This file contains the declaration of the ReduceFunctionMetadataPass pass.
+/// This file contains the definition of the ReduceFunctionMetadataPass pass.
+/// The pass currently removes custom sections from functions.
 ///
 //===----------------------------------------------------------------------===//
 

--- a/diffkemp/simpll/passes/ReduceFunctionMetadataPass.h
+++ b/diffkemp/simpll/passes/ReduceFunctionMetadataPass.h
@@ -23,8 +23,7 @@ using namespace llvm;
 class ReduceFunctionMetadataPass
         : public PassInfoMixin<ReduceFunctionMetadataPass> {
   public:
-    PreservedAnalyses run(Module &Mod, AnalysisManager<Module, Function *> &mam,
-                          Function *Main, Module *ModOther);
+    PreservedAnalyses run(Function &Fun, FunctionAnalysisManager &fam);
 };
 
 #endif //DIFFKEMP_SIMPLL_REDUCEFUNCTIONMETADATAPASS_H

--- a/diffkemp/simpll/passes/ReduceFunctionMetadataPass.h
+++ b/diffkemp/simpll/passes/ReduceFunctionMetadataPass.h
@@ -1,0 +1,30 @@
+//===----  ReduceFunctionMetadataPass.h - Removes some function metadata --===//
+//
+//       SimpLL - Program simplifier for analysis of semantic difference      //
+//
+// This file is published under Apache 2.0 license. See LICENSE for details.
+// Author: Tomas Glozar, tglozar@gmail.com
+//===----------------------------------------------------------------------===//
+///
+/// \file
+/// This file contains the declaration of the ReduceFunctionMetadataPass pass.
+///
+//===----------------------------------------------------------------------===//
+
+#ifndef DIFFKEMP_SIMPLL_REDUCEFUNCTIONMETADATAPASS_H
+#define DIFFKEMP_SIMPLL_REDUCEFUNCTIONMETADATAPASS_H
+
+#include <llvm/IR/PassManager.h>
+
+using namespace llvm;
+
+/// A pass that transforms functions returning some value to void in case their
+/// return value is never used.
+class ReduceFunctionMetadataPass
+        : public PassInfoMixin<ReduceFunctionMetadataPass> {
+  public:
+    PreservedAnalyses run(Module &Mod, AnalysisManager<Module, Function *> &mam,
+                          Function *Main, Module *ModOther);
+};
+
+#endif //DIFFKEMP_SIMPLL_REDUCEFUNCTIONMETADATAPASS_H


### PR DESCRIPTION
This is to fix the function usleep_range comparing as not equal. 

There is another problem with a return value when comparing the same function, which could be solved by extending the RemoveUnusedReturnValuesPass to all functions. (I didn't include that here because I'm not currently sure whether this causes any problems or not, that yet has to be tested.)