### PR TITLE
SimpLL: Indent info during comparison

### DIFF
--- a/diffkemp/simpll/DifferentialFunctionComparator.cpp
+++ b/diffkemp/simpll/DifferentialFunctionComparator.cpp
@@ -313,8 +313,9 @@ void DifferentialFunctionComparator::findMacroFunctionDifference(
                 {nullptr, dyn_cast<CallInst>(R)};
         }
 
-        DEBUG_WITH_TYPE(DEBUG_SIMPLL, dbgs() <<
-            "Writing function-macro syntactic difference\n");
+        DEBUG_WITH_TYPE(DEBUG_SIMPLL,
+                        dbgs() << getDebugIndent() << "Writing function-macro "
+                               << "syntactic difference\n");
 
         SyntaxDifference diff;
         diff.function = L->getFunction()->getName();
@@ -461,7 +462,8 @@ int DifferentialFunctionComparator::cmpBasicBlocks(const BasicBlock *BBL,
                                 mayIgnoreMacro(CArgsR[i]) &&
                                 (CArgsL[i] == CArgsR[i])) {
                             DEBUG_WITH_TYPE(DEBUG_SIMPLL,
-                                dbgs() << "Comparing integers as equal "
+                                dbgs() << getDebugIndent()
+                                       << "Comparing integers as equal "
                                        << "because of correspondence to an "
                                        << "ignored macro\n");
                             Res = 0;
@@ -522,7 +524,8 @@ int DifferentialFunctionComparator::cmpBasicBlocks(const BasicBlock *BBL,
                                   (!cmpTypes(TyIdL, TyIdR) ||
                                    TyIdLName == TyIdRName))) {
                                 DEBUG_WITH_TYPE(DEBUG_SIMPLL,
-                                    dbgs() << "Comparing integers as equal "
+                                    dbgs() << getDebugIndent()
+                                           << "Comparing integers as equal "
                                            << "because of correspondence to "
                                            << "structure type sizes \n");
                                 Res = 0;

--- a/diffkemp/simpll/ModuleComparator.cpp
+++ b/diffkemp/simpll/ModuleComparator.cpp
@@ -26,8 +26,10 @@
 void ModuleComparator::compareFunctions(Function *FirstFun,
                                         Function *SecondFun) {
     DEBUG_WITH_TYPE(DEBUG_SIMPLL,
-                    dbgs() << "Comparing " << FirstFun->getName() << " and "
-                           << SecondFun->getName() << "\n");
+                    dbgs() << getDebugIndent() << "Comparing "
+                           << FirstFun->getName() << " and "
+                           << SecondFun->getName() << "\n";
+                    increaseIndentLevel());
     ComparedFuns.emplace(std::make_pair(FirstFun, SecondFun), Result::UNKNOWN);
 
     // Comparing function declarations (function without bodies).
@@ -54,6 +56,8 @@ void ModuleComparator::compareFunctions(Function *FirstFun,
                     this->MissingDefs.push_back({nullptr, SecondFun});
             }
         }
+
+        DEBUG_WITH_TYPE(DEBUG_SIMPLL, decreaseIndentLevel());
         return;
     }
 
@@ -62,7 +66,8 @@ void ModuleComparator::compareFunctions(Function *FirstFun,
                                          showAsmDiffs, DI, this);
     if (fComp.compare() == 0) {
         DEBUG_WITH_TYPE(DEBUG_SIMPLL,
-                        dbgs() << "Function " << FirstFun->getName()
+                        dbgs() << getDebugIndent(-1) << "Function "
+                               << FirstFun->getName()
                                << " is same in both modules\n");
         ComparedFuns.at({FirstFun, SecondFun}) = Result::EQUAL;
     } else {
@@ -81,12 +86,13 @@ void ModuleComparator::compareFunctions(Function *FirstFun,
                 const Function *toInline =
                         getCalledFunction(inlineFirst->getCalledValue());
                 DEBUG_WITH_TYPE(DEBUG_SIMPLL,
-                                dbgs() << "Try to inline "
+                                dbgs() << getDebugIndent() << "Try to inline "
                                        << toInline->getName()
                                        << " in first.\n");
                 if (toInline->isDeclaration()) {
                     DEBUG_WITH_TYPE(DEBUG_SIMPLL,
-                                    dbgs() << "Missing definition\n");
+                                    dbgs() << getDebugIndent()
+                                           << "Missing definition\n");
                     if (!toInline->isIntrinsic()
                             && toInline->getName().find("simpll__")
                                     == std::string::npos)
@@ -104,12 +110,13 @@ void ModuleComparator::compareFunctions(Function *FirstFun,
                 const Function *toInline =
                         getCalledFunction(inlineSecond->getCalledValue());
                 DEBUG_WITH_TYPE(DEBUG_SIMPLL,
-                                dbgs() << "Try to inline "
+                                dbgs() << getDebugIndent() << "Try to inline "
                                        << toInline->getName()
                                        << " in second.\n");
                 if (toInline->isDeclaration()) {
                     DEBUG_WITH_TYPE(DEBUG_SIMPLL,
-                                    dbgs() << "Missing definition\n");
+                                    dbgs() << getDebugIndent()
+                                           << "Missing definition\n");
                     if (!toInline->isIntrinsic()
                             && toInline->getName().find("simpll__")
                                     == std::string::npos)
@@ -146,4 +153,6 @@ void ModuleComparator::compareFunctions(Function *FirstFun,
             }
         }
     }
+
+    DEBUG_WITH_TYPE(DEBUG_SIMPLL, decreaseIndentLevel());
 }

--- a/diffkemp/simpll/SourceCodeUtils.cpp
+++ b/diffkemp/simpll/SourceCodeUtils.cpp
@@ -116,9 +116,10 @@ std::unordered_map<std::string, MacroElement> getAllMacrosOnLine(
             if (usedMacroMap.find(Entry.first.str()) == usedMacroMap.end()) {
                 usedMacroMap[Entry.first.str()] = Entry.second;
                 DEBUG_WITH_TYPE(DEBUG_SIMPLL,
-                                dbgs() << "Adding macro " << Entry.first <<
-                                " : " << Entry.second.body << ", parent macro "
-                                << Entry.second.parentMacro << "\n");
+                                dbgs() << getDebugIndent() << "Adding macro "
+                                       << Entry.first << " : "
+                                       << Entry.second.body << ", parent macro "
+                                       << Entry.second.parentMacro << "\n");
             }
         }
 
@@ -220,20 +221,25 @@ std::unordered_map<std::string, MacroElement> getAllMacrosAtLocation(
 
     if (!LineLoc || LineLoc->getNumOperands() == 0) {
         // DILocation has no scope or is not present - cannot get macro stack
-        DEBUG_WITH_TYPE(DEBUG_SIMPLL, dbgs() << "Scope for macro not found\n");
+        DEBUG_WITH_TYPE(DEBUG_SIMPLL,
+                        dbgs() << getDebugIndent()
+                               << "Scope for macro not found\n");
         return std::unordered_map<std::string, MacroElement>();
     }
 
     std::string line = extractLineFromLocation(LineLoc, lineOffset);
     if (line == "") {
         // Source file was not found
-        DEBUG_WITH_TYPE(DEBUG_SIMPLL, dbgs() << "Source for macro not found\n");
+        DEBUG_WITH_TYPE(DEBUG_SIMPLL,
+                        dbgs() << getDebugIndent()
+                               << "Source for macro not found\n");
         return std::unordered_map<std::string, MacroElement>();
     }
 
     DEBUG_WITH_TYPE(DEBUG_SIMPLL,
-                    dbgs() << "Looking for all macros on line:" << line
-                    << "\n");
+                    dbgs() << getDebugIndent()
+                           << "Looking for all macros on line:"
+                           << line << "\n");
 
     // Get macro array from debug info
     DISubprogram *Sub = LineLoc->getScope()->getSubprogram();
@@ -367,22 +373,20 @@ std::vector<SyntaxDifference> findMacroDifferences(
             std::reverse(StackR.begin(), StackR.end());
 
             DEBUG_WITH_TYPE(DEBUG_SIMPLL,
-                dbgs() << "Left stack:\n\t";
-                dbgs() << LValue->second.body << "\n";
+                dbgs() << getDebugIndent() << "Left stack:\n\t";
+                dbgs() << getDebugIndent() << LValue->second.body << "\n";
                 for (CallInfo &elem : StackL) {
-                    dbgs() << "\t\tfrom " << elem.fun <<
-                        " in file " <<
-                        elem.file << " on line "
-                        << elem.line << "\n";
+                    dbgs() << getDebugIndent() << "\t\tfrom " << elem.fun
+                           << " in file " << elem.file << " on line "
+                           << elem.line << "\n";
                 });
             DEBUG_WITH_TYPE(DEBUG_SIMPLL,
-                dbgs() << "Right stack:\n\t";
-                dbgs() << RValue->second.body << "\n";
+                dbgs() << getDebugIndent() << "Right stack:\n\t";
+                dbgs() << getDebugIndent() << RValue->second.body << "\n";
                 for (CallInfo &elem : StackR) {
-                    dbgs() << "\t\tfrom " << elem.fun <<
-                        " in file " <<
-                        elem.file << " on line "
-                        << elem.line << "\n";
+                    dbgs() << getDebugIndent() << "\t\tfrom " << elem.fun
+                           << " in file " << elem.file << " on line "
+                           << elem.line << "\n";
                 });
 
             result.push_back(SyntaxDifference {

--- a/diffkemp/simpll/Utils.cpp
+++ b/diffkemp/simpll/Utils.cpp
@@ -32,6 +32,9 @@
 #include <llvm/Transforms/Scalar/SimplifyCFG.h>
 #include <llvm/Transforms/Utils/Cloning.h>
 
+/// Level of debug indentation. Each level corresponds to two characters.
+static int debugIndentLevel = 0;
+
 /// Extract called function from a called value Handles situation when the
 /// called value is a bitcast.
 const Function *getCalledFunction(const Value *CalledValue) {
@@ -620,4 +623,21 @@ std::string valueToString(const Value *Val) {
     std::string ValDump; llvm::raw_string_ostream DumpStrm(ValDump);
     Val->print(DumpStrm);
     return DumpStrm.str();
+}
+
+/// Get a string matching the current indentation level.
+/// \param offset Indentation level offset to use, defaults to zero.
+/// \param prefix Indentation prefix character, defaults to space.
+std::string getDebugIndent(const int offset, const char prefixChar) {
+    return std::string((debugIndentLevel + offset) * 2, prefixChar);
+}
+
+/// Increase the level of debug indentation by one.
+void increaseIndentLevel() {
+    debugIndentLevel++;
+}
+
+/// Decrease the level of debug indentation by one.
+void decreaseIndentLevel() {
+    debugIndentLevel--;
 }

--- a/diffkemp/simpll/Utils.cpp
+++ b/diffkemp/simpll/Utils.cpp
@@ -33,7 +33,7 @@
 #include <llvm/Transforms/Utils/Cloning.h>
 
 /// Level of debug indentation. Each level corresponds to two characters.
-static int debugIndentLevel = 0;
+static unsigned int debugIndentLevel = 0;
 
 /// Extract called function from a called value Handles situation when the
 /// called value is a bitcast.
@@ -626,18 +626,18 @@ std::string valueToString(const Value *Val) {
 }
 
 /// Get a string matching the current indentation level.
-/// \param offset Indentation level offset to use, defaults to zero.
 /// \param prefix Indentation prefix character, defaults to space.
-std::string getDebugIndent(const int offset, const char prefixChar) {
-    return std::string((debugIndentLevel + offset) * 2, prefixChar);
+std::string getDebugIndent(const char prefixChar) {
+    return std::string(debugIndentLevel * 2, prefixChar);
 }
 
 /// Increase the level of debug indentation by one.
-void increaseIndentLevel() {
+void increaseDebugIndentLevel() {
     debugIndentLevel++;
 }
 
 /// Decrease the level of debug indentation by one.
-void decreaseIndentLevel() {
+void decreaseDebugIndentLevel() {
+    assert(debugIndentLevel > 0);
     debugIndentLevel--;
 }

--- a/diffkemp/simpll/Utils.h
+++ b/diffkemp/simpll/Utils.h
@@ -133,14 +133,13 @@ std::string getIdentifierForValue(const Value *Val,
 std::string valueToString(const Value *Val);
 
 /// Get a string matching the current indentation level.
-/// \param offset Indentation level offset to use, defaults to zero.
 /// \param prefixChar Indentation prefix character, defaults to space.
-std::string getDebugIndent(const int offset = 0, const char prefixChar = ' ');
+std::string getDebugIndent(const char prefixChar = ' ');
 
 /// Increase the level of debug indentation by one.
-void increaseIndentLevel();
+void increaseDebugIndentLevel();
 
 /// Decrease the level of debug indentation by one.
-void decreaseIndentLevel();
+void decreaseDebugIndentLevel();
 
 #endif //DIFFKEMP_SIMPLL_UTILS_H

--- a/diffkemp/simpll/Utils.h
+++ b/diffkemp/simpll/Utils.h
@@ -132,4 +132,15 @@ std::string getIdentifierForValue(const Value *Val,
 /// methods.
 std::string valueToString(const Value *Val);
 
+/// Get a string matching the current indentation level.
+/// \param offset Indentation level offset to use, defaults to zero.
+/// \param prefixChar Indentation prefix character, defaults to space.
+std::string getDebugIndent(const int offset = 0, const char prefixChar = ' ');
+
+/// Increase the level of debug indentation by one.
+void increaseIndentLevel();
+
+/// Decrease the level of debug indentation by one.
+void decreaseIndentLevel();
+
 #endif //DIFFKEMP_SIMPLL_UTILS_H


### PR DESCRIPTION
Adds indentation to debugging prints during function comparison. Each such print should be moved by two spaces if referenced from another compared function.

Closes #66.