### PR TITLE
Bring back unknown functions.

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ The command compares functions from function lists stored inside the snapshots
 pairwise and prints syntactic diffs (thanks to the `--syntax-diff` option) of
 functions that are semantically different.
 
-Note: if `FUNCTION_LIST` contains any other symbols than functions (e.g. global
+Note: if `FUNCTION_LIST` contains any symbols other than functions (e.g. global
 variables), they will be ignored.
 
 ### Comparing sysctl options

--- a/README.md
+++ b/README.md
@@ -21,6 +21,9 @@ The command compares functions from function lists stored inside the snapshots
 pairwise and prints syntactic diffs (thanks to the `--syntax-diff` option) of
 functions that are semantically different.
 
+Note: if `FUNCTION_LIST` contains any other symbols than functions (e.g. global
+variables), they will be ignored.
+
 ### Comparing sysctl options
 
 Apart from comparing specific functions, DiffKemp supports comparison of
@@ -86,7 +89,7 @@ The analysis is composed of multiple steps:
 ## Running environment
 
 Currently, DiffKemp runs on Linux and needs the following software installed:
-* LLVM 8.0 (currently the only supported version)
+* LLVM (supported versions are 5, 6, 7 and 8)
 * Python 3 with CFFI (package `python3-cffi` in Fedora and Debian)
 * Python packages from `requirements.txt`
 * CScope

--- a/diffkemp/diffkemp.py
+++ b/diffkemp/diffkemp.py
@@ -185,6 +185,9 @@ def generate(args):
                     # it into the snapshot
                     sys.stdout.write("{}: ".format(symbol))
                     llvm_mod = source.get_module_for_symbol(symbol)
+                    if not llvm_mod.has_function(symbol):
+                        print("unsupported")
+                        continue
                     print(os.path.relpath(llvm_mod.llvm, args.kernel_dir))
                     fun_list.add(symbol, llvm_mod)
                 except SourceNotFoundException:
@@ -245,11 +248,6 @@ def compare(args):
             if old_fun_desc.mod is None or new_fun_desc.mod is None:
                 result.add_inner(Result(Result.Kind.UNKNOWN, fun, fun))
                 print("{}: unknown".format(fun))
-                continue
-
-            # Check if the function exists in both modules
-            if not (old_fun_desc.mod.has_function(fun) and
-                    new_fun_desc.mod.has_function(fun)):
                 continue
 
             # If function has a global variable, set it

--- a/diffkemp/function_list.py
+++ b/diffkemp/function_list.py
@@ -48,8 +48,9 @@ class FunctionList:
 
     def modules(self):
         """Get the set of all LLVM modules of all functions in the list."""
-        return set([fun.mod for group in self.groups.values() for fun in
-                    group.functions.values()])
+        return set([fun.mod for group in self.groups.values()
+                    for fun in group.functions.values()
+                    if fun.mod is not None])
 
     def get_by_name(self, name, group=None):
         """
@@ -77,7 +78,8 @@ class FunctionList:
             for f in functions:
                 self.add(f["name"],
                          LlvmKernelModule(
-                             os.path.join(self.root_dir, f["llvm"])),
+                             os.path.join(self.root_dir, f["llvm"]))
+                         if f["llvm"] else None,
                          f["glob_var"],
                          f["tag"],
                          group)
@@ -91,7 +93,8 @@ class FunctionList:
         if None in self.groups:
             yaml_dict = [{
                 "name": name,
-                "llvm": os.path.relpath(desc.mod.llvm, self.root_dir),
+                "llvm": os.path.relpath(desc.mod.llvm, self.root_dir)
+                if desc.mod else None,
                 "glob_var": desc.glob_var,
                 "tag": desc.tag
             } for name, desc in self.groups[None].functions.items()]
@@ -101,7 +104,8 @@ class FunctionList:
                  "functions": [
                      {"name": fun_name,
                       "llvm": os.path.relpath(fun_desc.mod.llvm,
-                                              self.root_dir),
+                                              self.root_dir)
+                      if fun_desc.mod else None,
                       "glob_var": fun_desc.glob_var,
                       "tag": fun_desc.tag}
                      for fun_name, fun_desc in g.functions.items()]


### PR DESCRIPTION
Previously functions whose source code wasn't found by CScope
were not included into snapshots; this commit changes this in a
way that they are now included with their LLVM IR field set to
None, enabling adding them into statistics as unknown in the
compare phase.