### PR TITLE
SimpLL: Fixed syntax diff call stack appending.

### DIFF
--- a/diffkemp/simpll/Output.cpp
+++ b/diffkemp/simpll/Output.cpp
@@ -189,13 +189,18 @@ void reportOutput(Config &config,
 
         // Try to append call stack of function to the syndiff stack if possible
         CallStack toAppendLeft, toAppendRight;
-        for (auto &diff : report.diffFuns) {
-            if (diff.first.name == synDiff.function &&
-                diff.first.callstack.size() > 0)
-                toAppendLeft = diff.first.callstack;
-            if (diff.second.name == synDiff.function &&
-                diff.second.callstack.size() > 0)
-                toAppendRight = diff.second.callstack;
+        for (auto &diff : nonequalFuns) {
+            // Find the right function diff
+            if (diff.first->getName() == synDiff.function) {
+                CallStack CS = getCallStack(*config.FirstFun, *diff.first);
+                if (!CS.empty())
+                    toAppendLeft = CS;
+            }
+            if (diff.second->getName() == synDiff.function) {
+                CallStack CS = getCallStack(*config.SecondFun, *diff.second);
+                if (!CS.empty())
+                    toAppendRight = CS;
+            }
         }
         if (toAppendLeft.size() > 0)
             synDiff.StackL.insert(synDiff.StackL.begin(),


### PR DESCRIPTION
The problem was caused by the change of the order of operations in
reportOutput, leading to the variable report.diffFuns not containing all
function differences (and their call stacks) at the point of syntax
difference generation (this order is necessary for the
coveredBySyntaxDiff mechanism to work properly)-