### PR TITLE
SimpLL: Better call comparison.

### DIFF
--- a/diffkemp/simpll/DifferentialFunctionComparator.h
+++ b/diffkemp/simpll/DifferentialFunctionComparator.h
@@ -121,6 +121,17 @@ class DifferentialFunctionComparator : public FunctionComparator {
     /// Check if the given operation can be ignored (it does not affect
     /// semantics) for control flow only diffs.
     bool mayIgnore(const Instruction *Inst) const;
+
+    /// Does additional operations in cases when a difference between two
+    /// CallInsts or their arguments is detected.
+    /// This consists of three parts:
+    /// 1. Compare the called functions using cmpGlobalValues (covers case when
+    /// they are not compared in cmpBasicBlocks because there is another
+    /// difference).
+    /// 2. Try to inline the functions.
+    /// 3. Look a macro-function differenfce.
+    void processCallInstDifference(const CallInst *CL,
+                                   const CallInst *CR) const;
 };
 
 #endif // DIFFKEMP_SIMPLL_DIFFERENTIALFUNCTIONCOMPARATOR_H

--- a/diffkemp/simpll/ModuleComparator.cpp
+++ b/diffkemp/simpll/ModuleComparator.cpp
@@ -108,12 +108,6 @@ void ModuleComparator::compareFunctions(Function *FirstFun,
 
             ConstFunPair missingDefs;
             bool inlined = false;
-            // If inlining two functions with the same name, it is possible that
-            // there is a difference in their bodies and only a formal
-            // difference that won't show up in the syntax diff.
-            // For this reason, the functions are compared using
-            // ModuleComparator and the original functions are marked as
-            // covered, leading to the diff not being show when empty.
             Function *InlinedFunFirst =
                     !inlineFirst
                             ? nullptr
@@ -122,15 +116,6 @@ void ModuleComparator::compareFunctions(Function *FirstFun,
                     !inlineSecond
                             ? nullptr
                             : getCalledFunction(inlineSecond->getCalledValue());
-            if (InlinedFunFirst && InlinedFunSecond
-                && !isSimpllAbstraction(InlinedFunFirst)
-                && (InlinedFunFirst->getName()
-                    == InlinedFunSecond->getName())) {
-                compareFunctions(InlinedFunFirst, InlinedFunSecond);
-                if (ComparedFuns.at({InlinedFunFirst, InlinedFunSecond})
-                    == Result::NOT_EQUAL)
-                    CoveredFuns.insert(FirstFun->getName().str());
-            }
             // If the called function is a declaration, add it to missingDefs.
             // Otherwise, inline the call and simplify the function.
             // The above is done for the first and the second call to inline.


### PR DESCRIPTION
If the call instructions have a difference that is detected before the
code get to the comparison of the functions itself, call cmpGlobalValues
to explicitly compare them and mark the parent function as covered in
case cmpGlobalValues returns zero. (This prevents false empty diffs in
cases when the difference in the parent function is actually in the
called function in the C source code.)

Fixes #120.