### PR TITLE
LLReve is optional as a component

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -94,3 +94,6 @@ tests/regression/diffsysctl/kernel_modules
 
 # Kernel sources directory
 kernel/
+
+# LLReve tool
+llreve/

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,0 @@
-[submodule "llreve"]
-	path = diffkemp/llreve
-	url = https://github.com/viktormalik/llreve.git
-	branch = diffkemp

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ jobs:
         - if [ "$TRAVIS_EVENT_TYPE" = "cron" ]; then tests/regression/clean_test.sh all; fi
       script: 
         - docker run -v $PWD:/diffkemp:Z -w /diffkemp viktormalik/diffkemp-devel /bin/bash -c \
-          "cd build; cmake .. -GNinja -DCMAKE_BUILD_TYPE=Release; ninja; cd .."
+          "cd build; cmake .. -GNinja -DCMAKE_BUILD_TYPE=Release -DBUILD_LLREVE=ON; ninja; cd .."
         - docker run -v $PWD:/diffkemp:Z -w /diffkemp viktormalik/diffkemp-devel /bin/bash -c \
           "pytest tests/unit_tests"
         - docker run -v $PWD:/diffkemp:Z -w /diffkemp viktormalik/diffkemp-devel /bin/bash -c \

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,4 +6,15 @@ include_directories(${LLVM_INCLUDE_DIRS})
 link_directories(${LLVM_LIBRARY_DIRS})
 
 add_subdirectory(diffkemp/simpll)
-add_subdirectory(diffkemp/llreve/reve)
+
+option(BUILD_LLREVE "Build the LLReve tool for semantic comparison" OFF)
+if (${BUILD_LLREVE})
+  if (NOT EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/llreve)
+    execute_process(COMMAND
+      git clone
+        -b diffkemp
+        https://github.com/viktormalik/llreve.git
+        ${CMAKE_CURRENT_SOURCE_DIR}/llreve)
+  endif ()
+  add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/llreve/reve)
+endif ()

--- a/README.md
+++ b/README.md
@@ -74,12 +74,12 @@ KABI whitelist file to be present or a single function to be specified (in fact,
 the tool can be used to compare semantic difference of any function). The tool
 can be invoked as follows:
 
-    bin/diffkabi old-version new-version [-f function] [--control-flow-only] [--syntax-diff]
+    bin/diffkabi old-version new-version [-f function] [--control-flow-only] [--print-diff]
 
 By default, all functions from the `kabi_whitelist_x86_64` file are compared.
 `--control-flow-only` ignores changes in assignments, only checks for changes in
 the control flow - conditions, loops, function calls, goto.
-`--syntax-diff` displays the `diff` command result for functions that are
+`--print-diff` displays the `diff` command result for functions that are
 semantically different.
 
 ### DiffSysctl

--- a/diffkemp/config.py
+++ b/diffkemp/config.py
@@ -1,10 +1,15 @@
 """Configuration of the tool."""
+import os
+
+
+class ConfigException(Exception):
+    pass
 
 
 class Config:
     def __init__(self, builder_first, builder_second,
                  timeout, syntax_only, control_flow_only, verbosity,
-                 do_not_link):
+                 do_not_link, semdiff_tool):
         """
         Store configuration of DiffKemp
         :param builder_first: Builder for the first kernel.
@@ -13,6 +18,8 @@ class Config:
         :param syntax_only: Only perform the syntax diff.
         :param control_flow_only: Check only for control-flow differences.
         :param verbosity: Verbosity level (currently boolean).
+        :param do_not_link: Do not link functions from other sources
+        :param semdiff_tool: Tool to use for semantic diff
         """
         self.builder_first = builder_first
         self.builder_second = builder_second
@@ -22,3 +29,12 @@ class Config:
         self.control_flow_only = control_flow_only
         self.verbosity = verbosity
         self.do_not_link = do_not_link
+
+        # Semantic diff tool configuration
+        self.semdiff_tool = semdiff_tool
+        if semdiff_tool == "llreve":
+            if not os.path.isfile("build/llreve/reve/reve/llreve"):
+                raise ConfigException("LLReve not built, try to re-run CMake \
+                                       with -DBUILD_LLREVE=ON")
+        elif semdiff_tool is not None:
+            raise ConfigException("Unsupported semantic diff tool")

--- a/diffkemp/config.py
+++ b/diffkemp/config.py
@@ -8,14 +8,14 @@ class ConfigException(Exception):
 
 class Config:
     def __init__(self, builder_first, builder_second,
-                 timeout, syntax_only, control_flow_only, verbosity,
+                 timeout, print_diff, control_flow_only, verbosity,
                  do_not_link, semdiff_tool):
         """
         Store configuration of DiffKemp
         :param builder_first: Builder for the first kernel.
         :param builder_second: Builder for the second kernel.
         :param timeout: Timeout.
-        :param syntax_only: Only perform the syntax diff.
+        :param print_diff: Only perform the syntax diff.
         :param control_flow_only: Check only for control-flow differences.
         :param verbosity: Verbosity level (currently boolean).
         :param do_not_link: Do not link functions from other sources
@@ -25,7 +25,7 @@ class Config:
         self.builder_second = builder_second
         # Default timeout is 40s
         self.timeout = int(timeout) if timeout else 40
-        self.syntax_only = syntax_only
+        self.print_diff = print_diff
         self.control_flow_only = control_flow_only
         self.verbosity = verbosity
         self.do_not_link = do_not_link

--- a/diffkemp/diffkabi.py
+++ b/diffkemp/diffkabi.py
@@ -42,6 +42,8 @@ def __make_argument_parser():
                     action="store_true")
     ap.add_argument("--show-empty-diff", help="shows difference in function \
                     when the syntactic diff is empty", action="store_true")
+    ap.add_argument("--semdiff-tool", help="tool to use for semantic \
+                    difference analysis", choices=["llreve"])
     return ap
 
 
@@ -68,7 +70,7 @@ def run_from_cli():
 
         config = Config(first_builder, second_builder, args.timeout,
                         args.syntax_diff, args.control_flow_only, args.verbose,
-                        args.do_not_link)
+                        args.do_not_link, args.semdiff_tool)
 
         if args.log_files:
             dirname = logs_dirname(args.src_version, args.dest_version)

--- a/diffkemp/diffkemp.py
+++ b/diffkemp/diffkemp.py
@@ -38,6 +38,8 @@ def __make_argument_parser():
     ap.add_argument("-t", "--timeout", help="timeout in seconds for a single \
                     parameter comparison")
     ap.add_argument("-s", "--function", help="analyse only specific function")
+    ap.add_argument("--semdiff-tool", help="tool to use for semantic \
+                    difference analysis", choices=["llreve"])
     return ap
 
 
@@ -90,7 +92,7 @@ def run_from_cli():
             return 0
 
         config = Config(first_builder, second_builder, args.timeout, False,
-                        False, args.verbose, True)
+                        False, args.verbose, True, args.semdiff_tool)
 
         print "Computing semantic difference of module parameters"
         print "--------------------------------------------------"

--- a/diffkemp/diffsysctl.py
+++ b/diffkemp/diffsysctl.py
@@ -28,6 +28,8 @@ def __make_argument_parser():
                     function comparison")
     ap.add_argument("--rebuild", help="force rebuild sources",
                     action="store_true")
+    ap.add_argument("--semdiff-tool", help="tool to use for semantic \
+                    difference analysis", choices=["llreve"])
     return ap
 
 
@@ -46,7 +48,7 @@ def run_from_cli():
                                            verbose=args.verbose)
 
         config = Config(first_builder, second_builder, args.timeout, False,
-                        False, args.verbose, True)
+                        False, args.verbose, True, args.semdiff_tool)
 
         sysctl_mod_first = first_builder.build_sysctl_module(args.sysctl)
         sysctl_mod_second = second_builder.build_sysctl_module(args.sysctl)

--- a/diffkemp/semdiff/function_diff.py
+++ b/diffkemp/semdiff/function_diff.py
@@ -143,7 +143,7 @@ def functions_diff(mod_first, mod_second,
     """
     result = Result(Result.Kind.NONE, mod_first, mod_second)
     try:
-        if not config.syntax_only:
+        if not config.print_diff:
             if fun_first == fun_second:
                 fun_str = fun_first
             else:
@@ -210,7 +210,7 @@ def functions_diff(mod_first, mod_second,
                 fun_result.first = fun_pair[0]
                 fun_result.second = fun_pair[1]
                 if (fun_result.kind == Result.Kind.NOT_EQUAL and
-                        config.syntax_only):
+                        config.print_diff):
                     if not fun_result.first.is_macro:
                         # Get the syntactic diff of functions
                         fun_result.diff = syntax_diff(
@@ -230,7 +230,7 @@ def functions_diff(mod_first, mod_second,
                             fun_result.diff = "  {}\n\n  {}\n".format(
                                 md["left-value"], md["right-value"])
                 result.add_inner(fun_result)
-        if not config.syntax_only:
+        if not config.print_diff:
             print "      {}".format(result)
     except SimpLLException:
         print "    Simplifying has failed"

--- a/tests/regression/task_spec.py
+++ b/tests/regression/task_spec.py
@@ -26,7 +26,7 @@ class TaskSpec:
         self.new_builder = LlvmKernelBuilder(self.new_kernel, module_dir,
                                              debug=self.debug, rebuild=True)
         self.config = Config(self.old_builder, self.new_builder, 120, False,
-                             self.control_flow_only, False, False)
+                             self.control_flow_only, False, False, "llreve")
 
     def _file_name(self, suffix, ext, name=None):
         """

--- a/tests/unit_tests/function_syntax_diff_test.py
+++ b/tests/unit_tests/function_syntax_diff_test.py
@@ -29,7 +29,7 @@ def test_syntax_diff(builder_left, builder_right):
             '\tif (dio->end_io)\n! \t\tdio->end_io(dio->iocb, offset, ret, dio'
             '->private, 0, 0);\n  \n')
 
-    config = Config(builder_left, builder_right, timeout=15, syntax_only=True,
+    config = Config(builder_left, builder_right, timeout=15, print_diff=True,
                     control_flow_only=True, verbosity=False, do_not_link=False,
                     semdiff_tool=None)
     first = builder_left.build_file_for_symbol(f)

--- a/tests/unit_tests/function_syntax_diff_test.py
+++ b/tests/unit_tests/function_syntax_diff_test.py
@@ -30,7 +30,8 @@ def test_syntax_diff(builder_left, builder_right):
             '->private, 0, 0);\n  \n')
 
     config = Config(builder_left, builder_right, timeout=15, syntax_only=True,
-                    control_flow_only=True, verbosity=False, do_not_link=False)
+                    control_flow_only=True, verbosity=False, do_not_link=False,
+                    semdiff_tool=None)
     first = builder_left.build_file_for_symbol(f)
     second = builder_right.build_file_for_symbol(f)
     fun_result = functions_diff(mod_first=first, mod_second=second,


### PR DESCRIPTION
Instead of having it as a git submodule, it is possible to download it during CMake by setting `-DBUILD_LLREVE=ON`. From now, LLReve is not run by default (only syntax diff by SimpLL is), it can be turned on by using parameter `--semdiff-tool=llreve`.