### PR TITLE
Compare sizeofs by value type names

### DIFF
--- a/diffkemp/simpll/DebugInfo.cpp
+++ b/diffkemp/simpll/DebugInfo.cpp
@@ -431,8 +431,16 @@ void DebugInfo::collectLocalVariables(std::set<const Function *> &Called,
                 auto Val = dyn_cast<ValueAsMetadata>(ValMD);
                 if (!Val)
                     continue;
-
+#if LLVM_VERSION_MAJOR < 6
+                MetadataAsValue *DIVal;
+                if (getCalledFunction(CInst->getCalledValue())->getName() ==
+                        "llvm.dbg.declare")
+                    DIVal = dyn_cast<MetadataAsValue>(CInst->getOperand(1));
+                else
+                    DIVal = dyn_cast<MetadataAsValue>(CInst->getOperand(2));
+#else
                 auto DIVal = dyn_cast<MetadataAsValue>(CInst->getOperand(1));
+#endif
                 auto DI = dyn_cast<DILocalVariable>(DIVal->getMetadata());
                 auto Name = Fun->getName().str() + "::" + DI->getName().str();
 

--- a/diffkemp/simpll/Transforms.cpp
+++ b/diffkemp/simpll/Transforms.cpp
@@ -146,7 +146,9 @@ void simplifyModulesDiff(Config &config,
     DebugInfo DI(*config.First, *config.Second,
                  config.FirstFun, config.SecondFun,
                  mam.getResult<CalledFunctionsAnalysis>(*config.First,
-                                                        config.FirstFun));
+                                                        config.FirstFun),
+                 mam.getResult<CalledFunctionsAnalysis>(*config.Second,
+                                                        config.SecondFun));
     DEBUG_WITH_TYPE(DEBUG_SIMPLL,
                     dbgs() << "StructFieldNames size: "
                            << DI.StructFieldNames.size() << "\n");

--- a/diffkemp/simpll/Utils.cpp
+++ b/diffkemp/simpll/Utils.cpp
@@ -562,7 +562,6 @@ Type *getCSourceIdentifierType(std::string expr, const Function *Parent,
         if (!Ty)
             return nullptr;
 
-        dbgs() << *Ty << "\n";
         PointerType *PTy = dyn_cast<PointerType>(Ty);
         return PTy->getElementType();
     } else if (expr[0] == '&') {

--- a/diffkemp/simpll/Utils.h
+++ b/diffkemp/simpll/Utils.h
@@ -110,6 +110,11 @@ void findAndReplace(std::string &input, std::string find,
 /// the built-in getAsInstruction method is sufficient.
 const Instruction *getConstExprAsInstruction(const ConstantExpr *CEx);
 
+/// Retrives type of the value based its C source code identifier.
+Type *getCSourceIdentifierType(std::string expr, const Function *Parent,
+        const std::unordered_map<std::string, const Value *>
+        &LocalVariableMap);
+
 /// Generates human-readable C-like identifier for type.
 std::string getIdentifierForType(Type *Ty);
 


### PR DESCRIPTION
This PR adds a local variable map to DebugInfo which allows to look up a local variable by its name. This is used in a function that attempts to get the type of a variable (either local or global) by its identifier. This function is then used to retrive the type of the value in a sizeof expression and the type is subsequently compared both by cmpTypes and by type name (in case it is a structure type), allowing comparing sizeofs with a value of the same type as its parameter to be compared as equal (this helps to avoid false positives in KABI comparison).