### PR TITLE
Add inline assembly arguments to syntax diff.

### DIFF
--- a/diffkemp/simpll/DebugInfo.cpp
+++ b/diffkemp/simpll/DebugInfo.cpp
@@ -154,19 +154,22 @@ void DebugInfo::extractAlignmentFromInstructions(GetElementPtrInst *GEP,
                 int indexSecond = getTypeMemberIndex(*TypeDISecond,
                                                      elementName);
 
-                // If indices do not match, align the first one to
-                // be the same as the second one
-                if (indexSecond > 0 && indexFirst != indexSecond) {
-                    indexMap.at(indexFirst) =
-                            (unsigned) indexSecond;
-                    setNewAlignmentOfIndex(
-                            *GEP, indices.size(),
-                            (unsigned) indexSecond,
-                            IndexConstant->getBitWidth(),
-                            ModFirst.getContext());
+                if (indexSecond > 0) {
+                    if (indexFirst != indexSecond) {
+                        // If indices do not match, align the first one to
+                        // be the same as the second one
+                        indexMap.at(indexFirst) =
+                                (unsigned) indexSecond;
+                        setNewAlignmentOfIndex(
+                                *GEP, indices.size(),
+                                (unsigned) indexSecond,
+                                IndexConstant->getBitWidth(),
+                                ModFirst.getContext());
+                    }
 
                     DEBUG_WITH_TYPE(DEBUG_SIMPLL, GEP->print(dbgs()));
 
+                    // Insert the names of the indices into StructFieldNames.
                     StructFieldNames.insert(
                         {{dyn_cast<StructType>(indexedType),
                             indexFirst}, elementName});

--- a/diffkemp/simpll/DifferentialFunctionComparator.cpp
+++ b/diffkemp/simpll/DifferentialFunctionComparator.cpp
@@ -532,8 +532,6 @@ int DifferentialFunctionComparator::cmpBasicBlocks(const BasicBlock *BBL,
 }
 
 /// Looks for inline assembly differences between the call instructions.
-/// Note: passing the parent function is necessary in order to properly generate
-/// the SyntaxDifference object.
 std::vector<SyntaxDifference> DifferentialFunctionComparator::findAsmDifference(
         const CallInst *IL, const CallInst *IR) const {
     auto FunL = getCalledFunction(IL->getCalledValue());
@@ -556,9 +554,18 @@ std::vector<SyntaxDifference> DifferentialFunctionComparator::findAsmDifference(
         // The difference is somewhere else
         return {};
 
+    // Iterate over inline asm operands and generate a C-like identifier for
+    // every one of them.
+    // Note: because this function's main purpose is to show inline assembly
+    // differences in cases when the original macro containing them cannot be
+    // found by SourceCodeUtils, the original arguments in the C source code
+    // also cannot be localed, therefore the C-like identifier is used instead.
     std::string argumentNamesL, argumentNamesR;
     for (auto T : {std::make_tuple(IL, &argumentNamesL),
                    std::make_tuple(IR, &argumentNamesR)}) {
+        // The identifier generation is done separately for the left and right
+        // call instruction; vector of tuples and pointers are used in order to
+        // re-use the code for both.
         const CallInst *I = std::get<0>(T);
         std::string *argumentNames = std::get<1>(T);
 

--- a/diffkemp/simpll/DifferentialFunctionComparator.h
+++ b/diffkemp/simpll/DifferentialFunctionComparator.h
@@ -92,9 +92,9 @@ class DifferentialFunctionComparator : public FunctionComparator {
     /// Looks for inline assembly differences between the certain values.
     /// Note: passing the parent function is necessary in order to properly
     /// generate the SyntaxDifference object.
-    std::vector<SyntaxDifference> findAsmDifference(const Value *L,
-            const Value *R, const Function *ParentL, const Function *ParentR)
-            const;
+    std::vector<SyntaxDifference> findAsmDifference(const CallInst *IL,
+            const CallInst *IR) const;
+
     /// Detects a change from a function to a macro between two instructions.
     /// This is necessary because such a change isn't visible in C source.
     void findMacroFunctionDifference(const Instruction *L,

--- a/diffkemp/simpll/ModuleComparator.h
+++ b/diffkemp/simpll/ModuleComparator.h
@@ -43,6 +43,8 @@ class ModuleComparator {
     // Structure size to structure name map.
     StructureSizeAnalysis::Result &StructSizeMapL;
     StructureSizeAnalysis::Result &StructSizeMapR;
+    // Counter of assembly diffs
+    int asmDifferenceCounter = 0;
 
     std::vector<ConstFunPair> MissingDefs;
 

--- a/diffkemp/simpll/Utils.cpp
+++ b/diffkemp/simpll/Utils.cpp
@@ -314,7 +314,10 @@ void findAndReplace(std::string &input, std::string find,
     }
 }
 
-/// Convert constant expression to instruction. (Copied from LLVM and modified)
+/// Convert constant expression to instruction. (Copied from LLVM and modified
+/// to work outside the ConstantExpr class; otherwise the function is the same,
+/// the only purpose of copying the function is making it work on constant
+/// input.)
 /// Note: this is for constant ConstantExpr pointers; for non-constant ones,
 /// the built-in getAsInstruction method is sufficient.
 const Instruction *getConstExprAsInstruction(const ConstantExpr *CEx) {

--- a/diffkemp/simpll/Utils.h
+++ b/diffkemp/simpll/Utils.h
@@ -110,6 +110,9 @@ void findAndReplace(std::string &input, std::string find,
 /// the built-in getAsInstruction method is sufficient.
 const Instruction *getConstExprAsInstruction(const ConstantExpr *CEx);
 
+/// Generates human-readable C-like identifier for type.
+std::string getIdentifierForType(Type *Ty);
+
 /// Finds the name of a value (in case there exists one).
 std::string getIdentifierForValue(const Value *Val,
         const std::map<std::pair<StructType *, uint64_t>, StringRef>

--- a/diffkemp/simpll/Utils.h
+++ b/diffkemp/simpll/Utils.h
@@ -14,6 +14,7 @@
 #ifndef DIFFKEMP_SIMPLL_UTILS_H
 #define DIFFKEMP_SIMPLL_UTILS_H
 
+#include <llvm/IR/Constants.h>
 #include <llvm/IR/DebugInfoMetadata.h>
 #include <llvm/IR/Function.h>
 #include <unordered_map>
@@ -103,5 +104,15 @@ bool isValidCharForIdentifierStart(char ch);
 /// given in the third argument.
 void findAndReplace(std::string &input, std::string find,
         std::string replace);
+
+/// Convert constant expression to instruction. (Copied from LLVM and modified)
+/// Note: this is for constant ConstantExpr pointers; for non-constant ones,
+/// the built-in getAsInstruction method is sufficient.
+const Instruction *getConstExprAsInstruction(const ConstantExpr *CEx);
+
+/// Finds the name of a value (in case there exists one).
+std::string getIdentifierForValue(const Value *Val,
+        const std::map<std::pair<StructType *, uint64_t>, StringRef>
+        &StructFieldNames, const Function *Parent = nullptr);
 
 #endif //DIFFKEMP_SIMPLL_UTILS_H


### PR DESCRIPTION
This PR adds code that attempts to reconstruct the original arguments for inline assembly in a C-like syntax to be shown alongside the differing assembly code.

There are several cases where this produces slightly different code from the original source, since some of the information is lost when compiling from C to LLVM IR; however it is sufficient to enable the user to identify the actual arguments in the C source code.

The function supports both local and global variables (including function arguments), load instructions, casts, extensions and has an incomplete support for GEPs.

The code uses DebugInfo to get GEP index names - because of this StructFieldNames generating was extended to include cases when indices are equal. (The cases that do not work, i.e. show the index number, are constant expressions - there is no debug information related to them).