### PR TITLE
SimpLL: Fixed function-macro difference reporting.

### DIFF
--- a/diffkemp/simpll/DifferentialFunctionComparator.h
+++ b/diffkemp/simpll/DifferentialFunctionComparator.h
@@ -95,6 +95,10 @@ class DifferentialFunctionComparator : public FunctionComparator {
     std::vector<SyntaxDifference> findAsmDifference(const Value *L,
             const Value *R, const Function *ParentL, const Function *ParentR)
             const;
+    /// Detects a change from a function to a macro between two instructions.
+    /// This is necessary because such a change isn't visible in C source.
+    void findMacroFunctionDifference(const Instruction *L,
+            const Instruction *R) const;
 };
 
 #endif //DIFFKEMP_SIMPLL_DIFFERENTIALFUNCTIONCOMPARATOR_H


### PR DESCRIPTION
There were two problems - the first was the skipping of the whole block
of code including both function inlining and function-macro difference
reporting when one of the calls was a SimpLL abstraction (this should
apply only to the inlining), the second was the missing implementation
of the reporting when one of the instruction wasn't a call instruction.

(Both problems caused false empty diffs in some functions.)