### PR TITLE
Source finding optimisation

### DIFF
--- a/diffkemp/diffkemp.py
+++ b/diffkemp/diffkemp.py
@@ -196,7 +196,9 @@ def generate(args):
 
     # Copy LLVM files to the snapshot
     source.copy_source_files(fun_list.modules(), args.output_dir)
-    source.copy_cscope_files(args.output_dir)
+
+    snapshot = KernelSource(args.output_dir)
+    snapshot.build_cscope_database()
 
     # Create YAML with functions list
     with open(os.path.join(args.output_dir, "functions.yaml"),

--- a/diffkemp/llvm_ir/kernel_source.py
+++ b/diffkemp/llvm_ir/kernel_source.py
@@ -182,18 +182,19 @@ class KernelSource:
         #   2. Files marked by cscope as using the symbol in <global> scope.
         #   3. Files marked by cscope as using the symbol in other scope.
         # Each group is also partially sorted - sources from the drivers/ and
-        # the arch/ directories occur later than the others (using prio_cmp).
+        # the arch/ directories occur later than the others (using prio_key).
         # Moreover, each file occurs in the list just once (in place of its
         # highest priority).
         seen = set()
 
         def prio_key(item):
             if item.startswith("drivers/"):
-                # Before any other string
-                return "_" + item
-            if item.startswith("arch/"):
-                # After any other string
                 return "}" + item
+            if item.startswith("arch/x86"):
+                # x86 has priority over other architectures
+                return "}}" + item
+            if item.startswith("arch/"):
+                return "}}}" + item
             else:
                 return item
 


### PR DESCRIPTION
The PR introduces 2 optimisations:
1. Instead of copying the CScope database from kernel to snapshot, it is re-built in the snapshot. This is much more space efficient.
2. Source priorities are fixed (see second commit).