### PR TITLE
SimpLL: Remove function abstraction hashes.

### DIFF
--- a/diffkemp/simpll/DifferentialFunctionComparator.cpp
+++ b/diffkemp/simpll/DifferentialFunctionComparator.cpp
@@ -690,6 +690,10 @@ int DifferentialFunctionComparator::cmpGlobalValues(GlobalValue *L,
                     // Compare field access abstractions using a special
                     // method.
                     return cmpFieldAccess(FunL, FunR);
+                } else if (FunL->getName().startswith(SimpllInlineAsmPrefix) &&
+                           FunR->getName().startswith(SimpllInlineAsmPrefix)) {
+                    return ModComparator->AsmToStringMapL[FunL->getName()] !=
+                           ModComparator->AsmToStringMapR[FunR->getName()];
                 }
             }
             return 0;

--- a/diffkemp/simpll/passes/FunctionAbstractionsGenerator.cpp
+++ b/diffkemp/simpll/passes/FunctionAbstractionsGenerator.cpp
@@ -67,14 +67,8 @@ FunctionAbstractionsGenerator::Result FunctionAbstractionsGenerator::run(
                         auto newFunType = FunctionType::get(
                                 FunType->getReturnType(), newParamTypes, false);
 
-                        uint64_t hashNumber = hash_value(hash);
-                        while (Mod.getFunction(abstractionPrefix(
-                                CallInstr->getCalledValue()) +
-                                std::to_string(hashNumber)) != nullptr)
-                            hashNumber++;
                         const std::string funName =
-                                abstractionPrefix(CallInstr->getCalledValue()) +
-                                std::to_string(hashNumber);
+                                abstractionPrefix(CallInstr->getCalledValue());
 
                         newFun = Function::Create(
                                 newFunType,


### PR DESCRIPTION
The comparison of the functions is handled by cmpBasicBlocks and
cmpOperations (the comparing of the function type and the argument
types) and by cmpGlobalValues in the case of inline assembly, which
is compared by inline assembly code strings from the map.

Note: The comparison by hashes was created when the comparison of global values was still handled by DifferentialGlobalNumberState and has the problem that the hash changes when the type name changes, even in cases when the result of cmpTypes is.