### PR TITLE
SimpLL: fix bug in CalledFunctionsAnalysis

### DIFF
--- a/diffkemp/simpll/passes/CalledFunctionsAnalysis.cpp
+++ b/diffkemp/simpll/passes/CalledFunctionsAnalysis.cpp
@@ -15,6 +15,7 @@
 #include "CalledFunctionsAnalysis.h"
 #include "Utils.h"
 #include <llvm/IR/Instructions.h>
+#include <llvm/IR/Operator.h>
 #include <llvm/IR/User.h>
 
 AnalysisKey CalledFunctionsAnalysis::Key;
@@ -45,17 +46,7 @@ void CalledFunctionsAnalysis::collectCalled(const Function *Fun,
                 }
             }
             for (auto &Op : Inst.operands()) {
-                if (auto *CalledFun = getCalledFunction(Op))
-                    collectCalled(CalledFun, Called);
-                if (isa<GlobalVariable>(Op)) {
-                    auto GV = dyn_cast<GlobalVariable>(&Op);
-                    if (GV->hasInitializer() && GV->isConstant()) {
-                        // The initializer is constant - see whether it contains
-                        // a function (or a user type constant that contains
-                        // a function).
-                        processValue(GV->getInitializer(), Called);
-                    }
-                }
+                processValue(Op, Called);
             }
         }
     }
@@ -64,11 +55,21 @@ void CalledFunctionsAnalysis::collectCalled(const Function *Fun,
 /// Looks for functions in a value (either a function itself, or a composite
 /// type constant).
 void CalledFunctionsAnalysis::processValue(const Value *Val, Result &Called) {
-    if (auto Fun = dyn_cast<Function>(Val))
+    if (auto Fun = getCalledFunction(Val))
         collectCalled(Fun, Called);
-    else if (auto U = dyn_cast<User>(Val)) {
-        for (auto &Value : U->operands()) {
-            processValue(Value.get(), Called);
-        }
+    else if (auto GV = dyn_cast<GlobalVariable>(Val)) {
+        if (GV->hasInitializer() && GV->isConstant())
+            // The initializer is constant - see whether it contains
+            // a function (or a user type constant that contains
+            // a function).
+            if (auto U = dyn_cast<User>(GV->getInitializer())) {
+                for (auto &UserOp : U->operands()) {
+                    processValue(UserOp.get(), Called);
+                }
+            } else {
+                processValue(GV->getInitializer(), Called);
+            }
+    } else if (auto BitCast = dyn_cast<BitCastOperator>(Val)) {
+        processValue(BitCast->getOperand(0), Called);
     }
 }


### PR DESCRIPTION
Before this fix, if a function was stored inside a global constant that was used in a bitcast operator, the function was not added to called functions (due to missing support of the bitcast operator).

This bug caused an error in comparing `2.6.32-696.el6` and `2.6.32-754.el6` in function `shmem_file_setup`.