### PR TITLE
Improved macro diff

### DIFF
--- a/diffkemp/simpll/DifferentialFunctionComparator.cpp
+++ b/diffkemp/simpll/DifferentialFunctionComparator.cpp
@@ -191,7 +191,9 @@ int DifferentialFunctionComparator::cmpOperations(
                         return cmpCallsWithExtraArg(CL, CR);
                     }
                 }
-                if (Result || CalledL->getName() != CalledR->getName()) {
+                if ((Result || CalledL->getName() != CalledR->getName()) &&
+                    !CalledL->getName().startswith("simpll") &&
+                    !CalledR->getName().startswith("simpll")) {
                     // If the call instructions are different (cmpOperations
                     // doesn't compare the called functions) or the called
                     // functions have different names, try inlining them.
@@ -202,9 +204,11 @@ int DifferentialFunctionComparator::cmpOperations(
             // If just one of the instructions is a call, it is possible that
             // some logic has been moved into a function. We'll try to inline
             // that function and compare again.
-            if (isa<CallInst>(L))
+            if (isa<CallInst>(L) && !dyn_cast<CallInst>(L)->
+                getCalledFunction()->getName().startswith("simpll"))
                 ModComparator->tryInline = {dyn_cast<CallInst>(L), nullptr};
-            else
+            else if (isa<CallInst>(R) && !dyn_cast<CallInst>(R)->
+                     getCalledFunction()->getName().startswith("simpll"))
                 ModComparator->tryInline = {nullptr, dyn_cast<CallInst>(R)};
         }
     }

--- a/diffkemp/simpll/MacroUtils.cpp
+++ b/diffkemp/simpll/MacroUtils.cpp
@@ -57,8 +57,13 @@ std::unordered_map<std::string, MacroElement> getAllMacrosOnLine(
                     // We are looking for the beginning of an identifier.
                     if (isValidCharForIdentifierStart(macroBody[i]))
                         potentialMacroName += macroBody[i];
-                } else if (!isValidCharForIdentifier(macroBody[i])) {
+                } else if (!isValidCharForIdentifier(macroBody[i]) ||
+                           (i == (macroBody.size() - 1))) {
                     // We found the end of the identifier.
+                    if (i == (macroBody.size() - 1))
+                        // We found the end of the entire macro - append the
+                        // last character, too
+                        potentialMacroName += macroBody[i];
                     auto potentialMacro = macroMap.find(potentialMacroName);
                     if (potentialMacro != macroMap.end()) {
                         // Macro used by the currently processed macro was

--- a/diffkemp/simpll/MacroUtils.cpp
+++ b/diffkemp/simpll/MacroUtils.cpp
@@ -60,7 +60,8 @@ std::unordered_map<std::string, MacroElement> getAllMacrosOnLine(
                 } else if (!isValidCharForIdentifier(macroBody[i]) ||
                            (i == (macroBody.size() - 1))) {
                     // We found the end of the identifier.
-                    if (i == (macroBody.size() - 1))
+                    if (i == (macroBody.size() - 1) &&
+                        isValidCharForIdentifier(macroBody[i]))
                         // We found the end of the entire macro - append the
                         // last character, too
                         potentialMacroName += macroBody[i];

--- a/diffkemp/simpll/ModuleComparator.cpp
+++ b/diffkemp/simpll/ModuleComparator.cpp
@@ -43,8 +43,16 @@ void ModuleComparator::compareFunctions(Function *FirstFun,
             if (FirstFun->isDeclaration() && SecondFun->isDeclaration()
                     && FirstFun->getName() == SecondFun->getName())
                 ComparedFuns.at({FirstFun, SecondFun}) = Result::EQUAL;
-            else
+            else if (FirstFun->getName() != SecondFun->getName())
                 ComparedFuns.at({FirstFun, SecondFun}) = Result::NOT_EQUAL;
+            else {
+                // One function has a body, the second one does not; add the
+                // missing definition
+                if (FirstFun->isDeclaration())
+                    this->MissingDefs.push_back({FirstFun, nullptr});
+                else if (SecondFun->isDeclaration())
+                    this->MissingDefs.push_back({nullptr, SecondFun});
+            }
         }
         return;
     }


### PR DESCRIPTION
This pull request:
1. Fixes a bug in macro utils that caused the macro finding algorithm to fail when the only thing in a macro's body was another macro.
2. Improves the code that is supposed to extract the line corresponding to a DILocation from the source code to join the adjacent lines when there is an expression longer than one line.
3. Optimizes the call instruction inlining so it does not attempt to inline functions generated by SimpLL itself.
4. Fixes #46 