### PR TITLE
SimpLL: Support aliases in getCalledFunction.

### DIFF
--- a/diffkemp/simpll/Utils.cpp
+++ b/diffkemp/simpll/Utils.cpp
@@ -37,6 +37,8 @@ const Function *getCalledFunction(const Value *CalledValue) {
     if (!fun) {
         if (auto BitCast = dyn_cast<BitCastOperator>(CalledValue)) {
             fun = dyn_cast<Function>(BitCast->getOperand(0));
+        } else if (auto Alias = dyn_cast<GlobalAlias>(CalledValue)) {
+            fun = getCalledFunction(Alias->getAliasee());
         }
     }
     return fun;


### PR DESCRIPTION
This causes an empty diff in one of the KABI functions from 7.6 to 7.7, because an alias call is falsely detected as an indirect call in one of the modules, creating an artificial difference by being replaced by a SimpLL abstraction.