### PR TITLE
function_syntax_diff: load source as UTF-8.

### DIFF
--- a/diffkemp/syndiff/function_syntax_diff.py
+++ b/diffkemp/syndiff/function_syntax_diff.py
@@ -20,7 +20,7 @@ def syntax_diff(first_file, second_file, fun, first_line, second_line):
     # functions into temporary files
     for filename in [first_file, second_file]:
         tmp_file = "1" if filename == first_file else "2"
-        with open(filename, "r") as input_file, \
+        with open(filename, "r", encoding='utf-8') as input_file, \
                 open(os.path.join(tmpdir, tmp_file), "w") as output_file:
             lines = input_file.readlines()
             start = first_line if filename == first_file else second_line


### PR DESCRIPTION
This is needed for some files in the kernel that contain names of
developers in comments that contain non-ASCII characters.