### PR TITLE
Fix regex for has_function.

### DIFF
--- a/diffkemp/llvm_ir/kernel_module.py
+++ b/diffkemp/llvm_ir/kernel_module.py
@@ -156,7 +156,7 @@ class LlvmKernelModule:
 
     def has_function(self, fun):
         """Check if module contains a function definition."""
-        pattern = re.compile(r"^define.*@{}".format(fun), flags=re.MULTILINE)
+        pattern = re.compile(r"^define.*@{}\(".format(fun), flags=re.MULTILINE)
         with open(self.llvm, "r") as llvm_file:
             return pattern.search(llvm_file.read()) is not None
 


### PR DESCRIPTION
The problem was in the regex for has_function, which previously caught incomplete function names (e.g. when a function with the name "apic", which is a global variable, was looked for, it found functions beginning with "apic", which caused diffkemp to think "apic" is a function).