### PR TITLE
Better syntactic diffs and function abstractions naming

### DIFF
--- a/diffkemp/diffkemp.py
+++ b/diffkemp/diffkemp.py
@@ -58,9 +58,6 @@ def __make_argument_parser():
     compare_ap.add_argument("--control-flow-only",
                             help=SUPPRESS,
                             action="store_true")
-    compare_ap.add_argument("--show-empty-diff",
-                            help=SUPPRESS,
-                            action="store_true")
     compare_ap.add_argument("--semdiff-tool",
                             help=SUPPRESS,
                             choices=["llreve"])
@@ -168,7 +165,7 @@ def compare(args):
                 print_syntax_diff(args.snapshot_dir_old,
                                   args.snapshot_dir_new,
                                   fun, fun_result, False,
-                                  args.show_diff, args.show_empty_diff)
+                                  args.show_diff)
 
         # Clean LLVM modules (allow GC to collect the occupied memory)
         old_mod.clean_module()
@@ -189,7 +186,7 @@ def logs_dirname(src_version, dest_version):
 
 
 def print_syntax_diff(snapshot_old, snapshot_new, fun, fun_result, log_files,
-                      show_diff, print_empty_diffs=False):
+                      show_diff):
     """
     Log syntax diff of 2 functions. If log_files is set, the output is printed
     into a separate file, otherwise it goes to stdout.
@@ -216,7 +213,7 @@ def print_syntax_diff(snapshot_old, snapshot_new, fun, fun_result, log_files,
             print("{}:".format(fun))
 
         for called_res in fun_result.inner.values():
-            if called_res.diff == "" and not print_empty_diffs:
+            if called_res.diff == "" and called_res.first.covered_by_syn_diff:
                 # Do not print empty diffs
                 continue
 

--- a/diffkemp/diffkemp.py
+++ b/diffkemp/diffkemp.py
@@ -61,6 +61,10 @@ def __make_argument_parser():
     compare_ap.add_argument("--semdiff-tool",
                             help=SUPPRESS,
                             choices=["llreve"])
+    compare_ap.add_argument("--show-errors",
+                            help="show functions that are either unknown or \
+                            ended with an error in statistics",
+                            action="store_true")
     compare_ap.set_defaults(func=compare)
     return ap
 
@@ -176,7 +180,7 @@ def compare(args):
         print("")
         print("Statistics")
         print("----------")
-        result.report_stat()
+        result.report_stat(args.show_errors)
     return 0
 
 

--- a/diffkemp/semdiff/function_diff.py
+++ b/diffkemp/semdiff/function_diff.py
@@ -141,7 +141,7 @@ def functions_diff(mod_first, mod_second,
     :param glob_var: Global variable whose effect on the functions to compare
     :param config: Configuration
     """
-    result = Result(Result.Kind.NONE, mod_first, mod_second)
+    result = Result(Result.Kind.NONE, fun_first, fun_second)
     try:
         if config.verbosity:
             if fun_first == fun_second:

--- a/diffkemp/semdiff/function_diff.py
+++ b/diffkemp/semdiff/function_diff.py
@@ -191,7 +191,7 @@ def functions_diff(mod_first, mod_second,
         mod_first.restore_unlinked_llvm()
         mod_second.restore_unlinked_llvm()
 
-        if not funs_to_compare:
+        if not objects_to_compare:
             result.kind = Result.Kind.EQUAL_SYNTAX
         else:
             # If the functions are not syntactically equal, objects_to_compare

--- a/diffkemp/semdiff/result.py
+++ b/diffkemp/semdiff/result.py
@@ -33,12 +33,13 @@ class Result:
         If it is a function, it contains the file of the function.
         """
         def __init__(self, name, filename=None, line=None, callstack=None,
-                     is_macro=False):
+                     is_macro=False, covered_by_syn_diff=False):
             self.name = name
             self.filename = filename
             self.line = line
             self.callstack = callstack
             self.is_macro = is_macro
+            self.covered_by_syn_diff = covered_by_syn_diff
 
     def __init__(self, kind, first_name, second_name):
         self.kind = kind

--- a/diffkemp/semdiff/result.py
+++ b/diffkemp/semdiff/result.py
@@ -62,7 +62,7 @@ class Result:
         # a higher priority is chosen from the two).
         self.kind = Result.Kind(max(int(self.kind), int(result.kind)))
 
-    def report_stat(self):
+    def report_stat(self, show_errors=False):
         """
         Report statistics.
         Print numbers of equal, non-equal, unknown, and error results with
@@ -80,26 +80,32 @@ class Result:
                      if r.kind == Result.Kind.UNKNOWN])
         errs = len([r for r in iter(self.inner.values())
                     if r.kind in [Result.Kind.ERROR, Result.Kind.TIMEOUT]])
+        empty_diff = len([r for r in iter(self.inner.values()) if all(map(
+            lambda x: x.diff == "", r.inner.values())) and
+            r.kind == Result.Kind.NOT_EQUAL])
         if total > 0:
             print("Total params: {}".format(total))
             print("Equal:        {0} ({1:.0f}%)".format(eq, eq / total * 100))
             print(" same syntax: {0}".format(eq_syn))
             print("Not equal:    {0} ({1:.0f}%)".format(
                   neq, neq / total * 100))
+            print("(empty diff): {0} ({1:.0f}%)".format(
+                  empty_diff, empty_diff / total * 100))
             print("Unknown:      {0} ({1:.0f}%)".format(unkwn,
                                                         unkwn / total * 100))
             print("Errors:       {0} ({1:.0f}%)".format(errs,
                                                         errs / total * 100))
 
-        if unkwn > 0:
-            print("\nFunctions that are unknown: ")
-            for f, r in iter(self.inner.items()):
-                if r.kind == Result.Kind.UNKNOWN:
-                    print(f)
-            print()
-        if errs > 0:
-            print("\nFunctions whose comparison ended with an error: ")
-            for f, r in iter(self.inner.items()):
-                if r.kind == Result.Kind.ERROR:
-                    print(f)
-            print()
+        if show_errors:
+            if unkwn > 0:
+                print("\nFunctions that are unknown: ")
+                for f, r in iter(self.inner.items()):
+                    if r.kind == Result.Kind.UNKNOWN:
+                        print(f)
+                print()
+            if errs > 0:
+                print("\nFunctions whose comparison ended with an error: ")
+                for f, r in iter(self.inner.items()):
+                    if r.kind == Result.Kind.ERROR:
+                        print(f)
+                print()

--- a/diffkemp/semdiff/result.py
+++ b/diffkemp/semdiff/result.py
@@ -33,12 +33,12 @@ class Result:
         If it is a function, it contains the file of the function.
         """
         def __init__(self, name, filename=None, line=None, callstack=None,
-                     is_macro=False, covered_by_syn_diff=False):
+                     is_syn_diff=False, covered_by_syn_diff=False):
             self.name = name
             self.filename = filename
             self.line = line
             self.callstack = callstack
-            self.is_macro = is_macro
+            self.is_syn_diff = is_syn_diff
             self.covered_by_syn_diff = covered_by_syn_diff
 
     def __init__(self, kind, first_name, second_name):

--- a/diffkemp/semdiff/result.py
+++ b/diffkemp/semdiff/result.py
@@ -90,3 +90,16 @@ class Result:
                                                         unkwn / total * 100))
             print("Errors:       {0} ({1:.0f}%)".format(errs,
                                                         errs / total * 100))
+
+        if unkwn > 0:
+            print("\nFunctions that are unknown: ")
+            for f, r in iter(self.inner.items()):
+                if r.kind == Result.Kind.UNKNOWN:
+                    print(f)
+            print()
+        if errs > 0:
+            print("\nFunctions whose comparison ended with an error: ")
+            for f, r in iter(self.inner.items()):
+                if r.kind == Result.Kind.ERROR:
+                    print(f)
+            print()

--- a/diffkemp/simpll/DifferentialFunctionComparator.cpp
+++ b/diffkemp/simpll/DifferentialFunctionComparator.cpp
@@ -227,9 +227,6 @@ int DifferentialFunctionComparator::cmpOperations(
                     std::string NameR = getCalledFunction(
                             dyn_cast<CallInst>(R)->getCalledValue())->getName();
 
-                    DEBUG_WITH_TYPE(DEBUG_SIMPLL, dbgs() << "LineL: " << LineL
-                            << "\nLineR: " << LineR << "\n");
-
                     // Note: the line has to actually have been found for the
                     // comparison to make sense.
                     if ((LineL != "") && (LineR != "") && (LineL == LineR) &&
@@ -242,12 +239,17 @@ int DifferentialFunctionComparator::cmpOperations(
                              MacrosR.find(NameL) != MacrosR.end())) {
                             trueName = NameL;
                             NameR = NameL + " (macro)";
+                            ModComparator->tryInline =
+                                {dyn_cast<CallInst>(L), nullptr};
                         } else {
                             trueName = NameR;
                             NameL = NameR + " (macro)";
+                            ModComparator->tryInline =
+                                {nullptr, dyn_cast<CallInst>(R)};
                         }
+
                         DEBUG_WITH_TYPE(DEBUG_SIMPLL, dbgs() <<
-                                "Writing syntactic difference\n");
+                            "Writing function-macro syntactic difference\n");
 
                         SyntaxDifference diff;
                         diff.function = L->getFunction()->getName();

--- a/diffkemp/simpll/ModuleComparator.cpp
+++ b/diffkemp/simpll/ModuleComparator.cpp
@@ -1,4 +1,4 @@
-//===----------- ModuleComparator.cpp - Numbering global symbols ----------===//
+//===------------ ModuleComparator.cpp - Comparing LLVM modules -----------===//
 //
 //       SimpLL - Program simplifier for analysis of semantic difference      //
 //

--- a/diffkemp/simpll/ModuleComparator.h
+++ b/diffkemp/simpll/ModuleComparator.h
@@ -1,4 +1,4 @@
-//===------------ ModuleComparator.h - Numbering global symbols -----------===//
+//===------------- ModuleComparator.h - Comparing LLVM modules ------------===//
 //
 //       SimpLL - Program simplifier for analysis of semantic difference      //
 //

--- a/diffkemp/simpll/Output.cpp
+++ b/diffkemp/simpll/Output.cpp
@@ -146,12 +146,19 @@ struct MappingTraits<ResultReport> {
 void reportOutput(Config &config,
                   std::vector<FunPair> &nonequalFuns,
                   std::vector<ConstFunPair> &missingDefs,
-                  std::vector<SyntaxDifference> &differingMacros) {
+                  std::vector<SyntaxDifference> &differingSynDiffs) {
     ResultReport report;
     // Set to store functions covered by syntax differences
     std::set<std::string> syntaxDiffCoveredFunctions;
 
-    for (auto &synDiff : differingMacros) {
+    // Transform non-equal functions into a function name set
+    std::set<StringRef> differingFunsSet;
+    for (FunPair FP : nonequalFuns) {
+        differingFunsSet.insert(FP.first->getName());
+        differingFunsSet.insert(FP.second->getName());
+    }
+
+    for (auto &synDiff : differingSynDiffs) {
         // Look whether the function the syntactic difference was found in is
         // among functions declared as non-equal.
         // In case it is not, then the syntax difference should not be shown,
@@ -163,12 +170,6 @@ void reportOutput(Config &config,
             // case macro differences are irrelevant
             auto ModuleL = nonequalFuns[0].first->getParent();
             auto ModuleR = nonequalFuns[0].second->getParent();
-
-            std::set<StringRef> differingFunsSet;
-            for (FunPair FP : nonequalFuns) {
-                differingFunsSet.insert(FP.first->getName());
-                differingFunsSet.insert(FP.second->getName());
-            }
 
             // Function has to exist in both modules to prevent mistakes.
             if ((ModuleL->getFunction(synDiff.function) == nullptr) ||

--- a/diffkemp/simpll/SourceCodeUtils.cpp
+++ b/diffkemp/simpll/SourceCodeUtils.cpp
@@ -1,4 +1,4 @@
-//===--------- MacroUtils.cpp - Functions for working with macros ----------==//
+//===---- SourceCodeUtils.cpp - Functions for working with C source code ---==//
 //
 //       SimpLL - Program simplifier for analysis of semantic difference      //
 //
@@ -7,8 +7,8 @@
 //===----------------------------------------------------------------------===//
 ///
 /// \file
-/// This file contains implementation of functions working with macros and their
-/// differences.
+/// This file contains implementation of functions working with various things
+/// related to C source code analysis.
 ///
 //===----------------------------------------------------------------------===//
 

--- a/diffkemp/simpll/SourceCodeUtils.cpp
+++ b/diffkemp/simpll/SourceCodeUtils.cpp
@@ -143,7 +143,8 @@ std::string extractLineFromLocation(DILocation *LineLoc) {
         do {
             ++it;
             line += it->str();
-        } while (!it.is_at_end() && (it->count('(') < it->count(')')));
+        } while (!it.is_at_end() && (StringRef(line).count(')') <
+                StringRef(line).count('(')));
     }
 
     return line;

--- a/diffkemp/simpll/SourceCodeUtils.h
+++ b/diffkemp/simpll/SourceCodeUtils.h
@@ -1,4 +1,4 @@
-//===---------- MacroUtils.h - Functions for working with macros -----------==//
+//===---- SourceCodeUtils.h - Functions for working with C source code -----==//
 //
 //       SimpLL - Program simplifier for analysis of semantic difference      //
 //
@@ -7,8 +7,8 @@
 //===----------------------------------------------------------------------===//
 ///
 /// \file
-/// This file contains declarations of functions working with macros and their
-/// differences and structures used by them.
+/// This file contains declarations of functions working with various things
+/// related to C source code analysis.
 ///
 //===----------------------------------------------------------------------===//
 

--- a/diffkemp/simpll/passes/ReduceFunctionMetadataPass.cpp
+++ b/diffkemp/simpll/passes/ReduceFunctionMetadataPass.cpp
@@ -22,5 +22,9 @@ PreservedAnalyses ReduceFunctionMetadataPass::run(
     if (Fun.hasSection())
         Fun.setSection("");
 
+    // Distinguishing linkage type is pointless, because it would only cause
+    // function inlining, discarding the attribute.
+    Fun.setLinkage(GlobalValue::LinkageTypes::ExternalLinkage);
+
     return PreservedAnalyses();
 }

--- a/diffkemp/simpll/simpll.py
+++ b/diffkemp/simpll/simpll.py
@@ -66,7 +66,7 @@ def simplify_modules_diff(first, second, fun_first, fun_second, var,
 
         objects_to_compare = []
         missing_defs = None
-        macro_defs = None
+        syndiff_defs = None
         try:
             simpll_result = yaml.safe_load(simpll_out)
             if simpll_result is not None:
@@ -83,7 +83,7 @@ def simplify_modules_diff(first, second, fun_first, fun_second, var,
                                                           call["line"])
                                      for call in fun["callstack"]])
                                 if "callstack" in fun else "",
-                                fun["is-macro"],
+                                fun["is-syn-diff"],
                                 fun["covered-by-syn-diff"]
                             )
                             for fun in [fun_pair_yaml["first"],
@@ -93,12 +93,12 @@ def simplify_modules_diff(first, second, fun_first, fun_second, var,
                         objects_to_compare.append(tuple(fun_pair))
                 missing_defs = simpll_result["missing-defs"] \
                     if "missing-defs" in simpll_result else None
-                macro_defs = simpll_result["macro-defs"] \
-                    if "macro-defs" in simpll_result else None
+                syndiff_defs = simpll_result["syndiff-defs"] \
+                    if "syndiff-defs" in simpll_result else None
         except yaml.YAMLError:
             pass
 
         return first_out, second_out, objects_to_compare, missing_defs, \
-            macro_defs
+            syndiff_defs
     except CalledProcessError:
         raise SimpLLException("Simplifying files failed")

--- a/diffkemp/simpll/simpll.py
+++ b/diffkemp/simpll/simpll.py
@@ -83,7 +83,8 @@ def simplify_modules_diff(first, second, fun_first, fun_second, var,
                                                           call["line"])
                                      for call in fun["callstack"]])
                                 if "callstack" in fun else "",
-                                fun["is-macro"]
+                                fun["is-macro"],
+                                fun["covered-by-syn-diff"]
                             )
                             for fun in [fun_pair_yaml["first"],
                                         fun_pair_yaml["second"]]


### PR DESCRIPTION
1. Do not include syntax diff when the parent function is compared as equal (for example when there is a macro found, but the functions calls are inlined and the result is compared as equal).
2. Include an attribute in the output YAML that says whether this function difference is covered by a syntax difference (in other words if there exists a syntax difference with this function as its parent). When an empty diff with this attribute set is encountered in diffkabi, it is excluded from the output. (diffkabi itself cannot distinguish them, because the parent function is not included in the YAML; moreover I think this should be done in SimpLL).
3. Add an option to show a list of functions that are unknown or ended with an error (these are not shown in the diff list, therefore it is useful to have an option to display their names somewhere).
4. Use the hashing function in LLVM to convert hash strings of function abstractions to numbers, which are used for numbering the generated functions (this prevents inline asm being compared as equal by coincidence when the same numbers are assigned to different inline asms).
5. Fix #58 and some minor bugs.