### PR TITLE
SimpLL: Added pass to unify globals numbering.

### DIFF
--- a/diffkemp/simpll/Transforms.cpp
+++ b/diffkemp/simpll/Transforms.cpp
@@ -28,6 +28,7 @@
 #include "passes/SimplifyKernelGlobalsPass.h"
 #include "passes/StructHashGeneratorPass.h"
 #include "passes/StructureSizeAnalysis.h"
+#include "passes/UnifyGlobalsNumberingPass.h"
 #include "passes/UnifyMemcpyPass.h"
 #include "passes/VarDependencySlicer.h"
 #include <llvm/IR/PassManager.h>
@@ -135,6 +136,7 @@ void simplifyModulesDiff(Config &config,
     PassManager<Module, AnalysisManager<Module, Function *>, Function *,
         Module *> mpm;
     mpm.addPass(RemoveUnusedReturnValuesPass {});
+    mpm.addPass(UnifyGlobalsNumberingPass {});
     mpm.run(*config.First, mam, config.FirstFun, config.Second.get());
     mpm.run(*config.Second, mam, config.SecondFun, config.First.get());
 

--- a/diffkemp/simpll/passes/UnifyGlobalsNumberingPass.cpp
+++ b/diffkemp/simpll/passes/UnifyGlobalsNumberingPass.cpp
@@ -92,7 +92,8 @@ void UnifyGlobalsNumberingPass::fixStaticVariablesNumbering(Module &Mod) {
     // Go through all static variables in map and number them according to the
     // order of the numbers assigned in the previous step.
     for (auto Elem : Map) {
-        std::sort(Elem.second.begin(), Elem.second.end());
+        std::sort(Elem.second.begin(), Elem.second.end(), [](auto L, auto R) ->
+                bool { return L.second < R.second; });
         int counter = 0;
         for (auto Pair : Elem.second) {
             Pair.first->setName(Elem.first + "." + std::to_string(counter++));

--- a/diffkemp/simpll/passes/UnifyGlobalsNumberingPass.cpp
+++ b/diffkemp/simpll/passes/UnifyGlobalsNumberingPass.cpp
@@ -1,0 +1,112 @@
+//==------ UnifyGlobalsNumberingPass.cpp - Unify numbering of globals ------==//
+//
+//       SimpLL - Program simplifier for analysis of semantic difference      //
+//
+// This file is published under Apache 2.0 license. See LICENSE for details.
+// Author: Tomas Glozar, tglozar@gmail.com
+//===----------------------------------------------------------------------===//
+///
+/// \file
+/// This file contains the declaration of the UnifyGlobalsNumberingPass pass.
+///
+//===----------------------------------------------------------------------===//
+
+#include "CalledFunctionsAnalysis.h"
+#include "UnifyGlobalsNumberingPass.h"
+#include "Utils.h"
+#include <Config.h>
+#include <llvm/IR/Instructions.h>
+#include <llvm/IR/Intrinsics.h>
+
+PreservedAnalyses UnifyGlobalsNumberingPass::run(
+        Module &Mod,
+        AnalysisManager<Module, Function *> &mam,
+        Function *Main,
+        Module *ModOther) {
+    // Currently this pass does only the unification for static variables.
+    fixStaticVariablesNumbering(Mod);
+
+    return PreservedAnalyses();
+}
+
+// Ensure that the numbering of static local variables is consistent in
+// cases when there are more of them with the same name.
+void UnifyGlobalsNumberingPass::fixStaticVariablesNumbering(Module &Mod) {
+    // This is a map that groups together variables differing only in number
+    // suffix along with the instruction numbers of their first users.
+    std::unordered_map<std::string,
+        std::vector<std::pair<GlobalVariable *, int>>> Map;
+
+    // Iterate over all globals and for eligible ones, retrieve their
+    // instruction number and save it to the map described above.
+    for (GlobalValue &GV : Mod.globals()) {
+        if (!GV.hasName() || !isa<GlobalVariable>(GV))
+            // Static variables always have a name and are variables.
+            continue;
+
+        auto GVa = dyn_cast<GlobalVariable>(&GV);
+        SmallVector<DIGlobalVariableExpression *, 10> DIStore;
+        GVa->getDebugInfo(DIStore);
+
+        if (DIStore.size() != 1)
+            // Static variables should have exactly one node.
+            continue;
+
+        auto DIGV = DIStore[0]->getVariable();
+        if (!isa<DISubprogram>(DIGV->getScope()))
+            // Not defined inside function (not "local" in the C sense).
+            continue;
+
+        // At this point we can be sure that we are dealing with a static
+        // local variable. Check whether it has a number suffix.
+        int Offset = GV.getName().find(("." + DIGV->getName()).str()) +
+                DIGV->getName().size() + 2;
+        if (Offset > GV.getName().size())
+            // There is no number suffix, no action needed.
+            continue;
+
+        // Now determine the number of the instruction where the value is.
+        // Note: the variable should have at least one user.
+        int minimum = INT32_MAX;
+        for (auto U : GV.users()) {
+            auto Instr = getUserInstruction(U);
+            if (!Instr)
+                continue;
+            int n = 0;
+            for (auto &BB : *(Instr->getFunction())) {
+                for (auto &I : BB) {
+                    if (&I == Instr && n < minimum) {
+                        minimum = n;
+                        goto end;
+                    }
+                    n++;
+                }
+            }
+            end:;
+        }
+        if (minimum == INT32_MAX)
+            continue;
+        Map[GV.getName().substr(0, Offset - 1)].push_back({GVa, minimum});
+    }
+
+    // Go through all static variables in map and number them according to the
+    // order of the numbers assigned in the previous step.
+    for (auto Elem : Map) {
+        std::sort(Elem.second.begin(), Elem.second.end());
+        int counter = 0;
+        for (auto Pair : Elem.second) {
+            Pair.first->setName(Elem.first + "." + std::to_string(counter++));
+        }
+    }
+}
+
+// Gets an instruction up in the user tree or nullptr in case it doesn't exist.
+const Instruction *getUserInstruction(const User *U) {
+    if (isa<Instruction>(U))
+        return dyn_cast<Instruction>(U);
+    else {
+        if (U->user_empty())
+            return nullptr;
+        return getUserInstruction(*U->user_begin());
+    }
+}

--- a/diffkemp/simpll/passes/UnifyGlobalsNumberingPass.h
+++ b/diffkemp/simpll/passes/UnifyGlobalsNumberingPass.h
@@ -1,0 +1,37 @@
+//===------ UnifyGlobalsNumberingPass.h - Unify numbering of globals ------===//
+//
+//       SimpLL - Program simplifier for analysis of semantic difference      //
+//
+// This file is published under Apache 2.0 license. See LICENSE for details.
+// Author: Tomas Glozar, tglozar@gmail.com
+//===----------------------------------------------------------------------===//
+///
+/// \file
+/// This file contains the declaration of the UnifyGlobalsNumberingPass pass.
+///
+//===----------------------------------------------------------------------===//
+
+#ifndef DIFFKEMP_SIMPLL_UNIFYGLOBALSNUMBERINGPASS_H
+#define DIFFKEMP_SIMPLL_UNIFYGLOBALSNUMBERINGPASS_H
+
+#include <llvm/IR/PassManager.h>
+
+using namespace llvm;
+
+/// This pass goes through global values with names ending in a number in both
+/// modules and unifies them when possible.
+class UnifyGlobalsNumberingPass
+        : public PassInfoMixin<UnifyGlobalsNumberingPass> {
+  public:
+    PreservedAnalyses run(Module &Mod, AnalysisManager<Module, Function *> &mam,
+                          Function *Main, Module *ModOther);
+  private:
+    // Ensure that the numbering of static local variables is consistent in
+    // cases when there are more of them with the same name.
+    void fixStaticVariablesNumbering(Module &Mod);
+};
+
+// Gets an instruction up in the user tree or nullptr in case it doesn't exist.
+const Instruction *getUserInstruction(const User *U);
+
+#endif //DIFFKEMP_SIMPLL_UNIFYGLOBALSNUMBERINGPASS_H


### PR DESCRIPTION
Currently this pass implements fixing the numbering of local
static variables, where Clang generates different number suffixes
in different modules in cases there is more than one such variable
with the same name in one function.

Fixes #90.