### PR TITLE
SimpLL: Extend the code for macro differences to cover differences

### DIFF
--- a/diffkemp/simpll/DifferentialFunctionComparator.cpp
+++ b/diffkemp/simpll/DifferentialFunctionComparator.cpp
@@ -15,6 +15,7 @@
 #include "DifferentialFunctionComparator.h"
 #include "Config.h"
 #include "MacroUtils.h"
+#include "passes/FunctionAbstractionsGenerator.h"
 #include <llvm/IR/GetElementPtrTypeIterator.h>
 #include <llvm/IR/Instructions.h>
 #include <llvm/IR/Module.h>
@@ -364,6 +365,9 @@ int DifferentialFunctionComparator::cmpBasicBlocks(const BasicBlock *BBL,
     return 0;
 }
 
+/// Looks for inline assembly differences between the certain values.
+/// Note: passing the parent function is necessary in order to properly generate
+/// the SyntaxDifference object.
 std::vector<SyntaxDifference> DifferentialFunctionComparator::findAsmDifference(
         const Value *L, const Value *R, const Function *ParentL,
         const Function *ParentR) const {
@@ -374,8 +378,8 @@ std::vector<SyntaxDifference> DifferentialFunctionComparator::findAsmDifference(
         // Both values have to be functions
         return {};
 
-    if (!FunL->getName().startswith("simpll__inlineasm") ||
-        !FunR->getName().startswith("simpll__inlineasm"))
+    if (!FunL->getName().startswith(SimpllInlineAsmPrefix) ||
+        !FunR->getName().startswith(SimpllInlineAsmPrefix))
         // Both functions have to be assembly abstractions
         return {};
 

--- a/diffkemp/simpll/DifferentialFunctionComparator.h
+++ b/diffkemp/simpll/DifferentialFunctionComparator.h
@@ -88,6 +88,10 @@ class DifferentialFunctionComparator : public FunctionComparator {
     const DataLayout &LayoutL, &LayoutR;
 
     ModuleComparator *ModComparator;
+
+    std::vector<SyntaxDifference> findAsmDifference(const Value *L,
+            const Value *R, const Function *ParentL, const Function *ParentR)
+            const;
 };
 
 #endif //DIFFKEMP_SIMPLL_DIFFERENTIALFUNCTIONCOMPARATOR_H

--- a/diffkemp/simpll/DifferentialFunctionComparator.h
+++ b/diffkemp/simpll/DifferentialFunctionComparator.h
@@ -89,6 +89,9 @@ class DifferentialFunctionComparator : public FunctionComparator {
 
     ModuleComparator *ModComparator;
 
+    /// Looks for inline assembly differences between the certain values.
+    /// Note: passing the parent function is necessary in order to properly
+    /// generate the SyntaxDifference object.
     std::vector<SyntaxDifference> findAsmDifference(const Value *L,
             const Value *R, const Function *ParentL, const Function *ParentR)
             const;

--- a/diffkemp/simpll/MacroUtils.cpp
+++ b/diffkemp/simpll/MacroUtils.cpp
@@ -224,13 +224,13 @@ std::unordered_map<std::string, MacroElement> getAllMacrosAtLocation(
 /// This is used when a difference is suspected to be in a macro in order to
 /// include that difference into ModuleComparator, and therefore avoid an
 /// empty diff.
-std::vector<MacroDifference> findMacroDifferences(
+std::vector<SyntaxDifference> findMacroDifferences(
     const Instruction *L, const Instruction *R) {
     // Try to discover a macro difference
     auto MacrosL = getAllMacrosAtLocation(L->getDebugLoc(), L->getModule());
     auto MacrosR = getAllMacrosAtLocation(R->getDebugLoc(), R->getModule());
 
-    std::vector<MacroDifference> result;
+    std::vector<SyntaxDifference> result;
 
     for (auto Elem : MacrosL) {
         if (Elem.second.name == "<>")
@@ -293,7 +293,7 @@ std::vector<MacroDifference> findMacroDifferences(
                         << elem.line << "\n";
                 });
 
-            result.push_back(MacroDifference {
+            result.push_back(SyntaxDifference {
                 Elem.first, LValue->second.body, RValue->second.body,
                 StackL, StackR, L->getFunction()->getName()
             });

--- a/diffkemp/simpll/MacroUtils.h
+++ b/diffkemp/simpll/MacroUtils.h
@@ -40,7 +40,8 @@ struct MacroElement {
 };
 
 /// Syntactic difference between objects that cannot be found in the original
-/// source files
+/// source files.
+/// Note: this can be either a macro difference or inline assembly difference.
 struct SyntaxDifference {
 	// Name of the object.
 	std::string name;

--- a/diffkemp/simpll/MacroUtils.h
+++ b/diffkemp/simpll/MacroUtils.h
@@ -39,14 +39,14 @@ struct MacroElement {
     std::string sourceFile;
 };
 
-/// Difference between macro in left module and the same macro in the right
-/// module.
-struct MacroDifference {
-	// Name of the macro.
-	std::string macroName;
+/// Syntactic difference between objects that cannot be found in the original
+/// source files
+struct SyntaxDifference {
+	// Name of the object.
+	std::string name;
 	// The difference.
 	std::string BodyL, BodyR;
-	// Stacks containing the differing macros and all other macros affected
+	// Stacks containing the differing objects and all other objects affected
 	// by the difference (again for both modules).
 	CallStack StackL, StackR;
 	// The function in which the difference was found
@@ -67,7 +67,7 @@ std::unordered_map<std::string, MacroElement> getAllMacrosAtLocation(
 /// This is used when a difference is suspected to be in a macro in order to
 /// include that difference into ModuleComparator, and therefore avoid an
 /// empty diff.
-std::vector<MacroDifference> findMacroDifferences(
+std::vector<SyntaxDifference> findMacroDifferences(
 		const Instruction *L, const Instruction *R);
 
 #endif // DIFFKEMP_SIMPLL_MACRO_UTILS_H

--- a/diffkemp/simpll/ModuleComparator.h
+++ b/diffkemp/simpll/ModuleComparator.h
@@ -34,8 +34,11 @@ class ModuleComparator {
     enum Result { EQUAL, NOT_EQUAL, UNKNOWN };
     /// Storing results of function comparisons.
     std::map<FunPair, Result> ComparedFuns;
-    /// Storing results from macro comparisons.
-    std::vector<MacroDifference> DifferingMacros;
+    /// Storing results from macro and asm comparisions.
+    std::vector<SyntaxDifference> DifferingObjects;
+    // Function abstraction to assembly string map.
+    StringMap<StringRef> AsmToStringMapL;
+    StringMap<StringRef> AsmToStringMapR;
 
     std::vector<ConstFunPair> MissingDefs;
 
@@ -43,9 +46,11 @@ class ModuleComparator {
     const DebugInfo *DI;
 
     ModuleComparator(Module &First, Module &Second, bool controlFlowOnly,
-                     const DebugInfo *DI)
+                     const DebugInfo *DI, StringMap<StringRef> &AsmToStringMapL,
+                     StringMap<StringRef> &AsmToStringMapR)
             : First(First), Second(Second), controlFlowOnly(controlFlowOnly),
-            GS(&First, &Second, this), DI(DI) {}
+            GS(&First, &Second, this), DI(DI), AsmToStringMapL(AsmToStringMapL),
+            AsmToStringMapR(AsmToStringMapR) {}
 
     /// Syntactically compare two functions.
     /// The result of the comparison is stored into the ComparedFuns map.

--- a/diffkemp/simpll/Output.cpp
+++ b/diffkemp/simpll/Output.cpp
@@ -143,7 +143,7 @@ struct MappingTraits<ResultReport> {
 void reportOutput(Config &config,
                   std::vector<FunPair> &nonequalFuns,
                   std::vector<ConstFunPair> &missingDefs,
-                  std::vector<MacroDifference> &differingMacros) {
+                  std::vector<SyntaxDifference> &differingMacros) {
     ResultReport report;
     for (auto &funPair : nonequalFuns) {
         report.diffFuns.push_back({
@@ -178,18 +178,18 @@ void reportOutput(Config &config,
                 toAppendRight.begin(), toAppendRight.end());
 
         report.diffFuns.push_back({
-               FunctionInfo(macroDiff.macroName,
+               FunctionInfo(macroDiff.name,
                             macroDiff.StackL[0].file,
                             macroDiff.StackL,
                             true),
-               FunctionInfo(macroDiff.macroName,
+               FunctionInfo(macroDiff.name,
                             macroDiff.StackR[0].file,
                             macroDiff.StackR,
                             true)
         });
 
         report.macroDefinitions.push_back(MacroBody {
-            macroDiff.macroName, macroDiff.BodyL, macroDiff.BodyR
+            macroDiff.name, macroDiff.BodyL, macroDiff.BodyR
         });
     }
     for (auto &funPair : missingDefs) {

--- a/diffkemp/simpll/Output.h
+++ b/diffkemp/simpll/Output.h
@@ -25,6 +25,6 @@
 void reportOutput(Config &config,
                   std::vector<FunPair> &nonequalFuns,
                   std::vector<ConstFunPair> &missingDefs,
-                  std::vector<MacroDifference> &differingMacros);
+                  std::vector<SyntaxDifference> &differingMacros);
 
 #endif // DIFFKEMP_SIMPLL_OUTPUT_H

--- a/diffkemp/simpll/SimpLL.cpp
+++ b/diffkemp/simpll/SimpLL.cpp
@@ -45,7 +45,7 @@ int main(int argc, const char **argv) {
 
     std::vector<FunPair> nonequalFuns;
     std::vector<ConstFunPair> missingDefs;
-    std::vector<MacroDifference> differingMacros;
+    std::vector<SyntaxDifference> differingMacros;
     simplifyModulesDiff(config, nonequalFuns, missingDefs, differingMacros);
 
     reportOutput(config, nonequalFuns, missingDefs, differingMacros);

--- a/diffkemp/simpll/Transforms.h
+++ b/diffkemp/simpll/Transforms.h
@@ -45,7 +45,7 @@ void preprocessModule(Module &Mod,
 void simplifyModulesDiff(Config &config,
                          std::vector<FunPair> &nonequalFuns,
                          std::vector<ConstFunPair> &missingDefs,
-                         std::vector<MacroDifference> &differingMacros);
+                         std::vector<SyntaxDifference> &differingMacros);
 
 /// Preprocessing transformations - run independently on each module at the
 /// end.

--- a/diffkemp/simpll/passes/FunctionAbstractionsGenerator.cpp
+++ b/diffkemp/simpll/passes/FunctionAbstractionsGenerator.cpp
@@ -121,9 +121,9 @@ std::string FunctionAbstractionsGenerator::funHash(Value *Fun) {
 
 std::string FunctionAbstractionsGenerator::abstractionPrefix(Value *Fun) {
     if (isa<InlineAsm>(Fun))
-        return "simpll__inlineasm_";
+        return SimpllInlineAsmPrefix;
     else
-        return "simpll__indirect_";
+        return SimpllIndirectFunctionPrefix;
 }
 
 /// Swaps names of two functions in a module.

--- a/diffkemp/simpll/passes/FunctionAbstractionsGenerator.h
+++ b/diffkemp/simpll/passes/FunctionAbstractionsGenerator.h
@@ -26,7 +26,10 @@ class FunctionAbstractionsGenerator
         : public AnalysisInfoMixin<FunctionAbstractionsGenerator> {
   public:
     typedef StringMap<Function *> FunMap;
-    using Result = FunMap;
+    struct Result {
+        FunMap funAbstractions;
+        StringMap<StringRef> asmValueMap;
+    };
 
     Result run(Module &Mod,
                AnalysisManager<Module, Function *> &mam,

--- a/diffkemp/simpll/passes/FunctionAbstractionsGenerator.h
+++ b/diffkemp/simpll/passes/FunctionAbstractionsGenerator.h
@@ -18,6 +18,9 @@
 #include <llvm/IR/PassManager.h>
 #include <set>
 
+const std::string SimpllInlineAsmPrefix = "simpll__inlineasm_";
+const std::string SimpllIndirectFunctionPrefix = "simpll__indirect_";
+
 using namespace llvm;
 
 /// Generates abstractions for indirect function calls and for inline assemblies


### PR DESCRIPTION
in inline assembly (to be able to show a diff when there is a
differering assembly generated from macros and the difference
cannot be found by following the macros).

This fixes an empty diff when comparing the function `slab_alloc_node` between kernel version 3.10.0-514.el7 and 3.10.0-693.el7.