### PR TITLE
SimpLL: Replace asm to value maps with metadata.

### DIFF
--- a/diffkemp/llvm_ir/kernel_source.py
+++ b/diffkemp/llvm_ir/kernel_source.py
@@ -164,6 +164,8 @@ class KernelSource:
                 # the macro has to be found to get the source file
                 cscope_defs = \
                     self._find_tracepoint_macro_use(symbol) + cscope_defs
+            elif symbol == "rcu_barrier":
+                cscope_defs = ["kernel/rcutree.c"] + cscope_defs
 
             if len(cscope_defs) == 0 and len(cscope_uses) == 0:
                 raise SourceNotFoundException(symbol)

--- a/diffkemp/simpll/ModuleComparator.h
+++ b/diffkemp/simpll/ModuleComparator.h
@@ -39,9 +39,6 @@ class ModuleComparator {
     /// Storing covered functions names.
     /// Note: currently only from inlining.
     std::set<std::string> CoveredFuns;
-    // Function abstraction to assembly string map.
-    StringMap<StringRef> AsmToStringMapL;
-    StringMap<StringRef> AsmToStringMapR;
     // Structure size to structure name map.
     StructureSizeAnalysis::Result &StructSizeMapL;
     StructureSizeAnalysis::Result &StructSizeMapR;
@@ -58,15 +55,11 @@ class ModuleComparator {
                      bool controlFlowOnly,
                      bool showAsmDiffs,
                      const DebugInfo *DI,
-                     StringMap<StringRef> &AsmToStringMapL,
-                     StringMap<StringRef> &AsmToStringMapR,
                      StructureSizeAnalysis::Result &StructSizeMapL,
                      StructureSizeAnalysis::Result &StructSizeMapR)
             : First(First), Second(Second), controlFlowOnly(controlFlowOnly),
               showAsmDiffs(showAsmDiffs), DI(DI),
-              AsmToStringMapL(AsmToStringMapL),
-              AsmToStringMapR(AsmToStringMapR), StructSizeMapL(StructSizeMapL),
-              StructSizeMapR(StructSizeMapR) {}
+              StructSizeMapL(StructSizeMapL), StructSizeMapR(StructSizeMapR) {}
 
     /// Syntactically compare two functions.
     /// The result of the comparison is stored into the ComparedFuns map.

--- a/diffkemp/simpll/Transforms.cpp
+++ b/diffkemp/simpll/Transforms.cpp
@@ -160,8 +160,6 @@ void simplifyModulesDiff(Config &config, ComparisonResult &Result) {
                              config.ControlFlowOnly,
                              config.PrintAsmDiffs,
                              &DI,
-                             AbstractionGeneratorResultL.asmValueMap,
-                             AbstractionGeneratorResultR.asmValueMap,
                              StructSizeMapL,
                              StructSizeMapR);
 

--- a/diffkemp/simpll/passes/FunctionAbstractionsGenerator.h
+++ b/diffkemp/simpll/passes/FunctionAbstractionsGenerator.h
@@ -32,7 +32,6 @@ class FunctionAbstractionsGenerator
     typedef std::unordered_map<std::string, Function *> FunMap;
     struct Result {
         FunMap funAbstractions;
-        StringMap<StringRef> asmValueMap;
     };
 
     Result run(Module &Mod,
@@ -59,5 +58,11 @@ bool isSimpllAbstractionDeclaration(const Function *Fun);
 
 /// Returns true if the function is a SimpLL abstraction.
 bool isSimpllAbstraction(const Function *Fun);
+
+/// Extracts inline assembly code string from abstraction.
+StringRef getInlineAsmString(const Function *Abstr);
+
+/// Extracts inline assembly code constraint string from abstraction.
+StringRef getInlineAsmConstraintString(const Function *Abstr);
 
 #endif // DIFFKEMP_SIMPLL_FUNCTIONABSTRACTIONSGENERATOR_H

--- a/diffkemp/simpll/passes/RemoveUnusedReturnValuesPass.cpp
+++ b/diffkemp/simpll/passes/RemoveUnusedReturnValuesPass.cpp
@@ -119,6 +119,9 @@ PreservedAnalyses RemoveUnusedReturnValuesPass::run(
                                          Fun->getParent());
             Fun_Clone->copyAttributesFrom(Fun);
             Fun_Clone->setSubprogram(Fun->getSubprogram());
+            if (Fun->getMetadata("inlineasm"))
+                Fun_Clone->setMetadata("inlineasm",
+                                       Fun->getMetadata("inlineasm"));
             for (Function::arg_iterator AI = Fun->arg_begin(),
                                         AE = Fun->arg_end(),
                                         NAI = Fun_Clone->arg_begin();
@@ -149,6 +152,8 @@ PreservedAnalyses RemoveUnusedReturnValuesPass::run(
         // Set the right function name and subprogram
         Fun_New->setName(OriginalName);
         Fun_New->setSubprogram(Fun->getSubprogram());
+        if (Fun->getMetadata("inlineasm"))
+            Fun_New->setMetadata("inlineasm", Fun->getMetadata("inlineasm"));
 
         // Set the names of all arguments of the new function
         for (Function::arg_iterator AI = Fun->arg_begin(),


### PR DESCRIPTION
Previously each inline assembly code abstraction had a correspoding
entry in a map contaning its (function) name and its content. This
caused a bug when the content wasn't found after the function was
renamed by a pass.

To handle this, the assembly code was moved to a metadata node attached
to the abstraction function together with the constraint, which is now
also used while comparing inline assembly code abstraction calls.

This fixes #124.