### PR TITLE
C source call arguments analysis

### DIFF
--- a/diffkemp/simpll/DifferentialFunctionComparator.cpp
+++ b/diffkemp/simpll/DifferentialFunctionComparator.cpp
@@ -22,6 +22,12 @@
 #include <llvm/Support/raw_ostream.h>
 #include <set>
 
+// If a operand of a call instruction is detected to be generated from one of
+// these macros, it should be always compared as equal.
+std::set<std::string> ignoredMacroList = {
+        "__COUNTER__", "__FILE__", "__LINE__", "__DATE__", "__TIME__"
+};
+
 /// Compare GEPs. This code is copied from FunctionComparator::cmpGEPs since it
 /// was not possible to simply call the original function.
 /// Handles offset between matching GEP indices in the compared modules.
@@ -299,10 +305,6 @@ bool mayIgnore(const Instruction *Inst) {
 }
 
 bool mayIgnoreMacro(std::string macro) {
-    std::set<std::string> ignoredMacroList = {
-        "__COUNTER__", "__FILE__", "__LINE__", "__DATE__", "__TIME__"
-    };
-
     return ignoredMacroList.find(macro) != ignoredMacroList.end();
 }
 
@@ -375,7 +377,7 @@ int DifferentialFunctionComparator::cmpBasicBlocks(const BasicBlock *BBL,
                                 ModComparator->AsmToStringMapR[CFR->getName()]);
                         else
                             CArgsR = findFunctionCallSourceArguments(
-                                InstL->getDebugLoc(), InstL->getModule(),
+                                InstR->getDebugLoc(), InstR->getModule(),
                                 CFL->getName());
                     }
 
@@ -385,8 +387,8 @@ int DifferentialFunctionComparator::cmpBasicBlocks(const BasicBlock *BBL,
                                 (CArgsL[i] == CArgsR[i])) {
                             DEBUG_WITH_TYPE(DEBUG_SIMPLL,
                                 dbgs() << "Comparing integers as equal "
-                                << "because of correspondence to an ignored "
-                                << "macro\n");
+                                       << "because of correspondence to an "
+                                       << "ignored macro\n");
                             Res = 0;
                         }
 
@@ -409,9 +411,9 @@ int DifferentialFunctionComparator::cmpBasicBlocks(const BasicBlock *BBL,
                                 SizeR != ModComparator->StructSizeMapR.end() &&
                                 SizeL->second == SizeR->second) {
                                 DEBUG_WITH_TYPE(DEBUG_SIMPLL,
-                                dbgs() << "Comparing integers as equal "
-                                << "because of correspondence to structure type"
-                                << " sizes \n");
+                                    dbgs() << "Comparing integers as equal "
+                                           << "because of correspondence to "
+                                           << "structure type sizes \n");
                                 Res = 0;
                             }
                         }

--- a/diffkemp/simpll/ModuleComparator.h
+++ b/diffkemp/simpll/ModuleComparator.h
@@ -17,10 +17,10 @@
 
 #include "DebugInfo.h"
 #include "DifferentialGlobalNumberState.h"
-#include "MacroUtils.h"
 #include "Utils.h"
 #include <llvm/IR/Module.h>
 #include <set>
+#include "SourceCodeUtils.h"
 
 using namespace llvm;
 

--- a/diffkemp/simpll/ModuleComparator.h
+++ b/diffkemp/simpll/ModuleComparator.h
@@ -17,10 +17,11 @@
 
 #include "DebugInfo.h"
 #include "DifferentialGlobalNumberState.h"
+#include "SourceCodeUtils.h"
+#include "passes/StructureSizeAnalysis.h"
 #include "Utils.h"
 #include <llvm/IR/Module.h>
 #include <set>
-#include "SourceCodeUtils.h"
 
 using namespace llvm;
 
@@ -39,6 +40,9 @@ class ModuleComparator {
     // Function abstraction to assembly string map.
     StringMap<StringRef> AsmToStringMapL;
     StringMap<StringRef> AsmToStringMapR;
+    // Structure size to structure name map.
+    StructureSizeAnalysis::Result &StructSizeMapL;
+    StructureSizeAnalysis::Result &StructSizeMapR;
 
     std::vector<ConstFunPair> MissingDefs;
 
@@ -47,10 +51,13 @@ class ModuleComparator {
 
     ModuleComparator(Module &First, Module &Second, bool controlFlowOnly,
                      const DebugInfo *DI, StringMap<StringRef> &AsmToStringMapL,
-                     StringMap<StringRef> &AsmToStringMapR)
+                     StringMap<StringRef> &AsmToStringMapR,
+                     StructureSizeAnalysis::Result &StructSizeMapL,
+                     StructureSizeAnalysis::Result &StructSizeMapR)
             : First(First), Second(Second), controlFlowOnly(controlFlowOnly),
             GS(&First, &Second, this), DI(DI), AsmToStringMapL(AsmToStringMapL),
-            AsmToStringMapR(AsmToStringMapR) {}
+            AsmToStringMapR(AsmToStringMapR), StructSizeMapL(StructSizeMapL),
+            StructSizeMapR(StructSizeMapR) {}
 
     /// Syntactically compare two functions.
     /// The result of the comparison is stored into the ComparedFuns map.

--- a/diffkemp/simpll/SourceCodeUtils.h
+++ b/diffkemp/simpll/SourceCodeUtils.h
@@ -58,6 +58,9 @@ struct SyntaxDifference {
 std::unordered_map<std::string, MacroElement> getAllMacrosOnLine(
     StringRef line, StringMap<StringRef> macroMap);
 
+/// Extract the line corresponding to the DILocation from the C source file.
+std::string extractLineFromLocation(DILocation *LineLoc);
+
 /// Gets all macros used on a certain DILocation in the form of a key to value
 /// map.
 std::unordered_map<std::string, MacroElement> getAllMacrosAtLocation(
@@ -70,5 +73,17 @@ std::unordered_map<std::string, MacroElement> getAllMacrosAtLocation(
 /// empty diff.
 std::vector<SyntaxDifference> findMacroDifferences(
 		const Instruction *L, const Instruction *R);
+
+/// Tries to convert C source syntax of inline ASM (the input may include other
+/// code, the inline asm is found and extracted) to the LLVM syntax.
+/// Returns a pair of strings - the first one contains the converted ASM, the
+/// second one contains (unparsed) arguments.
+std::pair<std::string, std::string> convertInlineAsmToLLVMFormat(
+        std::string input);
+
+/// Takes a LLVM inline assembly with the corresponding call location and
+/// retrieves the corresponding arguments in the C source code.
+std::vector<std::string> findInlineAssemblySourceArguments(DILocation *LineLoc,
+        const Module *Mod, std::string inlineAsm);
 
 #endif // DIFFKEMP_SIMPLL_MACRO_UTILS_H

--- a/diffkemp/simpll/SourceCodeUtils.h
+++ b/diffkemp/simpll/SourceCodeUtils.h
@@ -74,6 +74,10 @@ std::unordered_map<std::string, MacroElement> getAllMacrosAtLocation(
 std::vector<SyntaxDifference> findMacroDifferences(
 		const Instruction *L, const Instruction *R);
 
+// Takes a string and the position of the first bracket and returns the
+// substring in the brackets.
+std::string getSubstringToMatchingBracket(std::string str, size_t position);
+
 /// Tries to convert C source syntax of inline ASM (the input may include other
 /// code, the inline asm is found and extracted) to the LLVM syntax.
 /// Returns a pair of strings - the first one contains the converted ASM, the
@@ -85,6 +89,9 @@ std::pair<std::string, std::string> convertInlineAsmToLLVMFormat(
 /// retrieves the corresponding arguments in the C source code.
 std::vector<std::string> findInlineAssemblySourceArguments(DILocation *LineLoc,
         const Module *Mod, std::string inlineAsm);
+
+// Takes in a string with C function call arguments and splits it into a vector.
+std::vector<std::string> splitArgumentsList(std::string argumentString);
 
 /// Takes a function name with the corresponding call location and retrieves
 /// the corresponding arguments in the C source code.

--- a/diffkemp/simpll/SourceCodeUtils.h
+++ b/diffkemp/simpll/SourceCodeUtils.h
@@ -86,4 +86,9 @@ std::pair<std::string, std::string> convertInlineAsmToLLVMFormat(
 std::vector<std::string> findInlineAssemblySourceArguments(DILocation *LineLoc,
         const Module *Mod, std::string inlineAsm);
 
+/// Takes a function name with the corresponding call location and retrieves
+/// the corresponding arguments in the C source code.
+std::vector<std::string> findFunctionCallSourceArguments(DILocation *LineLoc,
+        const Module *Mod, std::string functionName);
+
 #endif // DIFFKEMP_SIMPLL_MACRO_UTILS_H

--- a/diffkemp/simpll/Transforms.cpp
+++ b/diffkemp/simpll/Transforms.cpp
@@ -117,8 +117,8 @@ void simplifyModulesDiff(Config &config,
     auto AbstractionGeneratorResultR =
             mam.getResult<FunctionAbstractionsGenerator>(*config.Second,
                     config.SecondFun);
-    unifyFunctionAbstractions(AbstractionGeneratorResultL.funAbstractions,
-                              AbstractionGeneratorResultR.funAbstractions);
+    unifyFunctionAbstractions(AbstractionGeneratorResultL,
+                              AbstractionGeneratorResultR);
 
     // Module passes
     PassManager<Module, AnalysisManager<Module, Function *>, Function *,

--- a/diffkemp/simpll/Utils.cpp
+++ b/diffkemp/simpll/Utils.cpp
@@ -297,3 +297,15 @@ bool isValidCharForIdentifierStart(char ch) {
     else
         return false;
 }
+
+/// Finds the string given in the second argument and replaces it with the one
+/// given in the third argument.
+void findAndReplace(std::string &input, std::string find,
+        std::string replace) {
+    int position = 0;
+    while ((position = input.find(find, position)) !=
+            std::string::npos) {
+        input.replace(position, find.length(), replace);
+        position += replace.length();
+    }
+}

--- a/diffkemp/simpll/Utils.h
+++ b/diffkemp/simpll/Utils.h
@@ -99,4 +99,9 @@ bool isValidCharForIdentifier(char ch);
 /// a C identifier.
 bool isValidCharForIdentifierStart(char ch);
 
+/// Finds the string given in the second argument and replaces it with the one
+/// given in the third argument.
+void findAndReplace(std::string &input, std::string find,
+        std::string replace);
+
 #endif //DIFFKEMP_SIMPLL_UTILS_H

--- a/diffkemp/simpll/passes/FunctionAbstractionsGenerator.h
+++ b/diffkemp/simpll/passes/FunctionAbstractionsGenerator.h
@@ -17,6 +17,7 @@
 
 #include <llvm/IR/PassManager.h>
 #include <set>
+#include <unordered_map>
 
 const std::string SimpllInlineAsmPrefix = "simpll__inlineasm_";
 const std::string SimpllIndirectFunctionPrefix = "simpll__indirect_";
@@ -28,7 +29,7 @@ using namespace llvm;
 class FunctionAbstractionsGenerator
         : public AnalysisInfoMixin<FunctionAbstractionsGenerator> {
   public:
-    typedef StringMap<Function *> FunMap;
+    typedef std::unordered_map<std::string, Function *> FunMap;
     struct Result {
         FunMap funAbstractions;
         StringMap<StringRef> asmValueMap;
@@ -55,7 +56,7 @@ class FunctionAbstractionsGenerator
 /// Unify function abstractions between modules. Makes sure that corresponding
 /// abstractions get the same name.
 void unifyFunctionAbstractions(
-        FunctionAbstractionsGenerator::FunMap &FirstMap,
-        FunctionAbstractionsGenerator::FunMap &SecondMap);
+        FunctionAbstractionsGenerator::Result &FirstResult,
+        FunctionAbstractionsGenerator::Result &SecondResult);
 
 #endif //DIFFKEMP_SIMPLL_FUNCTIONABSTRACTIONSGENERATOR_H

--- a/diffkemp/simpll/passes/StructureSizeAnalysis.cpp
+++ b/diffkemp/simpll/passes/StructureSizeAnalysis.cpp
@@ -1,0 +1,42 @@
+//===----- StructureSizeAnalysis.cpp - analysis of struct type sizes ------===//
+//
+//       SimpLL - Program simplifier for analysis of semantic difference      //
+//
+// This file is published under Apache 2.0 license. See LICENSE for details.
+// Author: Tomas Glozar, tglozar@gmail.com
+//===----------------------------------------------------------------------===//
+///
+/// \file
+/// This file contains the definition of the StructureSizeAnalysis pass.
+///
+//===----------------------------------------------------------------------===//
+
+#include "StructureSizeAnalysis.h"
+#include "llvm/IR/TypeFinder.h"
+
+AnalysisKey StructureSizeAnalysis::Key;
+
+StructureSizeAnalysis::Result StructureSizeAnalysis::run(Module &Mod,
+        AnalysisManager<Module, Function *> &mam, Function *Main) {
+    TypeFinder Types;
+    Result Res;
+    Types.run(Mod, true);
+
+    for (auto *Ty : Types) {
+        if (StructType *STy = dyn_cast<StructType>(Ty)) {
+            if (!STy->isSized())
+                continue;
+            uint64_t STySize = Mod.getDataLayout().getTypeAllocSize(STy);
+            auto Elem = Res.find(STySize);
+            if (Elem != Res.end()) {
+                Elem->second.insert(STy->getStructName());
+            } else {
+                std::set<std::string> Set;
+                Set.insert(STy->getStructName());
+                Res[STySize] = Set;
+            }
+        }
+    }
+
+    return Res;
+}

--- a/diffkemp/simpll/passes/StructureSizeAnalysis.h
+++ b/diffkemp/simpll/passes/StructureSizeAnalysis.h
@@ -1,0 +1,39 @@
+//===------ StructureSizeAnalysis.h - analysis of struct type sizes -------===//
+//
+//       SimpLL - Program simplifier for analysis of semantic difference      //
+//
+// This file is published under Apache 2.0 license. See LICENSE for details.
+// Author: Tomas Glozar, tglozar@gmail.com
+//===----------------------------------------------------------------------===//
+///
+/// \file
+/// This file contains the declaration of the StructureSizeAnalysis pass.
+///
+//===----------------------------------------------------------------------===//
+
+#ifndef DIFFKEMP_SIMPLL_STRUCTURESIZEANALYSIS_H
+#define DIFFKEMP_SIMPLL_STRUCTURESIZEANALYSIS_H
+
+#include <llvm/IR/PassManager.h>
+#include <set>
+#include <map>
+
+using namespace llvm;
+
+class StructureSizeAnalysis
+        : public AnalysisInfoMixin<StructureSizeAnalysis> {
+  public:
+    using Result = std::map<int, std::set<std::string>>;
+
+    /// Collects all structure type sizes and creates a map from the size
+    /// numbers to a set of structure names.
+    Result run(Module &Mod,
+               AnalysisManager<Module, Function *> &mam,
+               Function *Main);
+
+  private:
+    friend AnalysisInfoMixin<StructureSizeAnalysis>;
+    static AnalysisKey Key;
+};
+
+#endif //DIFFKEMP_SIMPLL_STRUCTURESIZEANALYSIS_H


### PR DESCRIPTION
Implements code that can extract arguments that correspond to call instructions operands from C source code for both regular function calls and inline assembly calls.
This is used to avoid differences in C builtin macros like `__LINE__` and `__COUNTER__` being compared as non-equal.
Also implements an analysis of structure type sizes, allowing the comparator to guess whether a change in a call function operand corresponds to a change in structure type size, in which case the values should be treated as equal (the aforementioned C source code utils are used to see whether the exact operand was generated by a `sizeof` or not).
This PR also fixes some bugs preventing the analysis from working correctly.