### PR TITLE
Support comparing sysctl options

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,25 @@ The command compares functions from function lists stored inside the snapshots
 pairwise and prints syntactic diffs (thanks to the `--syntax-diff` option) of
 functions that are semantically different.
 
+### Comparing sysctl options
+
+Apart from comparing specific functions, DiffKemp supports comparison of
+semantics of sysctl options. List of the options to compare can be passed as the
+`FUNCTION_LIST` in the `generate` command. In such case, use `--sysctl` switch
+to generate snapshot for sysctl parameter comparison. The `compare` command is
+used in normal way.
+
+Sysctl option comparison compares semantics of the proc handler function and
+semantics of all functions using the data variable that the sysctl option sets.
+
+It is possible to use patterns to specify a number of multiple sysctl options at
+once such as:
+* `kernel.*`
+* `kernel.{sysctl-1|sysctl-2}`
+
+Currently, these sysctl option groups are supported: `kernel.*`,
+`vm.*`, `fs.*`, `net.core.*`, `net.ipv4.conf.*`.
+
 ## About
 The tool uses static analysis methods to automatically determine how the effect
 of a chosen kernel function or option (module parameter, sysctl) changed between

--- a/diffkemp/function_list.py
+++ b/diffkemp/function_list.py
@@ -1,6 +1,8 @@
 """
 List of functions to be compared.
 Contains mapping from function names onto corresponding LLVM sources.
+Functions can be divided into groups. This is, e.g., used when comparing sysctl
+options.
 """
 from diffkemp.llvm_ir.kernel_module import LlvmKernelModule
 import os
@@ -8,25 +10,53 @@ import yaml
 
 
 class FunctionList:
-    def __init__(self, root_dir):
-        self.root_dir = root_dir
-        self.functions = dict()
+    class FunctionDesc:
+        """
+        Function description.
+        Contains LLVM module of the function definition, a global variable,
+        and a tag.
+        For sysctl option, glob_var is the data variable that the option sets.
+        """
+        def __init__(self, mod, glob_var, tag):
+            self.mod = mod
+            self.glob_var = glob_var
+            self.tag = tag
 
-    def add(self, name, llvm_mod):
+    class FunctionGroup:
+        """
+        Group of functions. Used to group functions belonging to a single
+        sysctl options.
+        """
+        def __init__(self):
+            self.functions = dict()
+
+    def __init__(self, root_dir, kind=None):
+        self.root_dir = root_dir
+        self.kind = kind
+        self.groups = dict()
+
+    def add(self, name, llvm_mod, glob_var=None, tag=None, group=None):
         """
         Add function to the list.
         :param name: Name of the function.
         :param llvm_mod: LLVM module with the function definition.
+        :param tag: Function tag.
+        :param group: Group to put the function to.
         """
-        self.functions[name] = llvm_mod
+        self.groups[group].functions[name] = self.FunctionDesc(llvm_mod,
+                                                               glob_var, tag)
 
     def modules(self):
-        """Get the set of all modules."""
-        return set(self.functions.values())
+        """Get the set of all LLVM modules of all functions in the list."""
+        return set([fun.mod for group in self.groups.values() for fun in
+                    group.functions.values()])
 
-    def get_by_name(self, name):
-        """Get module for the function with the given name."""
-        return self.functions[name] if name in self.functions else None
+    def get_by_name(self, name, group=None):
+        """
+        Get module for the function with the given name in the given group.
+        """
+        return self.groups[group].functions[name] \
+            if name in self.groups[group].functions else None
 
     def from_yaml(self, yaml_file):
         """
@@ -34,10 +64,23 @@ class FunctionList:
         root directory.
         :param yaml_file: Contents of the YAML file.
         """
-        funs = yaml.safe_load(yaml_file)
-        for f in funs:
-            self.add(f["name"],
-                     LlvmKernelModule(os.path.join(self.root_dir, f["llvm"])))
+        groups = yaml.safe_load(yaml_file)
+        for g in groups:
+            if "sysctl" in g:
+                self.kind = "sysctl"
+                group = g["sysctl"]
+                functions = g["functions"]
+            else:
+                group = None
+                functions = groups
+            self.groups[group] = self.FunctionGroup()
+            for f in functions:
+                self.add(f["name"],
+                         LlvmKernelModule(
+                             os.path.join(self.root_dir, f["llvm"])),
+                         f["glob_var"],
+                         f["tag"],
+                         group)
 
     def to_yaml(self):
         """
@@ -45,10 +88,43 @@ class FunctionList:
         the root directory.
         :return: YAML string.
         """
-        yaml_dict = [
-            {"name": name, "llvm": os.path.relpath(mod.llvm, self.root_dir)}
-            for name, mod in self.functions.items()]
+        if None in self.groups:
+            yaml_dict = [{
+                "name": name,
+                "llvm": os.path.relpath(desc.mod.llvm, self.root_dir),
+                "glob_var": desc.glob_var,
+                "tag": desc.tag
+            } for name, desc in self.groups[None].functions.items()]
+        else:
+            yaml_dict = [
+                {self.kind: group_name,
+                 "functions": [
+                     {"name": fun_name,
+                      "llvm": os.path.relpath(fun_desc.mod.llvm,
+                                              self.root_dir),
+                      "glob_var": fun_desc.glob_var,
+                      "tag": fun_desc.tag}
+                     for fun_name, fun_desc in g.functions.items()]
+                 } for group_name, g in self.groups.items()
+            ]
         return yaml.dump(yaml_dict)
 
-    def filter(self, functions):
-        self.functions = {f: self.functions[f] for f in functions}
+    def filter(self, functions, group=None):
+        """
+        Filter only chosen functions in the given group.
+        """
+        self.groups[group].functions = {f: self.groups[group].functions[f] for
+                                        f in functions}
+
+    def add_group(self, name):
+        """
+        Add new function group with the given name and global variable.
+        """
+        self.groups[name] = self.FunctionGroup()
+
+    def add_none_group(self):
+        """
+        Add new group with None name which is used when only a single group
+        is used.
+        """
+        self.groups[None] = self.FunctionGroup()

--- a/diffkemp/llvm_ir/kernel_module.py
+++ b/diffkemp/llvm_ir/kernel_module.py
@@ -262,6 +262,8 @@ class LlvmKernelModule:
         """
         self.parse_module()
         glob = self.llvm_module.get_named_global(param.name)
+        if not glob:
+            return set()
         result = set()
         for use in glob.iter_uses():
             if use.user.get_kind() == InstructionValueKind:

--- a/diffkemp/llvm_ir/kernel_source.py
+++ b/diffkemp/llvm_ir/kernel_source.py
@@ -315,10 +315,12 @@ class KernelSource:
                     src = "net/ipv4/sysctl_net_ipv4.c"
                     table = "ipv4_table"
                     entries = entries[2:]
-            if entries[1] == "core":
+            elif entries[1] == "core":
                 src = "net/core/sysctl_net_core.c"
                 table = "net_core_table"
                 entries = entries[2:]
+            else:
+                raise SourceNotFoundException(sysctl)
         else:
             raise SourceNotFoundException(sysctl)
 
@@ -332,7 +334,7 @@ class KernelSource:
                 return sysctl_mod
             table = sysctl_mod.get_child(entry).name
             src = self.find_srcs_with_symbol_def(table)[0]
-        return None
+        raise SourceNotFoundException(sysctl)
 
     def get_module_for_kernel_mod(self, mod_dir, mod_name):
         """

--- a/diffkemp/llvm_ir/llvm_sysctl_module.py
+++ b/diffkemp/llvm_ir/llvm_sysctl_module.py
@@ -65,7 +65,7 @@ class LlvmSysctlModule:
         # sysctl table is a global variable
         table = self.mod.llvm_module.get_named_global(ctl_table[0])
         if not table:
-            return None
+            return []
 
         # Get global variable initializer. If sysctl_name contains some indices
         # follow them to get the actual table.
@@ -73,7 +73,7 @@ class LlvmSysctlModule:
         for i in ctl_table[1:]:
             sysctl_list = sysctl_list.get_operand(int(i))
         if not sysctl_list:
-            return None
+            return []
 
         names = []
         # Iterate all entries in the table

--- a/tests/unit_tests/function_list_test.py
+++ b/tests/unit_tests/function_list_test.py
@@ -1,0 +1,233 @@
+"""Unit tests for the FunctionList class."""
+
+from diffkemp.function_list import FunctionList
+from diffkemp.llvm_ir.kernel_module import LlvmKernelModule
+import yaml
+
+
+def test_create_list_no_groups():
+    """
+    Create function list with a single "None" group.
+    Add a function into the list and check that it is there.
+    """
+    lst = FunctionList("snapshots/linux-3.10.0-957.el7")
+    assert lst.root_dir == "snapshots/linux-3.10.0-957.el7"
+    assert lst.kind is None
+
+    lst.add_none_group()
+    assert len(lst.groups) == 1
+    assert None in lst.groups
+
+    lst.add("___pskb_trim", LlvmKernelModule("net/core/skbuff.ll"))
+    assert "___pskb_trim" in lst.groups[None].functions
+    fun_desc = lst.groups[None].functions["___pskb_trim"]
+    assert fun_desc.mod.llvm == "net/core/skbuff.ll"
+    assert fun_desc.glob_var is None
+    assert fun_desc.tag is None
+
+
+def test_create_list_sysctl_group():
+    """
+    Create function list with a named group. Sysctl option is used as
+    group name since this is the normal use case.
+    Add function to the group and check that it is there.
+    :return:
+    """
+    lst = FunctionList("snapshots-sysctl/linux-3.10.0-957.el7", "sysctl")
+    assert lst.root_dir == "snapshots-sysctl/linux-3.10.0-957.el7"
+    assert lst.kind == "sysctl"
+
+    lst.add_group("kernel.sched_latency_ns")
+    assert len(lst.groups) == 1
+    assert "kernel.sched_latency_ns" in lst.groups
+
+    lst.add("sched_debug_header",
+            LlvmKernelModule("kernel/sched/debug.ll"),
+            "sysctl_sched_latency",
+            "using_data_variable \"sysctl_sched_latency\"",
+            "kernel.sched_latency_ns")
+    assert "sched_debug_header" in lst.groups[
+        "kernel.sched_latency_ns"].functions
+    fun_desc = lst.groups["kernel.sched_latency_ns"].functions[
+        "sched_debug_header"]
+    assert fun_desc.mod.llvm == "kernel/sched/debug.ll"
+    assert fun_desc.glob_var == "sysctl_sched_latency"
+    assert fun_desc.tag == "using_data_variable \"sysctl_sched_latency\""
+
+
+def test_get_modules():
+    """
+    Test getting all modules in the lists.
+    Check if the list returns a list of all modules of all groups in case that
+    multiple groups are present.
+    """
+    lst = FunctionList("snapshots-sysctl/linux-3.10.0-957.el7", "sysctl")
+    lst.add_group("kernel.sched_latency_ns")
+    lst.add_group("kernel.timer_migration")
+    lst.add("sched_proc_update_handler",
+            LlvmKernelModule("kernel/sched/fair.ll"), None, "proc_handler",
+            "kernel.sched_latency_ns")
+    lst.add("proc_dointvec_minmax", LlvmKernelModule("kernel/sysctl.ll"), None,
+            "proc_handler", "kernel.timer_migration")
+
+    modules = lst.modules()
+    assert len(modules) == 2
+    assert set([m.llvm for m in modules]) == {"kernel/sched/fair.ll",
+                                              "kernel/sysctl.ll"}
+
+
+def test_filter():
+    """Filtering functions."""
+    lst = FunctionList("snapshots/linux-3.10.0-957.el7")
+    lst.add_none_group()
+    lst.add("___pskb_trim", LlvmKernelModule("net/core/skbuff.ll"))
+    lst.add("__alloc_pages_nodemask", LlvmKernelModule("mm/page_alloc.ll"))
+
+    lst.filter(["__alloc_pages_nodemask"])
+    assert len(lst.groups[None].functions) == 1
+    assert "___pskb_trim" not in lst.groups[None].functions
+    assert "__alloc_pages_nodemask" in lst.groups[None].functions
+
+
+def test_to_yaml_functions():
+    """
+    Dump a list with a single "None" group into YAML.
+    YAML string should contain a simple list of functions, each one having
+    the "name" and the "llvm" field set.
+    The LLVM paths in the YAML should be relative to the function list root.
+    """
+    lst = FunctionList("snapshots/linux-3.10.0-957.el7")
+    lst.add_none_group()
+    lst.add("___pskb_trim", LlvmKernelModule(
+        "snapshots/linux-3.10.0-957.el7/net/core/skbuff.ll"))
+    lst.add("__alloc_pages_nodemask", LlvmKernelModule(
+        "snapshots/linux-3.10.0-957.el7/mm/page_alloc.ll"))
+
+    yaml_str = lst.to_yaml()
+    functions = yaml.safe_load(yaml_str)
+    assert len(functions) == 2
+    assert set([f["name"] for f in functions]) == {"___pskb_trim",
+                                                   "__alloc_pages_nodemask"}
+    for f in functions:
+        if f["name"] == "___pskb_trim":
+            assert f["llvm"] == "net/core/skbuff.ll"
+        elif f["name"] == "__alloc_pages_nodemask":
+            assert f["llvm"] == "mm/page_alloc.ll"
+
+
+def test_to_yaml_sysctls():
+    """
+    Dump a list with multiple sysctl groups into YAML.
+    YAML string should contain a list of groups, each group containing a list
+    of functions.
+    The LLVM paths in the YAML should be relative to the function list root.
+    """
+    lst = FunctionList("snapshots-sysctl/linux-3.10.0-957.el7", "sysctl")
+    lst.add_group("kernel.sched_latency_ns")
+    lst.add_group("kernel.timer_migration")
+    lst.add("sched_proc_update_handler",
+            LlvmKernelModule(
+                "snapshots-sysctl/linux-3.10.0-957.el7/kernel/sched/fair.ll"),
+            None, "proc handler", "kernel.sched_latency_ns")
+    lst.add("proc_dointvec_minmax",
+            LlvmKernelModule(
+                "snapshots-sysctl/linux-3.10.0-957.el7/kernel/sysctl.ll"),
+            None, "proc handler", "kernel.timer_migration")
+
+    yaml_str = lst.to_yaml()
+    groups = yaml.safe_load(yaml_str)
+    assert len(groups) == 2
+    assert set([g["sysctl"] for g in groups]) == {"kernel.sched_latency_ns",
+                                                  "kernel.timer_migration"}
+    for g in groups:
+        assert len(g["functions"]) == 1
+        if g["sysctl"] == "kernel.sched_latency_ns":
+            assert g["functions"][0] == {
+                "name": "sched_proc_update_handler",
+                "llvm": "kernel/sched/fair.ll",
+                "glob_var": None,
+                "tag": "proc handler"
+            }
+        elif g["sysctl"] == "kernel.timer_migration":
+            assert g["functions"][0] == {
+                "name": "proc_dointvec_minmax",
+                "llvm": "kernel/sysctl.ll",
+                "glob_var": None,
+                "tag": "proc handler"
+            }
+
+
+def test_from_yaml_functions():
+    """
+    Load function list from YAML. Use YAML that contains only a list of
+    functions. It is expected that the parsed list contains a single "None"
+    group which contains the list of loaded functions.
+    The loaded LLVM paths should contain the list root dir.
+    """
+    lst = FunctionList("snapshots/linux-3.10.0-957.el7")
+    lst.from_yaml("""
+    - glob_var: null
+      llvm: net/core/skbuff.ll
+      name: ___pskb_trim
+      tag: null
+    - glob_var: null
+      llvm: mm/page_alloc.ll
+      name: __alloc_pages_nodemask
+      tag: null
+    """)
+
+    assert len(lst.groups) == 1
+    assert None in lst.groups
+    assert len(lst.groups[None].functions) == 2
+    assert set(lst.groups[None].functions.keys()) == {"___pskb_trim",
+                                                      "__alloc_pages_nodemask"}
+    for name, f in lst.groups[None].functions.items():
+        assert f.glob_var is None
+        assert f.tag is None
+        if name == "___pskb_trim":
+            assert f.mod.llvm == \
+                   "snapshots/linux-3.10.0-957.el7/net/core/skbuff.ll"
+        elif name == "__alloc_pages_nodemas":
+            assert f.mod.llvm == \
+                   "snapshots/linux-3.10.0-957.el7/mm/page_alloc.ll"
+
+
+def test_from_yaml_sysctls():
+    """
+    Load function list from YAML. Use YAML that contains a list of sysctl
+    groups, each group containing a single function.
+    The loaded LLVM paths should contain the list root dir.
+    """
+    lst = FunctionList("snapshots-sysctl/linux-3.10.0-957.el7", "sysctl")
+    lst.from_yaml("""
+    - functions:
+        - glob_var: null
+          llvm: kernel/sched/fair.ll
+          name: sched_proc_update_handler
+          tag: proc handler
+      sysctl: kernel.sched_latency_ns
+    - functions:
+        - glob_var: null
+          llvm: kernel/sysctl.ll
+          name: proc_dointvec_minmax
+          tag: proc handler
+      sysctl: kernel.timer_migration
+    """)
+
+    assert len(lst.groups) == 2
+    assert set(lst.groups.keys()) == {"kernel.sched_latency_ns",
+                                      "kernel.timer_migration"}
+    for name, g in lst.groups.items():
+        assert len(g.functions) == 1
+        if name == "kernel.sched_latency_ns":
+            assert list(g.functions.keys()) == ["sched_proc_update_handler"]
+            f = g.functions["sched_proc_update_handler"]
+            assert f.mod.llvm == \
+                "snapshots-sysctl/linux-3.10.0-957.el7/kernel/sched/fair.ll"
+        elif name == "kernel.timer_migration":
+            assert list(g.functions.keys()) == ["proc_dointvec_minmax"]
+            f = g.functions["proc_dointvec_minmax"]
+            assert f.mod.llvm == \
+                "snapshots-sysctl/linux-3.10.0-957.el7/kernel/sysctl.ll"
+        assert f.tag == "proc handler"
+        assert f.glob_var is None


### PR DESCRIPTION
This mainly requires changing layout of the YAML file generated in the
snapshot:
 - functions can be split into groups (by sysctl option)
 - apart from LLVM file, each function has a global variable (in case it
   is a function using the sysctl data variable) and a tag that contains
   explanation why the function belongs to the given group
 - in case only a list of functions is compared, a single group with
   `None` key is created

Also, `generate` and `compare` functions are reworked to handle
functions split into groups.