### PR TITLE
SimpLL: Extending ignoring of casts when comparing control flow

### DIFF
--- a/diffkemp/simpll/DifferentialFunctionComparator.cpp
+++ b/diffkemp/simpll/DifferentialFunctionComparator.cpp
@@ -402,7 +402,7 @@ int DifferentialFunctionComparator::cmpValues(const Value *L,
 }
 
 /// Specific comparing of constants. If one of them (or both) is a cast
-/// constant expression, compare its interal value.
+/// constant expression, compare its operand.
 int DifferentialFunctionComparator::cmpConstants(const Constant *L,
         const Constant *R) const {
     int Result = FunctionComparator::cmpConstants(L, R);

--- a/diffkemp/simpll/DifferentialFunctionComparator.h
+++ b/diffkemp/simpll/DifferentialFunctionComparator.h
@@ -73,7 +73,7 @@ class DifferentialFunctionComparator : public FunctionComparator {
     /// whose value changed and values where at least one of them is a cast.
     int cmpValues(const Value *L, const Value *R) const override;
     /// Specific comparing of constants. If one of them (or both) is a cast
-    /// constant expression, compare its interal value.
+    /// constant expression, compare its operand.
     int cmpConstants(const Constant *L, const Constant *R) const override;
     /// Specific comarison of memcpy instructions
     int cmpMemset(const CallInst *CL, const CallInst *CR) const;

--- a/diffkemp/simpll/DifferentialFunctionComparator.h
+++ b/diffkemp/simpll/DifferentialFunctionComparator.h
@@ -72,6 +72,9 @@ class DifferentialFunctionComparator : public FunctionComparator {
     /// Specific comparing of values. Handles values generated from macros
     /// whose value changed and values where at least one of them is a cast.
     int cmpValues(const Value *L, const Value *R) const override;
+    /// Specific comparing of constants. If one of them (or both) is a cast
+    /// constant expression, compare its interal value.
+    int cmpConstants(const Constant *L, const Constant *R) const override;
     /// Specific comarison of memcpy instructions
     int cmpMemset(const CallInst *CL, const CallInst *CR) const;
     /// Comparing of a structure size with a constant

--- a/tests/regression/diffkabi/test_specs/rhel-73-74.yaml
+++ b/tests/regression/diffkabi/test_specs/rhel-73-74.yaml
@@ -1,0 +1,9 @@
+old_kernel: 3.10.0-514.el7
+new_kernel: 3.10.0-693.el7
+
+debug: true
+control_flow_only: true
+
+functions:
+        debugfs_create_u32: equal_syntax
+


### PR DESCRIPTION
only to constant expressions.

This fixes the function debugfs_create_u32 comparing as non-equal.