### PR TITLE
Travis CI: move code format checks into a separate job

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,12 +2,29 @@ language: python
 python: 3.6
 dist: xenial
 
-env:
-  - LLVM_VERSION=5.0
-  - LLVM_VERSION=6.0
-  - LLVM_VERSION=7
-  - LLVM_VERSION=8
-  - LLVM_VERSION=9
+jobs:
+  include:
+    - env: NAME="Code style checks" LLVM_VERSION=8
+      addons:
+        apt:
+          sources:
+            - sourceline: "deb http://apt.llvm.org/xenial/ llvm-toolchain-xenial-8 main"
+              key_url: "https://apt.llvm.org/llvm-snapshot.gpg.key"
+      before_install:
+        - sudo apt-get install -y clang-format-$LLVM_VERSION
+        - sudo update-alternatives --install /usr/local/bin/clang-format clang-format /usr/bin/clang-format-$LLVM_VERSION 100
+        - export PATH=`echo $PATH | sed -e 's#:/usr/local/clang-7.0.0/bin##'`
+      install:
+      before_script:
+      script:
+        - flake8 diffkemp --exclude=llreve --ignore=F403,F405,W504
+        - flake8 tests
+        - tools/check-clang-format.sh -d
+    - env: LLVM_VERSION=5.0
+    - env: LLVM_VERSION=6.0
+    - env: LLVM_VERSION=7
+    - env: LLVM_VERSION=8
+    - env: LLVM_VERSION=9
 
 addons:
   apt:
@@ -32,12 +49,11 @@ addons:
       - rpm2cpio
 
 before_install:
-  - sudo apt-get install -y clang-$LLVM_VERSION clang-format-8 llvm-$LLVM_VERSION llvm-$LLVM_VERSION-dev
+  - sudo apt-get install -y clang-$LLVM_VERSION llvm-$LLVM_VERSION llvm-$LLVM_VERSION-dev
   - sudo ln -s /usr/lib/llvm-$LLVM_VERSION/include/llvm /usr/local/include/llvm
   - sudo ln -s /usr/lib/llvm-$LLVM_VERSION/include/llvm-c /usr/local/include/llvm-c
   - sudo update-alternatives --install /usr/local/bin/llvm-config llvm-config /usr/bin/llvm-config-$LLVM_VERSION 100
   - sudo update-alternatives --install /usr/local/bin/clang clang /usr/bin/clang-$LLVM_VERSION 100
-  - sudo update-alternatives --install /usr/local/bin/clang-format clang-format /usr/bin/clang-format-8 100
   - sudo update-alternatives --install /usr/local/bin/opt opt /usr/bin/opt-$LLVM_VERSION 100
   - sudo update-alternatives --install /usr/local/bin/llvm-link llvm-link /usr/bin/llvm-link-$LLVM_VERSION 100
   - sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-7 100 --slave /usr/bin/g++ g++ /usr/bin/g++-7
@@ -64,6 +80,4 @@ before_script:
 
 script:
   - pytest tests
-  - flake8 diffkemp --exclude=llreve --ignore=F403,F405,W504
-  - flake8 tests
-  - tools/check-clang-format.sh -d
+


### PR DESCRIPTION
This can be useful if code format checks fail since there is no need to re-run tests for all versions, which takes a long time.