### PR TITLE
Improve comparing attributes and integer types

### DIFF
--- a/diffkemp/simpll/DifferentialFunctionComparator.cpp
+++ b/diffkemp/simpll/DifferentialFunctionComparator.cpp
@@ -134,32 +134,10 @@ int DifferentialFunctionComparator::cmpGEPs(
     return 0;
 }
 
-
-/// Remove chosen attributes from the attribute set at the given index of
-/// the given attribute list. Since attribute lists are immutable, they must be
-/// copied all over.
-AttributeList cleanAttributes(AttributeList AS, unsigned Idx, LLVMContext &C) {
-    AttributeList result = AS;
-    result = result.removeAttribute(C, Idx, Attribute::AttrKind::AlwaysInline);
-    result = result.removeAttribute(C, Idx, Attribute::AttrKind::InlineHint);
-    result = result.removeAttribute(C, Idx, Attribute::AttrKind::NoInline);
-    result = result.removeAttribute(C, Idx, Attribute::AttrKind::NoUnwind);
-    return result;
-}
-
+/// Ignore differences in attributes.
 int DifferentialFunctionComparator::cmpAttrs(const AttributeList L,
                                              const AttributeList R) const {
-    AttributeList LNew = L;
-    AttributeList RNew = R;
-    for (unsigned i = L.index_begin(), e = L.index_end(); i != e; ++i) {
-        LNew = cleanAttributes(LNew, i, LNew.getContext());
-    }
-    for (unsigned i = R.index_begin(), e = R.index_end(); i != e; ++i) {
-        RNew = cleanAttributes(RNew, i, RNew.getContext());
-    }
-    LNew = cleanAttributeList(LNew);
-    RNew = cleanAttributeList(RNew);
-    return FunctionComparator::cmpAttrs(LNew, RNew);
+    return 0;
 }
 
 /// Compare allocation instructions using separate cmpAllocs function in case

--- a/diffkemp/simpll/DifferentialFunctionComparator.cpp
+++ b/diffkemp/simpll/DifferentialFunctionComparator.cpp
@@ -901,9 +901,13 @@ int DifferentialFunctionComparator::cmpTypes(Type *L, Type *R) const {
         }
     }
 
-    // Compare integer types as the same when comparing the control flow only.
-    if (L->isIntegerTy() && R->isIntegerTy() && controlFlowOnly)
+    // Compare integer types (except the boolean type) as the same when
+    // comparing the control flow only.
+    if (L->isIntegerTy() && R->isIntegerTy() && controlFlowOnly) {
+        if (L->getIntegerBitWidth() == 1 || R->getIntegerBitWidth() == 1)
+            return !(L->getIntegerBitWidth() == R->getIntegerBitWidth());
         return 0;
+    }
 
     if (!L->isArrayTy() || !R->isArrayTy() || !controlFlowOnly)
         return FunctionComparator::cmpTypes(L, R);


### PR DESCRIPTION
- ignore differences in attributes (always compare attribute lists as equal)
- distinguish boolean from other integer types even when comparing the control flow only