### PR TITLE
SimpLL: clean messages printed by passes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -94,6 +94,7 @@ venv.bak/
 
 ### IDE part ###
 .idea
+.DS_Store
 cmake-build-debug/
 
 # Vim files

--- a/diffkemp/simpll/DebugInfo.cpp
+++ b/diffkemp/simpll/DebugInfo.cpp
@@ -161,10 +161,12 @@ void DebugInfo::extractAlignmentFromInstructions(GetElementPtrInst *GEP,
                                                (unsigned)indexSecond,
                                                IndexConstant->getBitWidth(),
                                                ModFirst.getContext());
+                        DEBUG_WITH_TYPE(
+                                DEBUG_SIMPLL,
+                                dbgs() << "Index alignment in:" << *GEP << "\n"
+                                       << "                     " << indexFirst
+                                       << " -> " << indexSecond << "\n");
                     }
-
-                    DEBUG_WITH_TYPE(DEBUG_SIMPLL, GEP->print(dbgs()));
-
                     // Insert the names of the indices into StructFieldNames.
                     StructFieldNames.insert(
                             {{dyn_cast<StructType>(indexedType), indexFirst},
@@ -181,10 +183,6 @@ void DebugInfo::extractAlignmentFromInstructions(GetElementPtrInst *GEP,
                                           indexedType->getStructName()),
                                   indexSecond},
                                  elementName});
-
-                    DEBUG_WITH_TYPE(DEBUG_SIMPLL,
-                                    dbgs() << "New index: " << indexSecond
-                                           << "\n");
                 }
             }
 

--- a/diffkemp/simpll/Transforms.cpp
+++ b/diffkemp/simpll/Transforms.cpp
@@ -150,9 +150,6 @@ void simplifyModulesDiff(Config &config, ComparisonResult &Result) {
                                                         config.FirstFun),
                  mam.getResult<CalledFunctionsAnalysis>(*config.Second,
                                                         config.SecondFun));
-    DEBUG_WITH_TYPE(DEBUG_SIMPLL,
-                    dbgs() << "StructFieldNames size: "
-                           << DI.StructFieldNames.size() << "\n");
 
     // Compare functions for syntactical equivalence
     ModuleComparator modComp(*config.First,

--- a/diffkemp/simpll/passes/ControlFlowSlicer.cpp
+++ b/diffkemp/simpll/passes/ControlFlowSlicer.cpp
@@ -14,6 +14,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "ControlFlowSlicer.h"
+#include "Config.h"
 #include "Utils.h"
 #include <llvm/IR/Constants.h>
 #include <llvm/IR/Instructions.h>
@@ -135,8 +136,16 @@ PreservedAnalyses ControlFlowSlicer::run(Function &Fun,
             }
         }
     }
-    for (auto &Instr : ToRemove)
-        Instr->eraseFromParent();
 
+    if (!ToRemove.empty()) {
+        DEBUG_WITH_TYPE(DEBUG_SIMPLL,
+                        dbgs() << "Removed instructions from " << Fun.getName()
+                               << ": \n");
+    }
+
+    for (auto &Instr : ToRemove) {
+        DEBUG_WITH_TYPE(DEBUG_SIMPLL, dbgs() << *Instr << "\n";);
+        Instr->eraseFromParent();
+    }
     return PreservedAnalyses::none();
 }

--- a/diffkemp/simpll/passes/FunctionAbstractionsGenerator.cpp
+++ b/diffkemp/simpll/passes/FunctionAbstractionsGenerator.cpp
@@ -104,7 +104,10 @@ FunctionAbstractionsGenerator::Result FunctionAbstractionsGenerator::run(
                     auto newCall =
                             CallInst::Create(newFun, args, "", CallInstr);
                     newCall->setDebugLoc(CallInstr->getDebugLoc());
-
+                    DEBUG_WITH_TYPE(DEBUG_SIMPLL,
+                                    dbgs() << "Replacing :" << *CallInstr
+                                           << "\n     with :" << *newCall
+                                           << "\n");
                     CallInstr->replaceAllUsesWith(newCall);
                     toErase.push_back(&Instr);
                 }

--- a/diffkemp/simpll/passes/RemoveUnusedReturnValuesPass.cpp
+++ b/diffkemp/simpll/passes/RemoveUnusedReturnValuesPass.cpp
@@ -219,9 +219,12 @@ PreservedAnalyses RemoveUnusedReturnValuesPass::run(
                 CI_New->setCallingConv(CI->getCallingConv());
                 if (CI->isTailCall())
                     CI_New->setTailCall();
-                DEBUG_WITH_TYPE(DEBUG_SIMPLL,
-                                dbgs() << "Replacing :" << *CI << " with "
-                                       << *CI_New << "\n");
+                DEBUG_WITH_TYPE(DEBUG_SIMPLL, increaseDebugIndentLevel();
+                                dbgs() << getDebugIndent()
+                                       << "Replacing :" << *CI << "\n"
+                                       << getDebugIndent()
+                                       << "     with :" << *CI_New << "\n";
+                                decreaseDebugIndentLevel());
                 // Erase the old instruction
                 CI->eraseFromParent();
             } else if (InvokeInst *II = dyn_cast<InvokeInst>(I)) {
@@ -254,9 +257,12 @@ PreservedAnalyses RemoveUnusedReturnValuesPass::run(
                         cleanAttributeList(II_New->getAttributes()));
                 II_New->setDebugLoc(II->getDebugLoc());
                 II_New->setCallingConv(II->getCallingConv());
-                DEBUG_WITH_TYPE(DEBUG_SIMPLL,
-                                dbgs() << "Replacing :" << *II << " with "
-                                       << *II_New << "\n");
+                DEBUG_WITH_TYPE(DEBUG_SIMPLL, increaseDebugIndentLevel();
+                                dbgs() << getDebugIndent()
+                                       << "Replacing :" << *II << "\n"
+                                       << getDebugIndent()
+                                       << "     with :" << *II_New << "\n";
+                                decreaseDebugIndentLevel());
                 // Erase the old instruction
                 II->eraseFromParent();
             }

--- a/diffkemp/simpll/passes/UnifyMemcpyPass.cpp
+++ b/diffkemp/simpll/passes/UnifyMemcpyPass.cpp
@@ -27,7 +27,6 @@ PreservedAnalyses UnifyMemcpyPass::run(Function &Fun,
                     continue;
 
                 if (CalledFun->getName() == "__memcpy") {
-                    DEBUG_WITH_TYPE(DEBUG_SIMPLL, Call->print(dbgs()));
                     // Replace call to __memcpy by llvm.memcpy intrinsic
                     IRBuilder<> builder(&Instr);
 #if LLVM_VERSION_MAJOR < 7


### PR DESCRIPTION
- ControlFlowSlicer: print of which instructions are removed by the pass.
- FunctionAbstractionsGenerator: print which call instruction is replaced by which abstraction
- RemoveUnusedReturnValuesPass: indent messages about replacing of call instructions so that it is clear which function they belong to. Remove unnecessary messages.
- UnifyMemcpyPass: Remove all messages (they are not useful).

Closes #68 