### PR TITLE
SimpLL: Name anonymous union types according to their content.

### DIFF
--- a/diffkemp/simpll/Transforms.cpp
+++ b/diffkemp/simpll/Transforms.cpp
@@ -28,6 +28,7 @@
 #include "passes/SimplifyKernelGlobalsPass.h"
 #include "passes/StructureSizeAnalysis.h"
 #include "passes/UnifyMemcpyPass.h"
+#include "passes/UnionHashGeneratorPass.h"
 #include "passes/VarDependencySlicer.h"
 #include <llvm/IR/PassManager.h>
 #include <llvm/Passes/PassBuilder.h>
@@ -86,6 +87,7 @@ void preprocessModule(Module &Mod,
 
     mpm.addPass(SimplifyKernelGlobalsPass {});
     mpm.addPass(RemoveLifetimeCallsPass {});
+    mpm.addPass(UnionHashGeneratorPass {});
 
     mpm.run(Mod, mam);
 }

--- a/diffkemp/simpll/passes/UnionHashGeneratorPass.cpp
+++ b/diffkemp/simpll/passes/UnionHashGeneratorPass.cpp
@@ -1,0 +1,44 @@
+//===-- UnionHashGeneratorPass.h - Renaming union types based on content --===//
+//
+//       SimpLL - Program simplifier for analysis of semantic difference      //
+//
+// This file is published under Apache 2.0 license. See LICENSE for details.
+// Author: Tomas Glozar, tglozar@gmail.com
+//===----------------------------------------------------------------------===//
+///
+/// \file
+/// This file contains the declaration of the UnionHashGeneratorPass pass.
+///
+//===----------------------------------------------------------------------===//
+
+#include "UnionHashGeneratorPass.h"
+#include <llvm/ADT/Hashing.h>
+#include <llvm/IR/TypeFinder.h>
+#include <llvm/Support/raw_ostream.h>
+
+PreservedAnalyses UnionHashGeneratorPass::run (
+        Module &Mod,
+        llvm::AnalysisManager<llvm::Module> &Main) {
+    TypeFinder Types;
+    Types.run(Mod, true);
+
+    for (auto *Ty : Types) {
+        if (auto STy = dyn_cast<StructType>(Ty)) {
+            if (!STy->getStructName().startswith("union.anon"))
+                continue;
+            std::string TypeName = STy->getStructName().str();
+            std::string TypeDump; llvm::raw_string_ostream DumpStrm(TypeDump);
+            DumpStrm << *STy; TypeDump = DumpStrm.str();
+
+            // Extract the type declaration without type name
+            std::string TypeDecl = TypeDump.substr(TypeDump.find("{"));
+            std::string NewTypeName = "union.anon." +
+                    std::to_string(hash_value(TypeDecl));
+
+            // Rename the type
+            STy->setName(NewTypeName);
+        }
+    }
+
+    return PreservedAnalyses();
+}

--- a/diffkemp/simpll/passes/UnionHashGeneratorPass.h
+++ b/diffkemp/simpll/passes/UnionHashGeneratorPass.h
@@ -1,0 +1,31 @@
+//===- UnionHashGeneratorPass.cpp - Renaming union types based on content -===//
+//
+//       SimpLL - Program simplifier for analysis of semantic difference      //
+//
+// This file is published under Apache 2.0 license. See LICENSE for details.
+// Author: Tomas Glozar, tglozar@gmail.com
+//===----------------------------------------------------------------------===//
+///
+/// \file
+/// This file contains the declaration of the UnionHashGeneratorPass pass.
+///
+//===----------------------------------------------------------------------===//
+
+#ifndef DIFFKEMP_SIMPLL_UNIONHASHGENERATORPASS_H
+#define DIFFKEMP_SIMPLL_UNIONHASHGENERATORPASS_H
+
+#include <llvm/IR/PassManager.h>
+
+using namespace llvm;
+
+/// This pass renames all anonymous union types to names with hashes
+/// corresponding to the union type definitions.
+class UnionHashGeneratorPass
+        : public PassInfoMixin<UnionHashGeneratorPass> {
+  public:
+    PreservedAnalyses run(
+            Module &Mod,
+            llvm::AnalysisManager<llvm::Module> &Main);
+};
+
+#endif //DIFFKEMP_SIMPLL_UNIONHASHGENERATORPASS_H


### PR DESCRIPTION
This PR adds a pass that converts anonymous union type suffixes to ones based on the hash of the dump of the type excluding its clang-generated name. This ensures that union types that are the same will have the same name even in cases when they are in different modules and were generated in a different order.

The consistent type naming is currently only needed for the FunctionAbstractionsGenerator hashes (besides better human readability of the LLVM IR); it may become redundant in the future in case a better implementation of the hash function is created.