### PR TITLE
SimpLL: Added support for detecting differences in macros by

### DIFF
--- a/diffkemp/diffkabi.py
+++ b/diffkemp/diffkabi.py
@@ -200,9 +200,14 @@ def print_sytax_diff(src_version, dest_version, src_path, dest_path, fun,
                     called_res.second.callstack.replace(dest_path + "/", ""),
                     indent))
                 output.write("\n\n")
-            output.write(text_indent("Diff:\n", indent))
-            output.write(text_indent(
-                called_res.diff, indent))
+            if called_res.diff.strip() == "" and \
+               called_res.macro_diff is not None:
+                output.write(text_indent(
+                    "\n".join(map(str, called_res.macro_diff)), indent))
+            else:
+                output.write(text_indent("Diff:\n", indent))
+                output.write(text_indent(
+                    called_res.diff, indent))
             if not log_files:
                 print "  }}}"
             output.write("\n")

--- a/diffkemp/diffkabi.py
+++ b/diffkemp/diffkabi.py
@@ -200,8 +200,8 @@ def print_sytax_diff(src_version, dest_version, src_path, dest_path, fun,
                     called_res.second.callstack.replace(dest_path + "/", ""),
                     indent))
                 output.write("\n\n")
-            if called_res.diff.strip() == "" and \
-               called_res.macro_diff is not None:
+            if (called_res.diff.strip() == "" and
+                    called_res.macro_diff is not None):
                 output.write(text_indent(
                     "\n".join(map(str, called_res.macro_diff)), indent))
             else:

--- a/diffkemp/diffkabi.py
+++ b/diffkemp/diffkabi.py
@@ -40,6 +40,8 @@ def __make_argument_parser():
     ap.add_argument("--do-not-link",
                     help="do not link function definitions from other sources",
                     action="store_true")
+    ap.add_argument("--show-empty-diff", help="shows difference in function \
+                    when the syntactic diff is empty", action="store_true")
     return ap
 
 
@@ -113,7 +115,8 @@ def run_from_cli():
                         print_sytax_diff(args.src_version, args.dest_version,
                                          first_builder.kernel_path,
                                          second_builder.kernel_path,
-                                         f, fun_result, args.log_files)
+                                         f, fun_result, args.log_files,
+                                         args.show_empty_diff)
                     else:
                         print "  {}".format(str(fun_result.kind).upper())
 
@@ -151,7 +154,7 @@ def logs_dirname(src_version, dest_version):
 
 
 def print_sytax_diff(src_version, dest_version, src_path, dest_path, fun,
-                     fun_result, log_files):
+                     fun_result, log_files, print_empty_diffs=False):
     """
     Log syntax diff of 2 functions. If log_files is set, the output is printed
     into a separate file, otherwise it goes to stdout.
@@ -162,6 +165,7 @@ def print_sytax_diff(src_version, dest_version, src_path, dest_path, fun,
     :param fun: Name of the analysed function
     :param fun_result: Result of the analysis
     :param log_files: True if the output is to be written into a file
+    :param print_empty_diffs: Print empty syntax diffs.
     """
     def text_indent(text, width):
         """Indent each line in the text by a number of spaces given by width"""
@@ -178,7 +182,7 @@ def print_sytax_diff(src_version, dest_version, src_path, dest_path, fun,
             print "{}:".format(fun)
 
         for called_res in fun_result.inner.itervalues():
-            if called_res.diff == "":
+            if called_res.diff == "" and not print_empty_diffs:
                 # Do not print empty diffs
                 continue
 

--- a/diffkemp/diffkabi.py
+++ b/diffkemp/diffkabi.py
@@ -178,6 +178,10 @@ def print_sytax_diff(src_version, dest_version, src_path, dest_path, fun,
             print "{}:".format(fun)
 
         for called_res in fun_result.inner.itervalues():
+            if called_res.diff == "":
+                # Do not print empty diffs
+                continue
+
             output.write(
                 text_indent("{} differs:\n".format(called_res.first.name),
                             indent - 2))

--- a/diffkemp/semdiff/function_diff.py
+++ b/diffkemp/semdiff/function_diff.py
@@ -224,6 +224,7 @@ def functions_diff(mod_first, mod_second,
                 fun_result.diff = syntax_diff(fun_result.first.filename,
                                               fun_result.second.filename,
                                               fun_result.first.name)
+                fun_result.macro_diff = fun_pair[2]
                 result.add_inner(fun_result)
         else:
             # If the functions are not syntactically equal, funs_to_compare

--- a/diffkemp/semdiff/result.py
+++ b/diffkemp/semdiff/result.py
@@ -61,17 +61,17 @@ class Result:
             self.second_line = yaml["right-line"]
 
         def __str__(self):
-            res = "Macro " + self.first_stack[0].name + " is different:\n"
+            res = "Macro {} is different:\n".format(self.first_stack[0].name)
             for stack in [self.first_stack, self.second_stack]:
                 for macro in stack:
-                    res = res + "  from macro " + macro.name + " in file " + \
-                        macro.file + " on line " + str(macro.line) + "\n"
-                res = res + "  used in the function on line " + \
-                    (str(self.first_line) if stack is self.first_stack else
-                     str(self.second_line)) + "\n"
-                res = res + "    " + stack[0].body + "\n"
+                    res += "  from macro {} in file {} on line {}\n".format(
+                        macro.name, macro.file, str(macro.line))
+                res += "  used in the function on line {}\n".format(
+                    (str(self.first_line) if stack is self.first_stack
+                     else str(self.second_line)))
+                res += "    {}\n".format(stack[0].body)
                 if stack is self.first_stack:
-                    res = res + "\n"
+                    res += "\n"
             return res
 
     def __init__(self, kind, first_name, second_name):

--- a/diffkemp/semdiff/result.py
+++ b/diffkemp/semdiff/result.py
@@ -32,47 +32,12 @@ class Result:
         or a parameter.
         If it is a function, it contains the file of the function.
         """
-        def __init__(self, name, filename=None, callstack=None):
+        def __init__(self, name, filename=None, callstack=None,
+                     is_macro=False):
             self.name = name
             self.filename = filename
             self.callstack = callstack
-
-    class MacroElement:
-        """
-        Represents a macro element on the macro stack.
-        """
-        def __init__(self, yaml):
-            """Transforms YAML to MacroElement object."""
-            self.name = yaml["name"]
-            self.body = yaml["body"]
-            self.file = yaml["file"]
-            self.line = yaml["line"]
-
-    class MacroDifference:
-        """
-        Represents a macro difference as found by SimpLL.
-        """
-        def __init__(self, yaml):
-            """Transforms YAML to MacroDifference object."""
-            self.name = yaml["name"]
-            self.first_stack = map(Result.MacroElement, yaml["left-stack"])
-            self.second_stack = map(Result.MacroElement, yaml["right-stack"])
-            self.first_line = yaml["left-line"]
-            self.second_line = yaml["right-line"]
-
-        def __str__(self):
-            res = "Macro {} is different:\n".format(self.first_stack[0].name)
-            for stack in [self.first_stack, self.second_stack]:
-                for macro in stack:
-                    res += "  from macro {} in file {} on line {}\n".format(
-                        macro.name, macro.file, str(macro.line))
-                res += "  used in the function on line {}\n".format(
-                    (str(self.first_line) if stack is self.first_stack
-                     else str(self.second_line)))
-                res += "    {}\n".format(stack[0].body)
-                if stack is self.first_stack:
-                    res += "\n"
-            return res
+            self.is_macro = is_macro
 
     def __init__(self, kind, first_name, second_name):
         self.kind = kind

--- a/diffkemp/semdiff/result.py
+++ b/diffkemp/semdiff/result.py
@@ -37,11 +37,49 @@ class Result:
             self.filename = filename
             self.callstack = callstack
 
+    class MacroElement:
+        """
+        Represents a macro element on the macro stack.
+        """
+        def __init__(self, yaml):
+            """Transforms YAML to MacroElement object."""
+            self.name = yaml["name"]
+            self.body = yaml["body"]
+            self.file = yaml["file"]
+            self.line = yaml["line"]
+
+    class MacroDifference:
+        """
+        Represents a macro difference as found by SimpLL.
+        """
+        def __init__(self, yaml):
+            """Transforms YAML to MacroDifference object."""
+            self.name = yaml["name"]
+            self.first_stack = map(Result.MacroElement, yaml["left-stack"])
+            self.second_stack = map(Result.MacroElement, yaml["right-stack"])
+            self.first_line = yaml["left-line"]
+            self.second_line = yaml["right-line"]
+
+        def __str__(self):
+            res = "Macro " + self.first_stack[0].name + " is different:\n"
+            for stack in [self.first_stack, self.second_stack]:
+                for macro in stack:
+                    res = res + "  from macro " + macro.name + " in file " + \
+                        macro.file + " on line " + str(macro.line) + "\n"
+                res = res + "  used in the function on line " + \
+                    (str(self.first_line) if stack is self.first_stack else
+                     str(self.second_line)) + "\n"
+                res = res + "    " + stack[0].body + "\n"
+                if stack is self.first_stack:
+                    res = res + "\n"
+            return res
+
     def __init__(self, kind, first_name, second_name):
         self.kind = kind
         self.first = Result.Entity(first_name)
         self.second = Result.Entity(second_name)
         self.diff = None
+        self.macro_diff = None
         self.inner = dict()
 
     def __str__(self):

--- a/diffkemp/simpll/DifferentialFunctionComparator.cpp
+++ b/diffkemp/simpll/DifferentialFunctionComparator.cpp
@@ -498,7 +498,8 @@ int DifferentialFunctionComparator::cmpMemset(const CallInst *CL,
 /// Finds macro differences at the locations of the instructions L and R and
 /// adds them to the list in ModuleComparator.
 /// This is used when a difference is suspected to be in a macro in order to
-/// include that difference into the diffkemp output.
+/// include that difference into ModuleComparator, and therefore avoid an
+/// empty diff.
 void DifferentialFunctionComparator::findMacroDifferences(
         const Instruction *L, const Instruction *R) const {
     // Try to discover a macro difference
@@ -513,7 +514,7 @@ void DifferentialFunctionComparator::findMacroDifferences(
             LValue->second.body != RValue->second.body) {
             // Macro difference found - get the macro stacks and insert the
             // object into the macro differences array to be passed on to
-            // the Python part of diffkemp.
+            // ModuleComparator.
             std::vector<MacroElement> StackL, StackR;
             MacroElement currentElement = LValue->second;
             while (currentElement.parentMacro != "") {

--- a/diffkemp/simpll/DifferentialFunctionComparator.cpp
+++ b/diffkemp/simpll/DifferentialFunctionComparator.cpp
@@ -547,10 +547,14 @@ void DifferentialFunctionComparator::findMacroDifferences(
                 });
 
 
-            ModComparator->DifferingMacros.push_back(
-                ModuleComparator::MacroDifference {Elem.first,
-                LValue->second.body, RValue->second.body, StackL, StackR,
-                L->getFunction()->getName()});
+            ModComparator->DifferingMacros.push_back(MacroDifference {
+                Elem.first,
+                StackL,
+                StackR,
+                L->getFunction()->getName(),
+                L->getDebugLoc()->getLine(),
+                R->getDebugLoc()->getLine()
+              });
         }
     }
 }

--- a/diffkemp/simpll/DifferentialFunctionComparator.h
+++ b/diffkemp/simpll/DifferentialFunctionComparator.h
@@ -78,6 +78,12 @@ class DifferentialFunctionComparator : public FunctionComparator {
                                       const Value *Const) const;
 
   private:
+    /// Finds macro differences at the locations of the instructions L and R and
+    /// adds them to the list in ModuleComparator.
+    /// This is used when a difference is suspected to be in a macro in order to
+    /// include that difference into the diffkemp output.
+    void findMacroDifferences(const Instruction *L, const Instruction *R) const;
+
     const DebugInfo *DI;
     bool controlFlowOnly;
 

--- a/diffkemp/simpll/DifferentialFunctionComparator.h
+++ b/diffkemp/simpll/DifferentialFunctionComparator.h
@@ -79,13 +79,6 @@ class DifferentialFunctionComparator : public FunctionComparator {
                                       const Value *Const) const;
 
   private:
-    /// Finds macro differences at the locations of the instructions L and R and
-    /// adds them to the list in ModuleComparator.
-    /// This is used when a difference is suspected to be in a macro in order to
-    /// include that difference into ModuleComparator, and therefore avoid an
-    /// empty diff.
-    void findMacroDifferences(const Instruction *L, const Instruction *R) const;
-
     const DebugInfo *DI;
     bool controlFlowOnly;
 

--- a/diffkemp/simpll/DifferentialFunctionComparator.h
+++ b/diffkemp/simpll/DifferentialFunctionComparator.h
@@ -81,7 +81,8 @@ class DifferentialFunctionComparator : public FunctionComparator {
     /// Finds macro differences at the locations of the instructions L and R and
     /// adds them to the list in ModuleComparator.
     /// This is used when a difference is suspected to be in a macro in order to
-    /// include that difference into the diffkemp output.
+    /// include that difference into ModuleComparator, and therefore avoid an
+    /// empty diff.
     void findMacroDifferences(const Instruction *L, const Instruction *R) const;
 
     const DebugInfo *DI;

--- a/diffkemp/simpll/DifferentialFunctionComparator.h
+++ b/diffkemp/simpll/DifferentialFunctionComparator.h
@@ -18,6 +18,7 @@
 
 #include "DebugInfo.h"
 #include "ModuleComparator.h"
+#include "Utils.h"
 #include <llvm/Transforms/Utils/FunctionComparator.h>
 
 using namespace llvm;

--- a/diffkemp/simpll/MacroUtils.cpp
+++ b/diffkemp/simpll/MacroUtils.cpp
@@ -1,0 +1,278 @@
+//===--------- MacroUtils.cpp - Functions for working with macros ----------==//
+//
+//       SimpLL - Program simplifier for analysis of semantic difference      //
+//
+// This file is published under Apache 2.0 license. See LICENSE for details.
+// Author: Tomas Glozar, tglozar@gmail.com
+//===----------------------------------------------------------------------===//
+///
+/// \file
+/// This file contains implementation of functions working with macros and their
+/// differences.
+///
+//===----------------------------------------------------------------------===//
+
+#include "Config.h"
+#include "MacroUtils.h"
+#include "Utils.h"
+#include <llvm/Support/Debug.h>
+#include <llvm/Support/LineIterator.h>
+#include <llvm/Support/raw_ostream.h>
+
+/// Gets all macros used on the line in the form of a key to value map.
+std::unordered_map<std::string, MacroElement> getAllMacrosOnLine(
+    StringRef line, StringMap<MacroElement> macroMap) {
+    // Transform macroMap into a second that will contain only macros that are
+    // used on the line.
+    // Note: For the purpose of the algorithm the starting line is treated as a
+    // with a space as its key, making it an invalid identifier for a macro.
+    std::unordered_map<std::string, MacroElement> usedMacroMap;
+    bool mapChanged = true;
+    usedMacroMap[" "] = MacroElement {"<>", line, StringRef(""), 0, ""};
+
+    // The bodies of all macros currently present in usedMacroMap are examined;
+    // every time another macro is found in it, it is added to the map.
+    // This process is repeated over and over until it gets to a state when the
+    // map does not change after the iteration (this means that all macros
+    // already are in it).
+    while (mapChanged) {
+        mapChanged = false;
+
+        // This vector is used to store the entries that are to be added to the
+        // map, but can't be added directly, because it would break the cycle
+        // because it is iterating over the same map.
+        std::vector<std::pair<StringRef, MacroElement>> entriesToAdd;
+
+        for (auto &Entry : usedMacroMap) {
+            // Go through the macro body to find all string that could possibly
+            // be macro identifiers. Because we know which characters the
+            // identifier starts and ends with, we can go through the string
+            // from the left, record all such substrings and test them using the
+            // macro map provided in the function arguments.
+            std::string macroBody = Entry.second.body.str();
+            std::string potentialMacroName;
+
+            for (int i = 0; i < macroBody.size(); i++) {
+                if (potentialMacroName.size() == 0) {
+                    // We are looking for the beginning of an identifier.
+                    if (isValidCharForIdentifierStart(macroBody[i]))
+                        potentialMacroName += macroBody[i];
+                } else if (!isValidCharForIdentifier(macroBody[i])) {
+                    // We found the end of the identifier.
+                    auto potentialMacro = macroMap.find(potentialMacroName);
+                    if (potentialMacro != macroMap.end()) {
+                        // Macro used by the currently processed macro was
+                        // found.
+                        // Add it to entriesToAdd in order for it to be added to
+                        // the map.
+                        MacroElement macro = potentialMacro->second;
+                        macro.parentMacro = Entry.first;
+                        entriesToAdd.push_back({potentialMacro->first(),
+                                                macro});
+                    }
+
+                    // Reset the potential identifier.
+                    potentialMacroName = "";
+                } else
+                    // We are in the middle of the identifier.
+                    potentialMacroName += macroBody[i];
+            }
+        }
+
+        int originalMapSize = usedMacroMap.size();
+        for (std::pair<StringRef, MacroElement> &Entry : entriesToAdd) {
+            if (usedMacroMap.find(Entry.first.str()) == usedMacroMap.end()) {
+                usedMacroMap[Entry.first.str()] = Entry.second;
+                DEBUG_WITH_TYPE(DEBUG_SIMPLL,
+                                dbgs() << "Adding macro " << Entry.first <<
+                                " : " << Entry.second.body << ", parent macro "
+                                << Entry.second.parentMacro << "\n");
+            }
+        }
+
+        if (originalMapSize < usedMacroMap.size())
+            mapChanged = true;
+    }
+
+    return usedMacroMap;
+}
+
+/// Gets all macros used on a certain DILocation in the form of a key to value
+/// map.
+std::unordered_map<std::string, MacroElement> getAllMacrosAtLocation(
+    DILocation *LineLoc, const Module *Mod) {
+    if (!LineLoc || LineLoc->getNumOperands() == 0) {
+        // DILocation has no scope or is not present - cannot get macro stack
+        DEBUG_WITH_TYPE(DEBUG_SIMPLL, dbgs() << "Scope for macro not found\n");
+        return std::unordered_map<std::string, MacroElement>();
+    }
+
+    // Get the path of the source file corresponding to the module where the
+    // difference was found
+    auto sourcePath = getSourceFilePath(
+            dyn_cast<DIScope>(LineLoc->getScope()));
+
+    // Open the C source file corresponding to the location and extract the line
+    auto sourceFile = MemoryBuffer::getFile(Twine(sourcePath));
+    if (sourceFile.getError()) {
+        // Source file was not found, return empty maps
+        DEBUG_WITH_TYPE(DEBUG_SIMPLL, dbgs() << "Source for macro not found\n");
+        return std::unordered_map<std::string, MacroElement>();
+    }
+
+    // Read the source file by lines, stop at the right number (the line that
+    // is referenced by the DILocation)
+    line_iterator it(**sourceFile);
+    StringRef line;
+    while (!it.is_at_end() && it.line_number() != (LineLoc->getLine())) {
+        ++it; line = *it;
+    }
+
+    DEBUG_WITH_TYPE(DEBUG_SIMPLL,
+                    dbgs() << "Looking for all macros on line:" << line
+                    << "\n");
+
+    // Get macro array from debug info
+    DISubprogram *Sub = LineLoc->getScope()->getSubprogram();
+    DIMacroNodeArray RawMacros = Sub->getUnit()->getMacros();
+
+    // Create a map from macro identifiers to their values.
+    StringMap<MacroElement> macroMap;
+    StringMap<const DIMacroFile *> macroFileMap;
+    std::vector<const DIMacroFile *> macroFileStack;
+
+    // First all DIMacroFiles (these represent directly included headers) are
+    // added to a stack.
+    for (const DIMacroNode *Node : RawMacros) {
+        if (const DIMacroFile *File = dyn_cast<DIMacroFile>(Node))
+            macroFileStack.push_back(File);
+    }
+
+    // Next a DFS algorithm (using the stack created in the previous step) is
+    // used to add all macros that are found inside the file on the top of the
+    // stack to a map and to add all macro files referenced from the top macro
+    // file to the stack (these represent indirectly included headers).
+    while (!macroFileStack.empty()) {
+        const DIMacroFile *MF = macroFileStack.back();
+        DIMacroNodeArray A = MF->getElements();
+        macroFileStack.pop_back();
+
+        for (const DIMacroNode *Node : A)
+            if (const DIMacroFile *File = dyn_cast<DIMacroFile>(Node))
+                // The macro node is another macro file - add it to the
+                // stack
+                macroFileStack.push_back(File);
+            else if (const DIMacro *Macro = dyn_cast<DIMacro>(Node)) {
+                // The macro node is an actual macro - add an object
+                // representing it (containing its full name) with its shortened
+                // name as the key.
+                std::string macroName = Macro->getName().str();
+
+                // If the macro name contains arguments, remove them for the
+                // purpose of the map key.
+                auto position = macroName.find('(');
+                if (position != std::string::npos) {
+                    macroName = macroName.substr(0, position);
+                }
+
+                MacroElement element;
+                element.name = macroName;
+                element.body = Macro->getValue();
+                element.parentMacro = "N/A";
+                element.sourceFile = MF->getFile()->getFilename().str();
+                element.line = Macro->getLine();
+                macroMap[macroName] = element;
+            }
+    }
+
+    // Add information about the original line to the map, then return the map
+    auto macrosOnLine = getAllMacrosOnLine(line, macroMap);
+    macrosOnLine[" "].sourceFile = sourcePath;
+    macrosOnLine[" "].line = LineLoc->getLine();
+
+    return macrosOnLine;
+}
+
+/// Finds macro differences at the locations of the instructions L and R and
+/// return them as a vector.
+/// This is used when a difference is suspected to be in a macro in order to
+/// include that difference into ModuleComparator, and therefore avoid an
+/// empty diff.
+std::vector<MacroDifference> findMacroDifferences(
+		const Instruction *L, const Instruction *R) {
+    // Try to discover a macro difference
+    auto MacrosL = getAllMacrosAtLocation(L->getDebugLoc(), L->getModule());
+    auto MacrosR = getAllMacrosAtLocation(R->getDebugLoc(), R->getModule());
+
+    std::vector<MacroDifference> result;
+
+    for (auto Elem : MacrosL) {
+        if (Elem.second.name == "<>")
+            // Note: this is the final parent "macro" element representing the
+            // actual line in the source file on which the macro is used
+            continue;
+
+        auto LValue = MacrosL.find(Elem.first);
+        auto RValue = MacrosR.find(Elem.first);
+
+        if (LValue != MacrosL.end() && RValue != MacrosR.end() &&
+            LValue->second.body != RValue->second.body) {
+            // Macro difference found - get the macro stacks and insert the
+            // object into the macro differences array to be passed on to
+            // ModuleComparator.
+            CallStack StackL, StackR;
+
+            // Insert all macros between the differing macro and the original
+            // macro that the line contains to the stack.
+            // Note: the lines on which are the macros have to be shifted,
+            // because we want the line on which the macro is used, not the line
+            // on which it is defined.
+            MacroElement currentElement = LValue->second;
+            while (currentElement.parentMacro != "") {
+                auto parent = MacrosL[currentElement.parentMacro];
+                StackL.push_back(CallInfo(currentElement.name + " (macro)",
+                    parent.sourceFile,
+                    parent.line));
+                currentElement = parent;
+            }
+            currentElement = RValue->second;
+            while (currentElement.parentMacro != "") {
+                auto parent = MacrosR[currentElement.parentMacro];
+                StackR.push_back(CallInfo(currentElement.name + " (macro)",
+                    parent.sourceFile,
+                    parent.line));
+                currentElement = parent;
+            }
+
+            // Invert stacks to match the format of actual call stacks
+            std::reverse(StackL.begin(), StackL.end());
+            std::reverse(StackR.begin(), StackR.end());
+
+            DEBUG_WITH_TYPE(DEBUG_SIMPLL,
+                dbgs() << "Left stack:\n\t";
+                dbgs() << LValue->second.body << "\n";
+                for (CallInfo &elem : StackL) {
+                    dbgs() << "\t\tfrom " << elem.fun <<
+                        " in file " <<
+                        elem.file << " on line "
+                        << elem.line << "\n";
+                });
+            DEBUG_WITH_TYPE(DEBUG_SIMPLL,
+                dbgs() << "Right stack:\n\t";
+                dbgs() << RValue->second.body << "\n";
+                for (CallInfo &elem : StackR) {
+                    dbgs() << "\t\tfrom " << elem.fun <<
+                        " in file " <<
+                        elem.file << " on line "
+                        << elem.line << "\n";
+                });
+
+            result.push_back(MacroDifference {
+                Elem.first, LValue->second.body, RValue->second.body,
+                StackL, StackR, L->getFunction()->getName()
+            });
+        }
+    }
+
+    return result;
+}

--- a/diffkemp/simpll/MacroUtils.h
+++ b/diffkemp/simpll/MacroUtils.h
@@ -1,0 +1,73 @@
+//===---------- MacroUtils.h - Functions for working with macros -----------==//
+//
+//       SimpLL - Program simplifier for analysis of semantic difference      //
+//
+// This file is published under Apache 2.0 license. See LICENSE for details.
+// Author: Tomas Glozar, tglozar@gmail.com
+//===----------------------------------------------------------------------===//
+///
+/// \file
+/// This file contains declarations of functions working with macros and their
+/// differences and structures used by them.
+///
+//===----------------------------------------------------------------------===//
+
+#ifndef DIFFKEMP_SIMPLL_MACRO_UTILS_H
+#define DIFFKEMP_SIMPLL_MACRO_UTILS_H
+
+#include "Utils.h"
+
+#include <llvm/ADT/StringMap.h>
+#include <llvm/ADT/StringRef.h>
+#include <llvm/IR/DebugInfoMetadata.h>
+#include <string>
+#include <unordered_map>
+
+using namespace llvm;
+
+/// Returned macros with value and location.
+struct MacroElement {
+    // The macro name is shortened, therefore it has to be stored as the whole
+    // string, because otherwise the content would be dropped on leaving the
+    // block in which the shortening is done.
+    std::string name;
+    // The body is in DebugInfo, parentMacro is a key in the map, therefore
+    // both can be stored by reference.
+    StringRef body, parentMacro;
+    // This is the line in the C source code on which the macro is located.
+    int line;
+    std::string sourceFile;
+};
+
+/// Difference between macro in left module and the same macro in the right
+/// module.
+struct MacroDifference {
+	// Name of the macro.
+	std::string macroName;
+	// The difference.
+	std::string BodyL, BodyR;
+	// Stacks containing the differing macros and all other macros affected
+	// by the difference (again for both modules).
+	CallStack StackL, StackR;
+	// The function in which the difference was found
+	std::string function;
+};
+
+/// Gets all macros used on the line in the form of a key to value map.
+std::unordered_map<std::string, MacroElement> getAllMacrosOnLine(
+    StringRef line, StringMap<StringRef> macroMap);
+
+/// Gets all macros used on a certain DILocation in the form of a key to value
+/// map.
+std::unordered_map<std::string, MacroElement> getAllMacrosAtLocation(
+    DILocation *LineLoc, const Module *Mod);
+
+/// Finds macro differences at the locations of the instructions L and R and
+/// return them as a vector.
+/// This is used when a difference is suspected to be in a macro in order to
+/// include that difference into ModuleComparator, and therefore avoid an
+/// empty diff.
+std::vector<MacroDifference> findMacroDifferences(
+		const Instruction *L, const Instruction *R);
+
+#endif // DIFFKEMP_SIMPLL_MACRO_UTILS_H

--- a/diffkemp/simpll/ModuleComparator.h
+++ b/diffkemp/simpll/ModuleComparator.h
@@ -35,8 +35,15 @@ class ModuleComparator {
     std::map<FunPair, Result> ComparedFuns;
     /// Storing results from macro comparisons.
     struct MacroDifference {
-        StringRef macroName, LValue, RValue;
+        // Name of the macro.
+        std::string macroName;
+        // Macro body for the both modules.
+        StringRef LValue, RValue;
+        // Stacks containing the differing macros and all other macros affected
+        // by the difference (again for both modules).
         std::vector<MacroElement> StackL, StackR;
+        // The name of the function the macro difference was found in. This is
+        // necessary for correct printing of the difference.
         StringRef functionName;
     };
     std::vector<MacroDifference> DifferingMacros;

--- a/diffkemp/simpll/ModuleComparator.h
+++ b/diffkemp/simpll/ModuleComparator.h
@@ -33,6 +33,13 @@ class ModuleComparator {
     enum Result { EQUAL, NOT_EQUAL, UNKNOWN };
     /// Storing results of function comparisons.
     std::map<FunPair, Result> ComparedFuns;
+    /// Storing results from macro comparisons.
+    struct MacroDifference {
+        StringRef macroName, LValue, RValue;
+        std::vector<MacroElement> StackL, StackR;
+        StringRef functionName;
+    };
+    std::vector<MacroDifference> DifferingMacros;
 
     std::vector<ConstFunPair> MissingDefs;
 

--- a/diffkemp/simpll/ModuleComparator.h
+++ b/diffkemp/simpll/ModuleComparator.h
@@ -26,14 +26,11 @@ using namespace llvm;
 struct MacroDifference {
 	// Name of the macro.
 	std::string macroName;
+	// The difference.
+	std::string BodyL, BodyR;
 	// Stacks containing the differing macros and all other macros affected
 	// by the difference (again for both modules).
-	std::vector<MacroElement> StackL, StackR;
-	// The name of the function the macro difference was found in. This is
-	// necessary for correct printing of the difference.
-	StringRef functionName;
-	// Line in the original source file where the difference was found.
-	unsigned lineLeft, lineRight;
+	CallStack StackL, StackR;
 };
 
 class ModuleComparator {

--- a/diffkemp/simpll/ModuleComparator.h
+++ b/diffkemp/simpll/ModuleComparator.h
@@ -31,6 +31,8 @@ struct MacroDifference {
 	// Stacks containing the differing macros and all other macros affected
 	// by the difference (again for both modules).
 	CallStack StackL, StackR;
+	// The function in which the difference was found
+	std::string function;
 };
 
 class ModuleComparator {

--- a/diffkemp/simpll/ModuleComparator.h
+++ b/diffkemp/simpll/ModuleComparator.h
@@ -23,6 +23,19 @@
 
 using namespace llvm;
 
+struct MacroDifference {
+	// Name of the macro.
+	std::string macroName;
+	// Stacks containing the differing macros and all other macros affected
+	// by the difference (again for both modules).
+	std::vector<MacroElement> StackL, StackR;
+	// The name of the function the macro difference was found in. This is
+	// necessary for correct printing of the difference.
+	StringRef functionName;
+	// Line in the original source file where the difference was found.
+	unsigned lineLeft, lineRight;
+};
+
 class ModuleComparator {
     Module &First;
     Module &Second;
@@ -34,18 +47,6 @@ class ModuleComparator {
     /// Storing results of function comparisons.
     std::map<FunPair, Result> ComparedFuns;
     /// Storing results from macro comparisons.
-    struct MacroDifference {
-        // Name of the macro.
-        std::string macroName;
-        // Macro body for the both modules.
-        StringRef LValue, RValue;
-        // Stacks containing the differing macros and all other macros affected
-        // by the difference (again for both modules).
-        std::vector<MacroElement> StackL, StackR;
-        // The name of the function the macro difference was found in. This is
-        // necessary for correct printing of the difference.
-        StringRef functionName;
-    };
     std::vector<MacroDifference> DifferingMacros;
 
     std::vector<ConstFunPair> MissingDefs;

--- a/diffkemp/simpll/ModuleComparator.h
+++ b/diffkemp/simpll/ModuleComparator.h
@@ -17,23 +17,12 @@
 
 #include "DebugInfo.h"
 #include "DifferentialGlobalNumberState.h"
+#include "MacroUtils.h"
 #include "Utils.h"
 #include <llvm/IR/Module.h>
 #include <set>
 
 using namespace llvm;
-
-struct MacroDifference {
-	// Name of the macro.
-	std::string macroName;
-	// The difference.
-	std::string BodyL, BodyR;
-	// Stacks containing the differing macros and all other macros affected
-	// by the difference (again for both modules).
-	CallStack StackL, StackR;
-	// The function in which the difference was found
-	std::string function;
-};
 
 class ModuleComparator {
     Module &First;

--- a/diffkemp/simpll/Output.cpp
+++ b/diffkemp/simpll/Output.cpp
@@ -158,10 +158,10 @@ void reportOutput(Config &config,
         // Try to append call stack of function to the macro stack if possible
         CallStack toAppendLeft, toAppendRight;
         for (auto &diff : report.diffFuns) {
-            if (diff.first.name == macroDiff.StackL[0].fun &&
+            if (diff.first.name == macroDiff.function &&
                 diff.first.callstack.size() > 0)
                 toAppendLeft = diff.first.callstack;
-            if (diff.second.name == macroDiff.StackR[0].fun &&
+            if (diff.second.name == macroDiff.function &&
                 diff.second.callstack.size() > 0)
                 toAppendRight = diff.second.callstack;
         }

--- a/diffkemp/simpll/Output.cpp
+++ b/diffkemp/simpll/Output.cpp
@@ -38,15 +38,41 @@ struct FunctionInfo {
     std::string name;
     std::string file;
     CallStack callstack;
+    bool isMacro;
 
     // Default constructor is needed for YAML serialisation so that the struct
     // can be used as an optional YAML field.
     FunctionInfo() {}
     FunctionInfo(const std::string &name,
                  const std::string &file,
+                 const CallStack &callstack,
+                 bool isMacro)
+            : name(name), file(file), callstack(callstack), isMacro(isMacro) {}
+    FunctionInfo(const std::string &name,
+                 const std::string &file,
                  const CallStack &callstack)
-            : name(name), file(file), callstack(callstack) {}
+            : FunctionInfo(name, file, callstack, false) {}
 };
+
+// Macro body
+struct MacroBody {
+    std::string name, LBody, RBody;
+};
+
+// MacroBody to YAML
+namespace llvm::yaml {
+template<>
+struct MappingTraits<MacroBody> {
+    static void mapping(IO &io, MacroBody &body) {
+        io.mapRequired("name", body.name);
+        io.mapRequired("left-value", body.LBody);
+        io.mapRequired("right-value", body.RBody);
+    }
+};
+}
+
+// Vector of MacroBody to YAML
+LLVM_YAML_IS_SEQUENCE_VECTOR(MacroBody);
 
 // FunctionInfo to YAML
 namespace llvm::yaml {
@@ -56,6 +82,7 @@ struct MappingTraits<FunctionInfo> {
         io.mapRequired("function", info.name);
         io.mapOptional("file", info.file);
         io.mapOptional("callstack", info.callstack);
+        io.mapRequired("is-macro", info.isMacro);
     }
 };
 }
@@ -63,7 +90,6 @@ struct MappingTraits<FunctionInfo> {
 // Pair of different functions that will be reported
 struct DiffFunPair {
     FunctionInfo first, second;
-    std::vector<MacroDifference> macroDiff;
 };
 
 // DiffFunPair to YAML
@@ -73,7 +99,6 @@ struct MappingTraits<DiffFunPair> {
     static void mapping(IO &io, DiffFunPair &funs) {
         io.mapOptional("first", funs.first);
         io.mapOptional("second", funs.second);
-        io.mapOptional("macro-diff", funs.macroDiff);
     }
 };
 }
@@ -99,7 +124,7 @@ struct MappingTraits<MissingDefPair> {
 struct ResultReport {
     std::vector<DiffFunPair> diffFuns;
     std::vector<MissingDefPair> missingDefs;
-    std::vector<MacroDifference> differingMacros;
+    std::vector<MacroBody> macroDefinitions;
 };
 
 // Report to YAML
@@ -109,44 +134,10 @@ struct MappingTraits<ResultReport> {
     static void mapping(IO &io, ResultReport &result) {
         io.mapOptional("diff-functions", result.diffFuns);
         io.mapOptional("missing-defs", result.missingDefs);
+        io.mapOptional("macro-defs", result.macroDefinitions);
     }
 };
 }
-
-// MacroElement to YAML (for stack in MacroDifference)
-namespace llvm::yaml {
-template<>
-struct MappingTraits<MacroElement> {
-    static void mapping(IO &io, MacroElement &result) {
-        auto filename = result.source->getFile()->getFilename().str();
-        io.mapRequired("name", result.name);
-        io.mapRequired("body", result.body);
-        io.mapRequired("file", filename);
-        io.mapRequired("line", result.line);
-    }
-};
-}
-
-// Vector of MacroElement to YAML
-LLVM_YAML_IS_SEQUENCE_VECTOR(MacroElement);
-
-// MacroDifference to YAML
-namespace llvm::yaml {
-template<>
-struct MappingTraits<MacroDifference> {
-    static void mapping(IO &io, MacroDifference &result) {
-        io.mapRequired("name", result.macroName);
-        io.mapRequired("function", result.functionName);
-        io.mapRequired("left-stack", result.StackL);
-        io.mapRequired("right-stack", result.StackR);
-        io.mapRequired("left-line", result.lineLeft);
-        io.mapRequired("right-line", result.lineRight);
-    }
-};
-}
-
-// Vector of MacroDifference to YAML
-LLVM_YAML_IS_SEQUENCE_VECTOR(MacroDifference);
 
 void reportOutput(Config &config,
                   std::vector<FunPair> &nonequalFuns,
@@ -154,22 +145,46 @@ void reportOutput(Config &config,
                   std::vector<MacroDifference> &differingMacros) {
     ResultReport report;
     for (auto &funPair : nonequalFuns) {
-        // Assign macro differences that belong to the function pair
-        std::vector<MacroDifference> macroDiffs;
-        for (MacroDifference diff : differingMacros) {
-            if (diff.functionName == funPair.first->getName() ||
-                diff.functionName == funPair.second->getName())
-                macroDiffs.push_back(diff);
-        }
-
         report.diffFuns.push_back({
                 FunctionInfo(funPair.first->getName(),
                              getFileForFun(funPair.first),
                              getCallStack(*config.FirstFun, *funPair.first)),
                 FunctionInfo(funPair.second->getName(),
                              getFileForFun(funPair.second),
-                             getCallStack(*config.SecondFun, *funPair.second)),
-                macroDiffs
+                             getCallStack(*config.SecondFun, *funPair.second))
+        });
+    }
+    for (auto &macroDiff : differingMacros) {
+        // Try to append call stack of function to the macro stack if possible
+        CallStack toAppendLeft, toAppendRight;
+        for (auto &diff : report.diffFuns) {
+            if (diff.first.name == macroDiff.StackL[0].fun &&
+                diff.first.callstack.size() > 0)
+                toAppendLeft = diff.first.callstack;
+            if (diff.second.name == macroDiff.StackR[0].fun &&
+                diff.second.callstack.size() > 0)
+                toAppendRight = diff.second.callstack;
+        }
+        if (toAppendLeft.size() > 0)
+            macroDiff.StackL.insert(macroDiff.StackL.begin(),
+                toAppendLeft.begin(), toAppendLeft.end());
+        if (toAppendRight.size() > 0)
+            macroDiff.StackR.insert(macroDiff.StackR.begin(),
+                toAppendRight.begin(), toAppendRight.end());
+
+        report.diffFuns.push_back({
+               FunctionInfo(macroDiff.macroName,
+                            macroDiff.StackL[0].file,
+                            macroDiff.StackL,
+                            true),
+               FunctionInfo(macroDiff.macroName,
+                            macroDiff.StackR[0].file,
+                            macroDiff.StackR,
+                            true)
+        });
+
+        report.macroDefinitions.push_back(MacroBody {
+            macroDiff.macroName, macroDiff.BodyL, macroDiff.BodyR
         });
     }
     for (auto &funPair : missingDefs) {

--- a/diffkemp/simpll/Output.h
+++ b/diffkemp/simpll/Output.h
@@ -17,12 +17,14 @@
 
 #include "Config.h"
 #include "Utils.h"
+#include "ModuleComparator.h"
 
 /// Report results in YAML format to stdout.
 /// \param config Configuration.
 /// \param nonequalFuns List of non-equal functions.
 void reportOutput(Config &config,
                   std::vector<FunPair> &nonequalFuns,
-                  std::vector<ConstFunPair> &missingDefs);
+                  std::vector<ConstFunPair> &missingDefs,
+                  std::vector<MacroDifference> &differingMacros);
 
 #endif // DIFFKEMP_SIMPLL_OUTPUT_H

--- a/diffkemp/simpll/SimpLL.cpp
+++ b/diffkemp/simpll/SimpLL.cpp
@@ -15,6 +15,7 @@
 #include "Transforms.h"
 #include "Utils.h"
 #include "Output.h"
+#include "ModuleComparator.h"
 #include <llvm/Support/FileSystem.h>
 #include <llvm/Support/raw_ostream.h>
 
@@ -44,9 +45,10 @@ int main(int argc, const char **argv) {
 
     std::vector<FunPair> nonequalFuns;
     std::vector<ConstFunPair> missingDefs;
-    simplifyModulesDiff(config, nonequalFuns, missingDefs);
+    std::vector<MacroDifference> differingMacros;
+    simplifyModulesDiff(config, nonequalFuns, missingDefs, differingMacros);
 
-    reportOutput(config, nonequalFuns, missingDefs);
+    reportOutput(config, nonequalFuns, missingDefs, differingMacros);
 
     // Split list of non-equal function pairs into two sets.
     std::set<Function *> MainFunsFirst;

--- a/diffkemp/simpll/Transforms.cpp
+++ b/diffkemp/simpll/Transforms.cpp
@@ -102,7 +102,8 @@ void preprocessModule(Module &Mod,
 /// 4. Removing bodies of functions that are syntactically equivalent.
 void simplifyModulesDiff(Config &config,
                          std::vector<FunPair> &nonequalFuns,
-                         std::vector<ConstFunPair> &missingDefs) {
+                         std::vector<ConstFunPair> &missingDefs,
+                         std::vector<MacroDifference> &differingMacros) {
     // Generate abstractions of indirect function calls and for inline
     // assemblies. Then, unify the abstractions between the modules so that
     // the corresponding abstractions get the same name.
@@ -176,6 +177,7 @@ void simplifyModulesDiff(Config &config,
     }
 
     missingDefs = modComp.MissingDefs;
+    differingMacros = modComp.DifferingMacros;
 }
 
 /// Recursively mark callees of a function with 'alwaysinline' attribute.

--- a/diffkemp/simpll/Transforms.h
+++ b/diffkemp/simpll/Transforms.h
@@ -18,6 +18,7 @@
 
 #include "Config.h"
 #include "Utils.h"
+#include "ModuleComparator.h"
 #include <llvm/IR/Function.h>
 #include <llvm/IR/Module.h>
 #include <set>
@@ -43,7 +44,8 @@ void preprocessModule(Module &Mod,
 /// of the semantic diff.
 void simplifyModulesDiff(Config &config,
                          std::vector<FunPair> &nonequalFuns,
-                         std::vector<ConstFunPair> &missingDefs);
+                         std::vector<ConstFunPair> &missingDefs,
+                         std::vector<MacroDifference> &differingMacros);
 
 /// Preprocessing transformations - run independently on each module at the
 /// end.

--- a/diffkemp/simpll/Utils.cpp
+++ b/diffkemp/simpll/Utils.cpp
@@ -280,6 +280,7 @@ std::string getSourceFilePath(DIScope *Scope) {
     return sourceFilePath;
 }
 
+/// Checks whether the character is valid for a C identifier.
 bool isValidCharForIdentifier(char ch) {
     if ((ch >= 'A' && ch <= 'Z') || (ch >= 'a' && ch <= 'z') ||
         (ch >= '0' && ch <= '9') || ch == '_')
@@ -288,183 +289,11 @@ bool isValidCharForIdentifier(char ch) {
         return false;
 }
 
+/// Checks whether the character is valid for the first character of
+/// a C identifier.
 bool isValidCharForIdentifierStart(char ch) {
     if ((ch >= 'A' && ch <= 'Z') || (ch >= 'a' && ch <= 'z') || ch == '_')
         return true;
     else
         return false;
-}
-
-/// Gets all macros used on the line in the form of a key to value map.
-std::unordered_map<std::string, MacroElement> getAllMacrosOnLine(
-    StringRef line, StringMap<MacroElement> macroMap) {
-    // Transform macroMap into a second that will contain only macros that are
-    // used on the line.
-    // Note: For the purpose of the algorithm the starting line is treated as a
-    // with a space as its key, making it an invalid identifier for a macro.
-    std::unordered_map<std::string, MacroElement> usedMacroMap;
-    bool mapChanged = true;
-    usedMacroMap[" "] = MacroElement {"<>", line, StringRef(""), 0, ""};
-
-    // The bodies of all macros currently present in usedMacroMap are examined;
-    // every time another macro is found in it, it is added to the map.
-    // This process is repeated over and over until it gets to a state when the
-    // map does not change after the iteration (this means that all macros
-    // already are in it).
-    while (mapChanged) {
-        mapChanged = false;
-
-        // This vector is used to store the entries that are to be added to the
-        // map, but can't be added directly, because it would break the cycle
-        // because it is iterating over the same map.
-        std::vector<std::pair<StringRef, MacroElement>> entriesToAdd;
-
-        for (auto &Entry : usedMacroMap) {
-            // Go through the macro body to find all string that could possibly
-            // be macro identifiers. Because we know which characters the
-            // identifier starts and ends with, we can go through the string
-            // from the left, record all such substrings and test them using the
-            // macro map provided in the function arguments.
-            std::string macroBody = Entry.second.body.str();
-            std::string potentialMacroName;
-
-            for (int i = 0; i < macroBody.size(); i++) {
-                if (potentialMacroName.size() == 0) {
-                    // We are looking for the beginning of an identifier.
-                    if (isValidCharForIdentifierStart(macroBody[i]))
-                        potentialMacroName += macroBody[i];
-                } else if (!isValidCharForIdentifier(macroBody[i])) {
-                    // We found the end of the identifier.
-                    auto potentialMacro = macroMap.find(potentialMacroName);
-                    if (potentialMacro != macroMap.end()) {
-                        // Macro used by the currently processed macro was
-                        // found.
-                        // Add it to entriesToAdd in order for it to be added to
-                        // the map.
-                        MacroElement macro = potentialMacro->second;
-                        macro.parentMacro = Entry.first;
-                        entriesToAdd.push_back({potentialMacro->first(),
-                                                macro});
-                    }
-
-                    // Reset the potential identifier.
-                    potentialMacroName = "";
-                } else
-                    // We are in the middle of the identifier.
-                    potentialMacroName += macroBody[i];
-            }
-        }
-
-        int originalMapSize = usedMacroMap.size();
-        for (std::pair<StringRef, MacroElement> &Entry : entriesToAdd) {
-            if (usedMacroMap.find(Entry.first.str()) == usedMacroMap.end()) {
-                usedMacroMap[Entry.first.str()] = Entry.second;
-                DEBUG_WITH_TYPE(DEBUG_SIMPLL,
-                                dbgs() << "Adding macro " << Entry.first <<
-                                " : " << Entry.second.body << ", parent macro "
-                                << Entry.second.parentMacro << "\n");
-            }
-        }
-
-        if (originalMapSize < usedMacroMap.size())
-            mapChanged = true;
-    }
-
-    return usedMacroMap;
-}
-
-/// Gets all macros used on a certain DILocation in the form of a key to value
-/// map.
-std::unordered_map<std::string, MacroElement> getAllMacrosAtLocation(
-    DILocation *LineLoc, const Module *Mod) {
-    if (!LineLoc || LineLoc->getNumOperands() == 0) {
-        // DILocation has no scope or is not present - cannot get macro stack
-        DEBUG_WITH_TYPE(DEBUG_SIMPLL, dbgs() << "Scope for macro not found\n");
-        return std::unordered_map<std::string, MacroElement>();
-    }
-
-    // Get the path of the source file corresponding to the module where the
-    // difference was found
-    auto sourcePath = getSourceFilePath(
-            dyn_cast<DIScope>(LineLoc->getScope()));
-
-    // Open the C source file corresponding to the location and extract the line
-    auto sourceFile = MemoryBuffer::getFile(Twine(sourcePath));
-    if (sourceFile.getError()) {
-        // Source file was not found, return empty maps
-        DEBUG_WITH_TYPE(DEBUG_SIMPLL, dbgs() << "Source for macro not found\n");
-        return std::unordered_map<std::string, MacroElement>();
-    }
-
-    // Read the source file by lines, stop at the right number (the line that
-    // is referenced by the DILocation)
-    line_iterator it(**sourceFile);
-    StringRef line;
-    while (!it.is_at_end() && it.line_number() != (LineLoc->getLine())) {
-        ++it; line = *it;
-    }
-
-    DEBUG_WITH_TYPE(DEBUG_SIMPLL,
-                    dbgs() << "Looking for all macros on line:" << line
-                    << "\n");
-
-    // Get macro array from debug info
-    DISubprogram *Sub = LineLoc->getScope()->getSubprogram();
-    DIMacroNodeArray RawMacros = Sub->getUnit()->getMacros();
-
-    // Create a map from macro identifiers to their values.
-    StringMap<MacroElement> macroMap;
-    StringMap<const DIMacroFile *> macroFileMap;
-    std::vector<const DIMacroFile *> macroFileStack;
-
-    // First all DIMacroFiles (these represent directly included headers) are
-    // added to a stack.
-    for (const DIMacroNode *Node : RawMacros) {
-        if (const DIMacroFile *File = dyn_cast<DIMacroFile>(Node))
-            macroFileStack.push_back(File);
-    }
-
-    // Next a DFS algorithm (using the stack created in the previous step) is
-    // used to add all macros that are found inside the file on the top of the
-    // stack to a map and to add all macro files referenced from the top macro
-    // file to the stack (these represent indirectly included headers).
-    while (!macroFileStack.empty()) {
-        const DIMacroFile *MF = macroFileStack.back();
-        DIMacroNodeArray A = MF->getElements();
-        macroFileStack.pop_back();
-
-        for (const DIMacroNode *Node : A)
-            if (const DIMacroFile *File = dyn_cast<DIMacroFile>(Node))
-                // The macro node is another macro file - add it to the
-                // stack
-                macroFileStack.push_back(File);
-            else if (const DIMacro *Macro = dyn_cast<DIMacro>(Node)) {
-                // The macro node is an actual macro - add an object
-                // representing it (containing its full name) with its shortened
-                // name as the key.
-                std::string macroName = Macro->getName().str();
-
-                // If the macro name contains arguments, remove them for the
-                // purpose of the map key.
-                auto position = macroName.find('(');
-                if (position != std::string::npos) {
-                    macroName = macroName.substr(0, position);
-                }
-
-                MacroElement element;
-                element.name = macroName;
-                element.body = Macro->getValue();
-                element.parentMacro = "N/A";
-                element.sourceFile = MF->getFile()->getFilename().str();
-                element.line = Macro->getLine();
-                macroMap[macroName] = element;
-            }
-    }
-
-    // Add information about the original line to the map, then return the map
-    auto macrosOnLine = getAllMacrosOnLine(line, macroMap);
-    macrosOnLine[" "].sourceFile = sourcePath;
-    macrosOnLine[" "].line = LineLoc->getLine();
-
-    return macrosOnLine;
 }

--- a/diffkemp/simpll/Utils.cpp
+++ b/diffkemp/simpll/Utils.cpp
@@ -118,7 +118,7 @@ bool searchCallStackRec(Function *Src,
                     auto loc = Inst.getDebugLoc();
                     if (!loc)
                         continue;
-                    callStack.push_back(CallInfo(called,
+                    callStack.push_back(CallInfo(called->getName().str(),
                                                  getFileForFun(Src),
                                                  loc.getLine()));
                     if (called == Dest)

--- a/diffkemp/simpll/Utils.h
+++ b/diffkemp/simpll/Utils.h
@@ -92,27 +92,11 @@ CallInst *findCallInst(const CallInst *Call, Function *Fun);
 /// Gets C source file from a DIScope and the module.
 std::string getSourceFilePath(DIScope *Scope);
 
-/// Returned macros with value and location.
-struct MacroElement {
-    // The macro name is shortened, therefore it has to be stored as the whole
-    // string, because otherwise the content would be dropped on leaving the
-    // block in which the shortening is done.
-    std::string name;
-    // The body is in DebugInfo, parentMacro is a key in the map, therefore
-    // both can be stored by reference.
-    StringRef body, parentMacro;
-    // This is the line in the C source code on which the macro is located.
-    int line;
-    std::string sourceFile;
-};
+/// Checks whether the character is valid for a C identifier.
+bool isValidCharForIdentifier(char ch);
 
-/// Gets all macros used on the line in the form of a key to value map.
-std::unordered_map<std::string, MacroElement> getAllMacrosOnLine(
-    StringRef line, StringMap<StringRef> macroMap);
-
-/// Gets all macros used on a certain DILocation in the form of a key to value
-/// map.
-std::unordered_map<std::string, MacroElement> getAllMacrosAtLocation(
-    DILocation *LineLoc, const Module *Mod);
+/// Checks whether the character is valid for the first character of
+/// a C identifier.
+bool isValidCharForIdentifierStart(char ch);
 
 #endif //DIFFKEMP_SIMPLL_UTILS_H

--- a/diffkemp/simpll/Utils.h
+++ b/diffkemp/simpll/Utils.h
@@ -90,11 +90,18 @@ AttributeList cleanAttributeList(AttributeList AL);
 CallInst *findCallInst(const CallInst *Call, Function *Fun);
 
 /// Gets C source file from a DIScope and the module.
-std::string getSourceFilePath(DIScope *Scope, const Module *Mod);
+std::string getSourceFilePath(DIScope *Scope);
 
 /// Returned macros with value and location.
 struct MacroElement {
-    StringRef name, body, parentMacro;
+    // The macro name is shortened, therefore it has to be stored as the whole
+    // string, because otherwise the content would be dropped on leaving the
+    // block in which the shortening is done.
+    std::string name;
+    // The body is in DebugInfo, parentMacro is a key in the map, therefore
+    // both can be stored by reference.
+    StringRef body, parentMacro;
+    // This is the line in the C source code on which the macro is located.
     int line;
     const DIMacroFile *source;
 };

--- a/diffkemp/simpll/Utils.h
+++ b/diffkemp/simpll/Utils.h
@@ -103,7 +103,7 @@ struct MacroElement {
     StringRef body, parentMacro;
     // This is the line in the C source code on which the macro is located.
     int line;
-    const DIMacroFile *source;
+    std::string sourceFile;
 };
 
 /// Gets all macros used on the line in the form of a key to value map.

--- a/diffkemp/simpll/Utils.h
+++ b/diffkemp/simpll/Utils.h
@@ -37,8 +37,8 @@ struct CallInfo {
 
     // Default constructor needed for YAML serialisation.
     CallInfo() {}
-    CallInfo(Function *fun, const std::string &file, unsigned int line)
-            : fun(fun->getName()), file(file), line(line) {}
+    CallInfo(const std::string &fun, const std::string &file, unsigned int line)
+            : fun(fun), file(file), line(line) {}
 };
 /// Call stack - list of call entries
 typedef std::vector<CallInfo> CallStack;

--- a/diffkemp/simpll/Utils.h
+++ b/diffkemp/simpll/Utils.h
@@ -16,6 +16,7 @@
 
 #include <llvm/IR/DebugInfoMetadata.h>
 #include <llvm/IR/Function.h>
+#include <unordered_map>
 
 using namespace llvm;
 
@@ -87,5 +88,24 @@ AttributeList cleanAttributeList(AttributeList AL);
 
 /// Get a non-const pointer to a call instruction in a function
 CallInst *findCallInst(const CallInst *Call, Function *Fun);
+
+/// Gets C source file from a DIScope and the module.
+std::string getSourceFilePath(DIScope *Scope, const Module *Mod);
+
+/// Returned macros with value and location.
+struct MacroElement {
+    StringRef name, body, parentMacro;
+    int line;
+    const DIMacroFile *source;
+};
+
+/// Gets all macros used on the line in the form of a key to value map.
+std::unordered_map<std::string, MacroElement> getAllMacrosOnLine(
+    StringRef line, StringMap<StringRef> macroMap);
+
+/// Gets all macros used on a certain DILocation in the form of a key to value
+/// map.
+std::unordered_map<std::string, MacroElement> getAllMacrosAtLocation(
+    DILocation *LineLoc, const Module *Mod);
 
 #endif //DIFFKEMP_SIMPLL_UTILS_H

--- a/diffkemp/simpll/simpll.py
+++ b/diffkemp/simpll/simpll.py
@@ -90,6 +90,7 @@ def simplify_modules_diff(first, second, fun_first, fun_second, var,
         except yaml.YAMLError:
             pass
 
-        return first_out, second_out, objects_to_compare, missing_defs, macro_defs
+        return first_out, second_out, objects_to_compare, missing_defs, \
+            macro_defs
     except CalledProcessError:
         raise SimpLLException("Simplifying files failed")

--- a/diffkemp/simpll/simpll.py
+++ b/diffkemp/simpll/simpll.py
@@ -65,7 +65,7 @@ def simplify_modules_diff(first, second, fun_first, fun_second, var,
             if simpll_result is not None:
                 if "diff-functions" in simpll_result:
                     for fun_pair_yaml in simpll_result["diff-functions"]:
-                        fun_pair = tuple([
+                        fun_pair = [
                             Result.Entity(
                                 fun["function"],
                                 fun["file"] if "file" in fun else "",
@@ -78,8 +78,14 @@ def simplify_modules_diff(first, second, fun_first, fun_second, var,
                             )
                             for fun in [fun_pair_yaml["first"],
                                         fun_pair_yaml["second"]]
-                        ])
-                        funs_to_compare.append(fun_pair)
+                        ]
+
+                        fun_pair.append(
+                            map(Result.MacroDifference,
+                                fun_pair_yaml["macro-diff"])
+                            if "macro-diff" in fun_pair_yaml else None)
+
+                        funs_to_compare.append(tuple(fun_pair))
                 missing_defs = simpll_result["missing-defs"] \
                     if "missing-defs" in simpll_result else None
         except yaml.YAMLError:

--- a/diffkemp/simpll/simpll.py
+++ b/diffkemp/simpll/simpll.py
@@ -58,8 +58,9 @@ def simplify_modules_diff(first, second, fun_first, fun_second, var,
         check_call(["opt", "-S", "-deadargelim", "-o", second_out, second_out],
                    stderr=stderr)
 
-        funs_to_compare = []
+        objects_to_compare = []
         missing_defs = None
+        macro_defs = None
         try:
             simpll_result = yaml.safe_load(simpll_out)
             if simpll_result is not None:
@@ -74,23 +75,21 @@ def simplify_modules_diff(first, second, fun_first, fun_second, var,
                                                           call["file"],
                                                           call["line"])
                                      for call in fun["callstack"]])
-                                if "callstack" in fun else ""
+                                if "callstack" in fun else "",
+                                fun["is-macro"]
                             )
                             for fun in [fun_pair_yaml["first"],
                                         fun_pair_yaml["second"]]
                         ]
 
-                        fun_pair.append(
-                            map(Result.MacroDifference,
-                                fun_pair_yaml["macro-diff"])
-                            if "macro-diff" in fun_pair_yaml else None)
-
-                        funs_to_compare.append(tuple(fun_pair))
+                        objects_to_compare.append(tuple(fun_pair))
                 missing_defs = simpll_result["missing-defs"] \
                     if "missing-defs" in simpll_result else None
+                macro_defs = simpll_result["macro-defs"] \
+                    if "macro-defs" in simpll_result else None
         except yaml.YAMLError:
             pass
 
-        return first_out, second_out, funs_to_compare, missing_defs
+        return first_out, second_out, objects_to_compare, missing_defs, macro_defs
     except CalledProcessError:
         raise SimpLLException("Simplifying files failed")


### PR DESCRIPTION
extracting them from the source code, getting a list of used
macros on the corresponding line and comparing them.

Note: this currently does not work in tests, because it can't find the original source file. Also due to a planned change in the communication interface between SimpLL and diffkemp it does not pass the differences to diffkabi yet (they can be seen in the debug output of SimpLL).