### PR TITLE
Macro argument/parameter extraction

### DIFF
--- a/diffkemp/config.py
+++ b/diffkemp/config.py
@@ -8,7 +8,7 @@ class ConfigException(Exception):
 
 class Config:
     def __init__(self, source_first, source_second, show_diff,
-                 control_flow_only, verbosity, semdiff_tool):
+                 control_flow_only, print_asm_diffs, verbosity, semdiff_tool):
         """
         Store configuration of DiffKemp
         :param source_first: Sources for the first kernel (instance of
@@ -24,6 +24,7 @@ class Config:
         self.source_second = source_second
         self.show_diff = show_diff
         self.control_flow_only = control_flow_only
+        self.print_asm_diffs = print_asm_diffs
         self.verbosity = verbosity
 
         # Semantic diff tool configuration

--- a/diffkemp/diffkemp.py
+++ b/diffkemp/diffkemp.py
@@ -61,6 +61,10 @@ def __make_argument_parser():
     compare_ap.add_argument("--control-flow-only",
                             help=SUPPRESS,
                             action="store_true")
+    compare_ap.add_argument("--print-asm-diffs",
+                            help="print raw inline assembly differences (does \
+                            not apply to macros)",
+                            action="store_true")
     compare_ap.add_argument("--semdiff-tool",
                             help=SUPPRESS,
                             choices=["llreve"])
@@ -222,7 +226,7 @@ def compare(args):
         new_functions.filter([args.function])
 
     config = Config(old_source, new_source, args.show_diff,
-                    args.control_flow_only, args.verbose,
+                    args.control_flow_only, args.print_asm_diffs, args.verbose,
                     args.semdiff_tool)
     result = Result(Result.Kind.NONE, args.snapshot_dir_old,
                     args.snapshot_dir_old)

--- a/diffkemp/semdiff/function_diff.py
+++ b/diffkemp/semdiff/function_diff.py
@@ -162,6 +162,7 @@ def functions_diff(mod_first, mod_second,
                                       glob_var.name if glob_var else None,
                                       glob_var.name if glob_var else "simpl",
                                       config.control_flow_only,
+                                      config.print_asm_diffs,
                                       config.verbosity)
             funs_to_compare = list([o for o in objects_to_compare
                                     if not o[0].is_syn_diff])

--- a/diffkemp/simpll/Config.cpp
+++ b/diffkemp/simpll/Config.cpp
@@ -33,6 +33,9 @@ cl::opt<bool> PrintCallstacksOpt("print-callstacks", cl::desc(
         "Print call stacks for non-equal functions."));
 cl::opt<bool> VerboseOpt("verbose", cl::desc(
         "Show verbose output (debugging information)."));
+cl::opt<bool> PrintAsmDiffsOpt("print-asm-diffs", cl::desc(
+        "Print raw differences in inline assembly code "
+        "(does not apply to macros)."));
 
 /// Add suffix to the file name.
 /// \param File Original file name.
@@ -48,6 +51,7 @@ Config::Config() : First(parseIRFile(FirstFileOpt, err, context_first)),
                    Second(parseIRFile(SecondFileOpt, err, context_second)),
                    FirstOutFile(FirstFileOpt), SecondOutFile(SecondFileOpt),
                    ControlFlowOnly(ControlFlowOpt),
+                   PrintAsmDiffs(PrintAsmDiffsOpt),
                    PrintCallStacks(PrintCallstacksOpt) {
     if (!FunctionOpt.empty()) {
         // Parse --fun option - find functions with given names.

--- a/diffkemp/simpll/Config.h
+++ b/diffkemp/simpll/Config.h
@@ -60,6 +60,8 @@ class Config {
 
     // Keep only control-flow related instructions
     bool ControlFlowOnly;
+    // Print raw differences in inline assembly.
+    bool PrintAsmDiffs;
     // Show call stacks for non-equal functions
     bool PrintCallStacks;
 

--- a/diffkemp/simpll/DifferentialFunctionComparator.cpp
+++ b/diffkemp/simpll/DifferentialFunctionComparator.cpp
@@ -503,7 +503,8 @@ int DifferentialFunctionComparator::cmpBasicBlocks(const BasicBlock *BBL,
                             macroDiffs.begin(), macroDiffs.end());
 
                         // Try to find assembly functions causing the difference
-                        if (isa<CallInst>(&*InstL) && isa<CallInst>(&*InstR)) {
+                        if (isa<CallInst>(&*InstL) && isa<CallInst>(&*InstR) &&
+                                showAsmDiff) {
                             auto asmDiffs = findAsmDifference(
                                     dyn_cast<CallInst>(&*InstL),
                                     dyn_cast<CallInst>(&*InstR));

--- a/diffkemp/simpll/DifferentialFunctionComparator.h
+++ b/diffkemp/simpll/DifferentialFunctionComparator.h
@@ -32,11 +32,12 @@ class DifferentialFunctionComparator : public FunctionComparator {
     DifferentialFunctionComparator(const Function *F1,
                                    const Function *F2,
                                    bool controlFlowOnly,
+                                   bool showAsmDiff,
                                    GlobalNumberState *GN,
                                    const DebugInfo *DI,
                                    ModuleComparator *MC)
             : FunctionComparator(F1, F2, GN), DI(DI),
-              controlFlowOnly(controlFlowOnly),
+              controlFlowOnly(controlFlowOnly), showAsmDiff(showAsmDiff),
               LayoutL(F1->getParent()->getDataLayout()),
               LayoutR(F2->getParent()->getDataLayout()),
               ModComparator(MC) {}
@@ -83,7 +84,7 @@ class DifferentialFunctionComparator : public FunctionComparator {
 
   private:
     const DebugInfo *DI;
-    bool controlFlowOnly;
+    bool controlFlowOnly, showAsmDiff;
 
     const DataLayout &LayoutL, &LayoutR;
 

--- a/diffkemp/simpll/ModuleComparator.cpp
+++ b/diffkemp/simpll/ModuleComparator.cpp
@@ -59,7 +59,7 @@ void ModuleComparator::compareFunctions(Function *FirstFun,
 
     // Comparing functions with bodies using custom FunctionComparator.
     DifferentialFunctionComparator fComp(FirstFun, SecondFun, controlFlowOnly,
-                                         &GS, DI, this);
+                                         showAsmDiffs, &GS, DI, this);
     if (fComp.compare() == 0) {
         DEBUG_WITH_TYPE(DEBUG_SIMPLL,
                         dbgs() << "Function " << FirstFun->getName()
@@ -137,6 +137,7 @@ void ModuleComparator::compareFunctions(Function *FirstFun,
             // Re-run the comparison
             DifferentialFunctionComparator fCompSecond(FirstFun, SecondFun,
                                                        controlFlowOnly,
+                                                       showAsmDiffs,
                                                        &GS, DI, this);
             if (fCompSecond.compare() == 0) {
                 ComparedFuns.at({FirstFun, SecondFun}) = Result::EQUAL;

--- a/diffkemp/simpll/ModuleComparator.h
+++ b/diffkemp/simpll/ModuleComparator.h
@@ -28,7 +28,7 @@ using namespace llvm;
 class ModuleComparator {
     Module &First;
     Module &Second;
-    bool controlFlowOnly;
+    bool controlFlowOnly, showAsmDiffs;
 
   public:
     /// Possible results of syntactical function comparison.
@@ -52,14 +52,15 @@ class ModuleComparator {
     const DebugInfo *DI;
 
     ModuleComparator(Module &First, Module &Second, bool controlFlowOnly,
-                     const DebugInfo *DI, StringMap<StringRef> &AsmToStringMapL,
+                     bool showAsmDiffs, const DebugInfo *DI,
+                     StringMap<StringRef> &AsmToStringMapL,
                      StringMap<StringRef> &AsmToStringMapR,
                      StructureSizeAnalysis::Result &StructSizeMapL,
                      StructureSizeAnalysis::Result &StructSizeMapR)
             : First(First), Second(Second), controlFlowOnly(controlFlowOnly),
-            GS(&First, &Second, this), DI(DI), AsmToStringMapL(AsmToStringMapL),
-            AsmToStringMapR(AsmToStringMapR), StructSizeMapL(StructSizeMapL),
-            StructSizeMapR(StructSizeMapR) {}
+            showAsmDiffs(showAsmDiffs), GS(&First, &Second, this), DI(DI),
+            AsmToStringMapL(AsmToStringMapL), AsmToStringMapR(AsmToStringMapR),
+            StructSizeMapL(StructSizeMapL), StructSizeMapR(StructSizeMapR) {}
 
     /// Syntactically compare two functions.
     /// The result of the comparison is stored into the ComparedFuns map.

--- a/diffkemp/simpll/SourceCodeUtils.h
+++ b/diffkemp/simpll/SourceCodeUtils.h
@@ -68,12 +68,12 @@ void expandCompositeMacroNames(std::vector<std::pair<std::string, std::string>>
         args, std::string &body);
 
 /// Extract the line corresponding to the DILocation from the C source file.
-std::string extractLineFromLocation(DILocation *LineLoc);
+std::string extractLineFromLocation(DILocation *LineLoc, int offset = 0);
 
 /// Gets all macros used on a certain DILocation in the form of a key to value
 /// map.
 std::unordered_map<std::string, MacroElement> getAllMacrosAtLocation(
-    DILocation *LineLoc, const Module *Mod);
+    DILocation *LineLoc, const Module *Mod, int lineOffset = 0);
 
 /// Finds macro differences at the locations of the instructions L and R and
 /// return them as a vector.
@@ -81,7 +81,7 @@ std::unordered_map<std::string, MacroElement> getAllMacrosAtLocation(
 /// include that difference into ModuleComparator, and therefore avoid an
 /// empty diff.
 std::vector<SyntaxDifference> findMacroDifferences(
-		const Instruction *L, const Instruction *R);
+		const Instruction *L, const Instruction *R, int lineOffset = 0);
 
 // Takes a string and the position of the first bracket and returns the
 // substring in the brackets.

--- a/diffkemp/simpll/SourceCodeUtils.h
+++ b/diffkemp/simpll/SourceCodeUtils.h
@@ -31,12 +31,16 @@ struct MacroElement {
     // string, because otherwise the content would be dropped on leaving the
     // block in which the shortening is done.
     std::string name;
+    // Full macro name. (Used for extracting parameters.)
+    std::string fullName;
     // The body is in DebugInfo, parentMacro is a key in the map, therefore
     // both can be stored by reference.
     StringRef body, parentMacro;
     // This is the line in the C source code on which the macro is located.
     int line;
     std::string sourceFile;
+    // This is a list of the arguments of the macro and its parameters.
+    std::vector<std::string> args, params;
 };
 
 /// Syntactic difference between objects that cannot be found in the original
@@ -97,5 +101,10 @@ std::vector<std::string> splitArgumentsList(std::string argumentString);
 /// the corresponding arguments in the C source code.
 std::vector<std::string> findFunctionCallSourceArguments(DILocation *LineLoc,
         const Module *Mod, std::string functionName);
+
+/// Expand simple non-argument macros in string. The macros are determined by
+/// macro-body pairs.
+std::string expandMacros(std::vector<std::pair<std::string, std::string>>
+        Macros, std::string Input);
 
 #endif // DIFFKEMP_SIMPLL_MACRO_UTILS_H

--- a/diffkemp/simpll/SourceCodeUtils.h
+++ b/diffkemp/simpll/SourceCodeUtils.h
@@ -62,6 +62,11 @@ struct SyntaxDifference {
 std::unordered_map<std::string, MacroElement> getAllMacrosOnLine(
     StringRef line, StringMap<StringRef> macroMap);
 
+/// Takes a list of parameter-argument pairs and expand them on places where
+/// are a part of a composite macro name joined by ##.
+void expandCompositeMacroNames(std::vector<std::pair<std::string, std::string>>
+        args, std::string &body);
+
 /// Extract the line corresponding to the DILocation from the C source file.
 std::string extractLineFromLocation(DILocation *LineLoc);
 

--- a/diffkemp/simpll/SourceCodeUtils.h
+++ b/diffkemp/simpll/SourceCodeUtils.h
@@ -64,8 +64,9 @@ std::unordered_map<std::string, MacroElement> getAllMacrosOnLine(
 
 /// Takes a list of parameter-argument pairs and expand them on places where
 /// are a part of a composite macro name joined by ##.
-void expandCompositeMacroNames(std::vector<std::pair<std::string, std::string>>
-        args, std::string &body);
+void expandCompositeMacroNames(std::vector<std::string> params,
+                               std::vector<std::string> args,
+                               std::string &body);
 
 /// Extract the line corresponding to the DILocation from the C source file.
 std::string extractLineFromLocation(DILocation *LineLoc, int offset = 0);
@@ -109,7 +110,7 @@ std::vector<std::string> findFunctionCallSourceArguments(DILocation *LineLoc,
 
 /// Expand simple non-argument macros in string. The macros are determined by
 /// macro-body pairs.
-std::string expandMacros(std::vector<std::pair<std::string, std::string>>
-        Macros, std::string Input);
+std::string expandMacros(std::vector<std::string> macros,
+                         std::vector<std::string> bodies, std::string Input);
 
 #endif // DIFFKEMP_SIMPLL_MACRO_UTILS_H

--- a/diffkemp/simpll/Transforms.cpp
+++ b/diffkemp/simpll/Transforms.cpp
@@ -153,7 +153,7 @@ void simplifyModulesDiff(Config &config,
 
     // Compare functions for syntactical equivalence
     ModuleComparator modComp(*config.First, *config.Second,
-                             config.ControlFlowOnly, &DI,
+                             config.ControlFlowOnly, config.PrintAsmDiffs, &DI,
                              AbstractionGeneratorResultL.asmValueMap,
                              AbstractionGeneratorResultR.asmValueMap,
                              StructSizeMapL, StructSizeMapR);

--- a/diffkemp/simpll/Utils.cpp
+++ b/diffkemp/simpll/Utils.cpp
@@ -306,6 +306,9 @@ bool isValidCharForIdentifierStart(char ch) {
 /// given in the third argument.
 void findAndReplace(std::string &input, std::string find,
         std::string replace) {
+    if (find == "")
+        return;
+
     int position = 0;
     while ((position = input.find(find, position)) !=
             std::string::npos) {

--- a/diffkemp/simpll/Utils.h
+++ b/diffkemp/simpll/Utils.h
@@ -118,15 +118,4 @@ std::string getIdentifierForValue(const Value *Val,
         const std::map<std::pair<StructType *, uint64_t>, StringRef>
         &StructFieldNames, const Function *Parent = nullptr);
 
-/// Takes two vectors and creates a vector of pairs from them.
-template<typename T> std::vector<std::pair<T, T>> pairZip(std::vector<T> A,
-        std::vector<T> B) {
-    std::vector<std::pair<T, T>> Result;
-    for (auto Ai = A.begin(), Bi = B.begin(); Ai != A.end() && Bi != B.end();
-         ++Ai, ++Bi) {
-        Result.push_back(std::pair<T, T> {*Ai, *Bi});
-    }
-    return Result;
-}
-
 #endif //DIFFKEMP_SIMPLL_UTILS_H

--- a/diffkemp/simpll/Utils.h
+++ b/diffkemp/simpll/Utils.h
@@ -118,4 +118,15 @@ std::string getIdentifierForValue(const Value *Val,
         const std::map<std::pair<StructType *, uint64_t>, StringRef>
         &StructFieldNames, const Function *Parent = nullptr);
 
+/// Takes two vectors and creates a vector of pairs from them.
+template<typename T> std::vector<std::pair<T, T>> pairZip(std::vector<T> A,
+        std::vector<T> B) {
+    std::vector<std::pair<T, T>> Result;
+    for (auto Ai = A.begin(), Bi = B.begin(); Ai != A.end() && Bi != B.end();
+         ++Ai, ++Bi) {
+        Result.push_back(std::pair<T, T> {*Ai, *Bi});
+    }
+    return Result;
+}
+
 #endif //DIFFKEMP_SIMPLL_UTILS_H

--- a/diffkemp/simpll/simpll.py
+++ b/diffkemp/simpll/simpll.py
@@ -19,7 +19,8 @@ def add_suffix(file, suffix):
 
 
 def simplify_modules_diff(first, second, fun_first, fun_second, var,
-                          suffix=None, control_flow_only=False, verbose=False):
+                          suffix=None, control_flow_only=False,
+                          print_asm_diffs=False, verbose=False):
     """
     Simplify modules to ease their semantic difference. Uses the SimpLL tool.
     """
@@ -48,6 +49,9 @@ def simplify_modules_diff(first, second, fun_first, fun_second, var,
 
         if control_flow_only:
             simpll_command.append("--control-flow")
+
+        if print_asm_diffs:
+            simpll_command.append("--print-asm-diffs")
 
         if verbose:
             simpll_command.append("--verbose")

--- a/tests/regression/task_spec.py
+++ b/tests/regression/task_spec.py
@@ -47,7 +47,7 @@ class TaskSpec:
         self.old_kernel = KernelSource(self.old_kernel_dir, True)
         self.new_kernel = KernelSource(self.new_kernel_dir, True)
         self.config = Config(self.old_kernel, self.new_kernel, False,
-                             self.control_flow_only, False, None)
+                             self.control_flow_only, False, False, None)
 
         self.functions = dict()
 

--- a/tests/unit_tests/function_syntax_diff_test.py
+++ b/tests/unit_tests/function_syntax_diff_test.py
@@ -19,7 +19,8 @@ def test_syntax_diff():
     source_first = KernelSource("kernel/linux-3.10.0-862.el7", True)
     source_second = KernelSource("kernel/linux-3.10.0-957.el7", True)
     config = Config(source_first, source_second, show_diff=True,
-                    control_flow_only=True, verbosity=False, semdiff_tool=None)
+                    control_flow_only=True, print_asm_diffs=False,
+                    verbosity=False, semdiff_tool=None)
     first = source_first.get_module_for_symbol(f)
     second = source_second.get_module_for_symbol(f)
     fun_result = functions_diff(mod_first=first, mod_second=second,


### PR DESCRIPTION
This PR adds support for getting macro parameters and arguments from DebugInfo to SourceCodeUtils. This is done by parsing of macro bodies (arguments) and full macro names (parameters) using the functions originally created for ignored macro detection. (Any parameter names in the arguments are expanded using the fields of the parent macro, ensuring the arguments from the use of the parent macro get to the differing macros.)

This feature is then used to expand macro names created by joining an argument with a name template with the ## preprocessor symbol, allowing SimpLL to follow macros in many cases where it previously wasn't possible (this directly fixes several empty diff cases).

Note: Because inline assembly differences should now be detected in macros in most cases showing the raw diffs from LLVM IR is now optional to avoid unnecessarily long diffs.