### PR TITLE
SimpLL: Fixed a bug in RemoveUnusedReturnValuesPass - the pass did

### DIFF
--- a/diffkemp/simpll/Utils.cpp
+++ b/diffkemp/simpll/Utils.cpp
@@ -262,3 +262,31 @@ void simplifyFunction(Function *Fun) {
     fpm.addPass(DCEPass {});
     fpm.run(*Fun, fam);
 }
+
+/// Removes empty attribute sets from an attribute list.
+/// This function is used when some attributes are removed to clean up.
+AttributeList cleanAttributeList(AttributeList AL) {
+    // Copy over all attributes to a new attribute list.
+    AttributeList NewAttrList;
+
+    // There are three possible indices for attribute sets
+    std::vector<AttributeList::AttrIndex> indices {
+        AttributeList::FirstArgIndex,
+        AttributeList::FunctionIndex,
+        AttributeList::ReturnIndex
+    };
+
+    for (AttributeList::AttrIndex i : indices) {
+        AttributeSet AttrSet =
+                AL.getAttributes(i);
+        if (AttrSet.getNumAttributes() != 0) {
+            AttrBuilder AB;
+            for (const Attribute &A : AttrSet)
+                AB.addAttribute(A);
+            NewAttrList = NewAttrList.addAttributes(
+                    AL.getContext(), i, AB);
+        }
+    }
+
+    return NewAttrList;
+}

--- a/diffkemp/simpll/Utils.h
+++ b/diffkemp/simpll/Utils.h
@@ -82,4 +82,7 @@ std::string valueAsString(const Constant *Val);
 /// Works if the value is of pointer type which can be even bitcasted.
 StructType *getStructType(const Value *Value);
 
+/// Removes empty attribute sets from an attribute list.
+AttributeList cleanAttributeList(AttributeList AL);
+
 #endif //DIFFKEMP_SIMPLL_UTILS_H


### PR DESCRIPTION
not remove empty attribute sets from call and invoke instructions
and didn't copy debug information.

Fixes #33 