### PR TITLE
SimpLL: Fix bug in findInlineAssemblySourceArguments.

### DIFF
--- a/diffkemp/simpll/SourceCodeUtils.cpp
+++ b/diffkemp/simpll/SourceCodeUtils.cpp
@@ -561,6 +561,9 @@ std::vector<std::string> findInlineAssemblySourceArguments(DILocation *LineLoc,
 
     while (position < int(rawArguments.size())) {
         position = rawArguments.find('(', position + 1);
+        if (position == std::string::npos)
+            // There is no additional bracket.
+            break;
         std::string argument =
                 getSubstringToMatchingBracket(rawArguments, position);
         if (argument.empty() || (argument.size() == 1 && argument[0] == 0)) {


### PR DESCRIPTION
The problem was in the code that extracts inline assembly arguments
from C source code - it didn't check whether a starting bracket was
found and the value was passed directly to getSubstringToMatchingBracket.

Note: the problem didn't appear when using a standard C++ library that
does not assert on invalid string index.