### PR TITLE
SimpLL: Fix inlining causing empty diffs.

### DIFF
--- a/diffkemp/diffkemp.py
+++ b/diffkemp/diffkemp.py
@@ -401,7 +401,7 @@ def print_syntax_diff(snapshot_old, snapshot_new, fun, fun_result, fun_tag,
             indent = initial_indent + 4
 
         for called_res in fun_result.inner.values():
-            if called_res.diff == "" and called_res.first.covered_by_syn_diff:
+            if called_res.diff == "" and called_res.first.covered:
                 # Do not print empty diffs
                 continue
 

--- a/diffkemp/semdiff/result.py
+++ b/diffkemp/semdiff/result.py
@@ -32,13 +32,13 @@ class Result:
         If it is a function, it contains the file of the function.
         """
         def __init__(self, name, filename=None, line=None, callstack=None,
-                     is_syn_diff=False, covered_by_syn_diff=False):
+                     is_syn_diff=False, covered=False):
             self.name = name
             self.filename = filename
             self.line = line
             self.callstack = callstack
             self.is_syn_diff = is_syn_diff
-            self.covered_by_syn_diff = covered_by_syn_diff
+            self.covered = covered
 
     def __init__(self, kind, first_name, second_name):
         self.kind = kind
@@ -128,7 +128,7 @@ class Result:
         for _, inner_res_out in self.inner.items():
             for _, inner_res in inner_res_out.inner.items():
                 if (inner_res.diff == "" and
-                        inner_res.first.covered_by_syn_diff):
+                        inner_res.first.covered):
                     continue
                 unique_diffs.add(UniqueDiff(inner_res))
 

--- a/diffkemp/simpll/DifferentialFunctionComparator.cpp
+++ b/diffkemp/simpll/DifferentialFunctionComparator.cpp
@@ -673,8 +673,7 @@ int DifferentialFunctionComparator::cmpGlobalValues(GlobalValue *L,
                 auto FunR = dyn_cast<Function>(R);
 
                 // Do not compare SimpLL abstractions.
-                if (!FunL->getName().startswith("simpll_") &&
-                    !FunR->getName().startswith("simpll_") &&
+                if (!isSimpllAbstraction(FunL) && !isSimpllAbstraction(FunR) &&
                     (ModComparator->ComparedFuns.find({FunL, FunR}) ==
                         ModComparator->ComparedFuns.end()) &&
                     (!isPrintFunction(L->getName()) &&

--- a/diffkemp/simpll/ModuleComparator.cpp
+++ b/diffkemp/simpll/ModuleComparator.cpp
@@ -12,6 +12,7 @@
 ///
 //===----------------------------------------------------------------------===//
 
+#include "passes/FunctionAbstractionsGenerator.h"
 #include "ModuleComparator.h"
 #include "DifferentialFunctionComparator.h"
 #include "Utils.h"
@@ -106,7 +107,7 @@ void ModuleComparator::compareFunctions(Function *FirstFun,
             Function *InlinedFunSecond = !inlineSecond ? nullptr :
                     getCalledFunction(inlineSecond->getCalledValue());
             if (InlinedFunFirst && InlinedFunSecond &&
-                !InlinedFunFirst->getName().startswith("simpll__") &&
+                !isSimpllAbstraction(InlinedFunFirst) &&
                 (InlinedFunFirst->getName() == InlinedFunSecond->getName())) {
                 compareFunctions(InlinedFunFirst, InlinedFunSecond);
                 if (ComparedFuns.at({InlinedFunFirst, InlinedFunSecond}) ==
@@ -127,9 +128,8 @@ void ModuleComparator::compareFunctions(Function *FirstFun,
                     DEBUG_WITH_TYPE(DEBUG_SIMPLL,
                                     dbgs() << getDebugIndent()
                                            << "Missing definition\n");
-                    if (!toInline->isIntrinsic()
-                            && toInline->getName().find("simpll__")
-                                    == std::string::npos)
+                    if (!toInline->isIntrinsic() &&
+                            !isSimpllAbstraction(toInline))
                         missingDefs.first = toInline;
                 } else {
                     InlineFunctionInfo ifi;
@@ -148,9 +148,8 @@ void ModuleComparator::compareFunctions(Function *FirstFun,
                     DEBUG_WITH_TYPE(DEBUG_SIMPLL,
                                     dbgs() << getDebugIndent()
                                            << "Missing definition\n");
-                    if (!toInline->isIntrinsic()
-                            && toInline->getName().find("simpll__")
-                                    == std::string::npos)
+                    if (!toInline->isIntrinsic() &&
+                            !isSimpllAbstraction(toInline))
                         missingDefs.second = toInline;
                 } else {
                     InlineFunctionInfo ifi;

--- a/diffkemp/simpll/ModuleComparator.h
+++ b/diffkemp/simpll/ModuleComparator.h
@@ -36,6 +36,9 @@ class ModuleComparator {
     std::map<FunPair, Result> ComparedFuns;
     /// Storing results from macro and asm comparisions.
     std::vector<SyntaxDifference> DifferingObjects;
+    /// Storing covered functions names.
+    /// Note: currently only from inlining.
+    std::set<std::string> CoveredFuns;
     // Function abstraction to assembly string map.
     StringMap<StringRef> AsmToStringMapL;
     StringMap<StringRef> AsmToStringMapR;

--- a/diffkemp/simpll/Output.h
+++ b/diffkemp/simpll/Output.h
@@ -18,13 +18,11 @@
 #include "Config.h"
 #include "Utils.h"
 #include "ModuleComparator.h"
+#include "Transforms.h"
 
 /// Report results in YAML format to stdout.
 /// \param config Configuration.
 /// \param nonequalFuns List of non-equal functions.
-void reportOutput(Config &config,
-                  std::vector<FunPair> &nonequalFuns,
-                  std::vector<ConstFunPair> &missingDefs,
-                  std::vector<SyntaxDifference> &differingMacros);
+void reportOutput(Config &config, ComparisonResult &Result);
 
 #endif // DIFFKEMP_SIMPLL_OUTPUT_H

--- a/diffkemp/simpll/SimpLL.cpp
+++ b/diffkemp/simpll/SimpLL.cpp
@@ -43,22 +43,20 @@ int main(int argc, const char **argv) {
                      config.ControlFlowOnly);
     config.refreshFunctions();
 
-    std::vector<FunPair> nonequalFuns;
-    std::vector<ConstFunPair> missingDefs;
-    std::vector<SyntaxDifference> differingMacros;
-    simplifyModulesDiff(config, nonequalFuns, missingDefs, differingMacros);
+    ComparisonResult Result;
+    simplifyModulesDiff(config, Result);
 
-    reportOutput(config, nonequalFuns, missingDefs, differingMacros);
+    reportOutput(config, Result);
 
     // Split list of non-equal function pairs into two sets.
     std::set<Function *> MainFunsFirst;
-    std::transform(nonequalFuns.begin(),
-                   nonequalFuns.end(),
+    std::transform(Result.nonequalFuns.begin(),
+                   Result.nonequalFuns.end(),
                    std::inserter(MainFunsFirst, MainFunsFirst.begin()),
                    [](FunPair &p) { return p.first; });
     std::set<Function *> MainFunsSecond;
-    std::transform(nonequalFuns.begin(),
-                   nonequalFuns.end(),
+    std::transform(Result.nonequalFuns.begin(),
+                   Result.nonequalFuns.end(),
                    std::inserter(MainFunsSecond, MainFunsSecond.begin()),
                    [](FunPair &p) { return p.second; });
 

--- a/diffkemp/simpll/Transforms.cpp
+++ b/diffkemp/simpll/Transforms.cpp
@@ -104,10 +104,7 @@ void preprocessModule(Module &Mod,
 /// 3. Using debug information to compute offsets of the corresponding GEP
 ///    indices. Offsets are stored inside LLVM metadata.
 /// 4. Removing bodies of functions that are syntactically equivalent.
-void simplifyModulesDiff(Config &config,
-                         std::vector<FunPair> &nonequalFuns,
-                         std::vector<ConstFunPair> &missingDefs,
-                         std::vector<SyntaxDifference> &differingMacros) {
+void simplifyModulesDiff(Config &config, ComparisonResult &Result) {
     // Generate abstractions of indirect function calls and for inline
     // assemblies.
     AnalysisManager<Module, Function *> mam(false);
@@ -168,8 +165,8 @@ void simplifyModulesDiff(Config &config,
         for (auto &funPair : modComp.ComparedFuns) {
             if (funPair.second == ModuleComparator::NOT_EQUAL) {
                 allEqual = false;
-                nonequalFuns.emplace_back(funPair.first.first,
-                                          funPair.first.second);
+                Result.nonequalFuns.emplace_back(funPair.first.first,
+                                                 funPair.first.second);
                 DEBUG_WITH_TYPE(DEBUG_SIMPLL,
                                 dbgs() << funPair.first.first->getName()
                                        << " are syntactically different\n");
@@ -196,8 +193,9 @@ void simplifyModulesDiff(Config &config,
         }
     }
 
-    missingDefs = modComp.MissingDefs;
-    differingMacros = modComp.DifferingObjects;
+    Result.missingDefs = modComp.MissingDefs;
+    Result.differingSynDiffs = modComp.DifferingObjects;
+    Result.coveredFuns = modComp.CoveredFuns;
 }
 
 /// Recursively mark callees of a function with 'alwaysinline' attribute.

--- a/diffkemp/simpll/Transforms.h
+++ b/diffkemp/simpll/Transforms.h
@@ -38,14 +38,20 @@ void preprocessModule(Module &Mod,
                       GlobalVariable *Var,
                       bool ControlFlowOnly);
 
+/// Structure to represent the output value of simplifyModulesDiff containing
+/// several vectors that are all outputs of ModuleComparator.
+struct ComparisonResult {
+    std::vector<FunPair> nonequalFuns;
+    std::vector<ConstFunPair> missingDefs;
+    std::vector<SyntaxDifference> differingSynDiffs;
+    std::set<std::string> coveredFuns;
+};
+
 /// Simplify two corresponding modules for the purpose of their subsequent
 /// semantic difference analysis. Tries to remove all the code that is
 /// syntactically equal between the modules which should decrease the complexity
 /// of the semantic diff.
-void simplifyModulesDiff(Config &config,
-                         std::vector<FunPair> &nonequalFuns,
-                         std::vector<ConstFunPair> &missingDefs,
-                         std::vector<SyntaxDifference> &differingMacros);
+void simplifyModulesDiff(Config &config, ComparisonResult &Result);
 
 /// Preprocessing transformations - run independently on each module at the
 /// end.

--- a/diffkemp/simpll/Utils.cpp
+++ b/diffkemp/simpll/Utils.cpp
@@ -49,6 +49,18 @@ const Function *getCalledFunction(const Value *CalledValue) {
     return fun;
 }
 
+Function *getCalledFunction(Value *CalledValue) {
+    Function *fun = dyn_cast<Function>(CalledValue);
+    if (!fun) {
+        if (auto BitCast = dyn_cast<BitCastOperator>(CalledValue)) {
+            fun = dyn_cast<Function>(BitCast->getOperand(0));
+        } else if (auto Alias = dyn_cast<GlobalAlias>(CalledValue)) {
+            fun = getCalledFunction(Alias->getAliasee());
+        }
+    }
+    return fun;
+}
+
 /// Get name of a type so that it can be used as a variable in Z3.
 std::string typeName(const Type *Type) {
     std::string result;

--- a/diffkemp/simpll/Utils.cpp
+++ b/diffkemp/simpll/Utils.cpp
@@ -49,16 +49,11 @@ const Function *getCalledFunction(const Value *CalledValue) {
     return fun;
 }
 
+/// Extract called function from a called value. Handles situation when the
+/// called value is a bitcast.
 Function *getCalledFunction(Value *CalledValue) {
-    Function *fun = dyn_cast<Function>(CalledValue);
-    if (!fun) {
-        if (auto BitCast = dyn_cast<BitCastOperator>(CalledValue)) {
-            fun = dyn_cast<Function>(BitCast->getOperand(0));
-        } else if (auto Alias = dyn_cast<GlobalAlias>(CalledValue)) {
-            fun = getCalledFunction(Alias->getAliasee());
-        }
-    }
-    return fun;
+    return const_cast<Function *>(getCalledFunction(
+            const_cast<const Value *>(CalledValue)));
 }
 
 /// Get name of a type so that it can be used as a variable in Z3.

--- a/diffkemp/simpll/Utils.h
+++ b/diffkemp/simpll/Utils.h
@@ -44,8 +44,12 @@ struct CallInfo {
 /// Call stack - list of call entries
 typedef std::vector<CallInfo> CallStack;
 
-/// Extract called function from a called value
+/// Extract called function from a called value. Handles situation when the
+/// called value is a bitcast.
 const Function *getCalledFunction(const Value *CalledValue);
+
+/// Extract called function from a called value. Handles situation when the
+/// called value is a bitcast.
 Function *getCalledFunction(Value *CalledValue);
 
 /// Get name of a type.

--- a/diffkemp/simpll/Utils.h
+++ b/diffkemp/simpll/Utils.h
@@ -46,6 +46,7 @@ typedef std::vector<CallInfo> CallStack;
 
 /// Extract called function from a called value
 const Function *getCalledFunction(const Value *CalledValue);
+Function *getCalledFunction(Value *CalledValue);
 
 /// Get name of a type.
 std::string typeName(const Type *Type);

--- a/diffkemp/simpll/passes/FieldAccessFunctionGenerator.cpp
+++ b/diffkemp/simpll/passes/FieldAccessFunctionGenerator.cpp
@@ -176,3 +176,8 @@ void FieldAccessFunctionGenerator::processStack(
     auto ReturnInst = ReturnInst::Create(Abstraction->getContext(),
             &BB->back(), BB);
 }
+
+/// Returns true if the function is an SimpLL field access abstraction.
+bool isSimpllFieldAccessAbstraction(const Function *Fun) {
+    return Fun->getName().startswith(SimpllFieldAccessFunName);
+}

--- a/diffkemp/simpll/passes/FieldAccessFunctionGenerator.h
+++ b/diffkemp/simpll/passes/FieldAccessFunctionGenerator.h
@@ -36,4 +36,7 @@ class FieldAccessFunctionGenerator
     void processStack(const std::vector<Instruction *> &Stack, Module &Mod);
 };
 
+/// Returns true if the function is an SimpLL field access abstraction.
+bool isSimpllFieldAccessAbstraction(const Function *Fun);
+
 #endif //DIFFKEMP_SIMPLL_FIELDACCESSFUNCTIONGENERATOR_H

--- a/diffkemp/simpll/passes/FunctionAbstractionsGenerator.cpp
+++ b/diffkemp/simpll/passes/FunctionAbstractionsGenerator.cpp
@@ -13,6 +13,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "CalledFunctionsAnalysis.h"
+#include "FieldAccessFunctionGenerator.h"
 #include "FunctionAbstractionsGenerator.h"
 #include "Utils.h"
 #include <llvm/IR/InlineAsm.h>
@@ -152,4 +153,10 @@ bool trySwap(FunctionAbstractionsGenerator::FunMap &Map,
 bool isSimpllAbstractionDeclaration(const Function *Fun) {
     return Fun->getName().startswith(SimpllIndirectFunctionPrefix) ||
            Fun->getName().startswith(SimpllInlineAsmPrefix);
+}
+
+/// Returns true if the function is a SimpLL abstraction.
+bool isSimpllAbstraction(const Function *Fun) {
+    return isSimpllAbstractionDeclaration(Fun) ||
+           isSimpllFieldAccessAbstraction(Fun);
 }

--- a/diffkemp/simpll/passes/FunctionAbstractionsGenerator.h
+++ b/diffkemp/simpll/passes/FunctionAbstractionsGenerator.h
@@ -57,4 +57,7 @@ class FunctionAbstractionsGenerator
 /// FunctionAbstractionsGenerator.
 bool isSimpllAbstractionDeclaration(const Function *Fun);
 
+/// Returns true if the function is a SimpLL abstraction.
+bool isSimpllAbstraction(const Function *Fun);
+
 #endif //DIFFKEMP_SIMPLL_FUNCTIONABSTRACTIONSGENERATOR_H

--- a/diffkemp/simpll/passes/MergeNumberedFunctionsPass.cpp
+++ b/diffkemp/simpll/passes/MergeNumberedFunctionsPass.cpp
@@ -27,7 +27,7 @@ PreservedAnalyses MergeNumberedFunctionsPass::run(Module &Mod,
     // Go over all called functions and put them into the map. Functions without
     // a suffix are included, too, because there may be variants that have it.
     for (Function &Fun : Mod) {
-        if (Fun.getName().startswith("simpll__") ||
+        if (isSimpllAbstraction(&Fun) ||
                 Fun.getName().startswith("llvm."))
             // Do not merge LLVM intrinsics and SimpLL abstractions.
             continue;

--- a/diffkemp/simpll/simpll.py
+++ b/diffkemp/simpll/simpll.py
@@ -88,7 +88,7 @@ def simplify_modules_diff(first, second, fun_first, fun_second, var,
                                      for call in fun["callstack"]])
                                 if "callstack" in fun else "",
                                 fun["is-syn-diff"],
-                                fun["covered-by-syn-diff"]
+                                fun["covered"]
                             )
                             for fun in [fun_pair_yaml["first"],
                                         fun_pair_yaml["second"]]


### PR DESCRIPTION
The problem was that there were some cases when the call instructions
differed in a way that didn't show up in the C source code (e.g. the
return type changed without affecting the call), leading to inlining,
but the original difference was inside the inlined function (and after
the inlining it was reported in the parent one).

The fix uses a similar technique to syntax difference handling - in case
two functions with the same name are being inlined, they are compared
using ModuleComparator and in case both the original and the inlined
functions are compared as non-equal, the difference between the original
ones is marked as covered (in case the original functions are equal after
the inlining, the difference of the inlined function is removed.

Note: the variables `missingDefs`, `nonequalFuns` and `differingSynDiffs`, which are present at several locations in DiffKemp (in SimpLL.cpp, arguments of the functions `simplifyModulesDiff` and `reportOutput`) and share the fact that they are all main and additonal information generated by ModuleComparator (in which they have the same type, only slightly different names), are merged into a structure type called `ComparisonResult`, including the newly introduced set `coveredFuns`.
Also following this change `coveredBySyntaxDiff` was renamed to `covered` at all places, since it now represents two different types of diff covering.