### PR TITLE
SimpLL: Added custom pass for function merging.

### DIFF
--- a/diffkemp/simpll/Transforms.cpp
+++ b/diffkemp/simpll/Transforms.cpp
@@ -21,6 +21,7 @@
 #include "passes/ControlFlowSlicer.h"
 #include "passes/FieldAccessFunctionGenerator.h"
 #include "passes/FunctionAbstractionsGenerator.h"
+#include "passes/MergeNumberedFunctionsPass.h"
 #include "passes/ReduceFunctionMetadataPass.h"
 #include "passes/RemoveLifetimeCallsPass.h"
 #include "passes/RemoveUnusedReturnValuesPass.h"
@@ -84,6 +85,7 @@ void preprocessModule(Module &Mod,
     ModuleAnalysisManager mam(false);
     pb.registerModuleAnalyses(mam);
 
+    mpm.addPass(MergeNumberedFunctionsPass {});
     mpm.addPass(SimplifyKernelGlobalsPass {});
     mpm.addPass(RemoveLifetimeCallsPass {});
     mpm.addPass(StructHashGeneratorPass {});

--- a/diffkemp/simpll/passes/MergeNumberedFunctionsPass.cpp
+++ b/diffkemp/simpll/passes/MergeNumberedFunctionsPass.cpp
@@ -1,0 +1,65 @@
+//== MergeNumberedFunctionsPass.h - Merge functions with different numbers ===//
+//
+//       SimpLL - Program simplifier for analysis of semantic difference      //
+//
+// This file is published under Apache 2.0 license. See LICENSE for details.
+// Author: Tomas Glozar, tglozar@gmail.com
+//===----------------------------------------------------------------------===//
+///
+/// \file
+/// This file contains the declaration of the MergeNumberedFunctionsPass pass.
+///
+//===----------------------------------------------------------------------===//
+
+#include "MergeNumberedFunctionsPass.h"
+
+#include "CalledFunctionsAnalysis.h"
+#include "FunctionAbstractionsGenerator.h"
+#include "Utils.h"
+#include <unordered_map>
+
+PreservedAnalyses MergeNumberedFunctionsPass::run(Module &Mod,
+        AnalysisManager<Module> &mam) {
+    // All functions with the same number are grouped together into a vector,
+    // its index is the name of the functions without the suffix.
+    std::unordered_map<std::string, std::vector<Function *>> GroupingMap;
+
+    // Go over all called functions and put them into the map. Functions without
+    // a suffix are included, too, because there may be variants that have it.
+    for (Function &Fun : Mod) {
+        if (Fun.getName().startswith("simpll__") ||
+                Fun.getName().startswith("llvm."))
+            // Do not merge LLVM intrinsics and SimpLL abstractions.
+            continue;
+        std::string originalName = Fun.getName();
+        std::string strippedName = hasSuffix(originalName) ?
+                                   dropSuffix(originalName) : originalName;
+        GroupingMap[strippedName].push_back(&Fun);
+    }
+
+    // Go over the map and process the functions.
+    for (auto It : GroupingMap) {
+        std::vector<Function *> &Vec = It.second;
+        if (Vec.size() < 2)
+            // There is nothing to be merged.
+            continue;
+
+        // Merge the functions.
+        auto FirstF = Vec.front();
+        for (auto F = Vec.begin() + 1; F != Vec.end(); F++) {
+            if (FirstF->getFunctionType() != (*F)->getFunctionType())
+                continue;
+            (*F)->replaceAllUsesWith(FirstF);
+            (*F)->eraseFromParent();
+        }
+
+        // If FirstF has a suffix, drop it to ensure that the suffix won't end
+        // up anywhere in the output of SimpLL.
+        auto name = FirstF->getName().str();
+        name = hasSuffix(name) ? dropSuffix(name) : name;
+        FirstF->setName(name);
+    }
+
+    return PreservedAnalyses();
+}
+

--- a/diffkemp/simpll/passes/MergeNumberedFunctionsPass.h
+++ b/diffkemp/simpll/passes/MergeNumberedFunctionsPass.h
@@ -1,0 +1,29 @@
+//== MergeNumberedFunctionsPass.h - Merge functions with different numbers ===//
+//
+//       SimpLL - Program simplifier for analysis of semantic difference      //
+//
+// This file is published under Apache 2.0 license. See LICENSE for details.
+// Author: Tomas Glozar, tglozar@gmail.com
+//===----------------------------------------------------------------------===//
+///
+/// \file
+/// This file contains the declaration of the MergeNumberedFunctionsPass pass.
+///
+//===----------------------------------------------------------------------===//
+
+#ifndef DIFFKEMP_SIMPLL_MERGENUMBEREDFUNCTIONSPASS_H
+#define DIFFKEMP_SIMPLL_MERGENUMBEREDFUNCTIONSPASS_H
+
+#include <llvm/IR/PassManager.h>
+
+using namespace llvm;
+
+/// Merges functions with names differing only in number suffixes if they are
+/// equal.
+class MergeNumberedFunctionsPass
+        : public PassInfoMixin<MergeNumberedFunctionsPass> {
+  public:
+    PreservedAnalyses run(Module &Mod, AnalysisManager<Module> &mam);
+};
+
+#endif //DIFFKEMP_SIMPLL_MERGENUMBEREDFUNCTIONSPASS_H


### PR DESCRIPTION
The pass merges functions that differ only in name number suffix and
have the same type together into one function without the suffix.

This fixes cases when multiple diffs between numbered versions of the
same function are passed to DiffKemp, which may show the wrong one (it
shows only one of them) and some other problems in function comparison.