### PR TITLE
Improve printing diffs to files

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,11 @@ The command compares functions from function lists stored inside the snapshots
 pairwise and prints syntactic diffs (thanks to the `--syntax-diff` option) of
 functions that are semantically different.
 
+The diffs are stored in separate files (one file for each compared function that
+is different) in a newly created directory. The name of the directory can be
+specified using the `-o` option, otherwise it is generated automatically. Using
+the `--stdout` option causes the diffs to be printed to standard output.
+
 Note: if `FUNCTION_LIST` contains any symbols other than functions (e.g. global
 variables), they will be ignored.
 

--- a/diffkemp/syndiff/function_syntax_diff.py
+++ b/diffkemp/syndiff/function_syntax_diff.py
@@ -21,7 +21,8 @@ def syntax_diff(first_file, second_file, fun, first_line, second_line):
     for filename in [first_file, second_file]:
         tmp_file = "1" if filename == first_file else "2"
         with open(filename, "r", encoding='utf-8') as input_file, \
-                open(os.path.join(tmpdir, tmp_file), "w") as output_file:
+                open(os.path.join(tmpdir, tmp_file), "w",
+                     encoding='utf-8') as output_file:
             lines = input_file.readlines()
             start = first_line if filename == first_file else second_line
 


### PR DESCRIPTION
By default, diffs and callstacks are printed to files. A single file is created for each compared symbol that is different. In case that the groups are used, there is a separate directory for each group.

All diff files (and group directories) are stored inside a directory that can be specified from the command line.

If there are unknown or error results, these are always printed to stdout.