### PR TITLE
Do not fail in syntax_diff if function definition cannot be found

### DIFF
--- a/diffkemp/syndiff/function_syntax_diff.py
+++ b/diffkemp/syndiff/function_syntax_diff.py
@@ -31,6 +31,8 @@ def syntax_diff(first_file, second_file, fun, first_line, second_line):
             line = lines[line_index]
             while line.rstrip() != "}" and line.rstrip() != ");":
                 line_index += 1
+                if line_index == len(lines):
+                    return "Error: cannot get diff\n"
                 output_file.write(line)
                 line = lines[line_index]
             output_file.write(line)


### PR DESCRIPTION
This can occur, e.g., if the function definition is generated from a one line macro. In such case, function_syntax_diff cannot extract the definition and throws an exception.
This prevents the exception from occurring by returning an error message instead of the diff.
This is a workaround for #100.