### PR TITLE
Remove debug hashes

### DIFF
--- a/diffkemp/llvm_ir/build_llvm.py
+++ b/diffkemp/llvm_ir/build_llvm.py
@@ -92,6 +92,14 @@ class LlvmKernelBuilder:
                     param.endswith(".o")):
                 continue
 
+            # Do not use generated debug hashes.
+            # Note: they are used for debugging purposes only and cause false
+            # positives in SimpLL.
+            if param.startswith('-D"DEBUG_HASH='):
+                param = '-D"DEBUG_HASH=1"'
+            if param.startswith('-D"DEBUG_HASH2='):
+                param = '-D"DEBUG_HASH2=1"'
+
             # Output name is given by replacing .c by .ll in source name
             if param.endswith(".c"):
                 output_file = "{}.ll".format(param[:-2])

--- a/diffkemp/simpll/passes/CalledFunctionsAnalysis.cpp
+++ b/diffkemp/simpll/passes/CalledFunctionsAnalysis.cpp
@@ -62,14 +62,14 @@ void CalledFunctionsAnalysis::processValue(const Value *Val, Result &Called) {
             // The initializer is constant - see whether it contains
             // a function (or a user type constant that contains
             // a function).
-            if (auto U = dyn_cast<User>(GV->getInitializer())) {
-                for (auto &UserOp : U->operands()) {
-                    processValue(UserOp.get(), Called);
-                }
-            } else {
-                processValue(GV->getInitializer(), Called);
-            }
+            processValue(GV->getInitializer(), Called);
     } else if (auto BitCast = dyn_cast<BitCastOperator>(Val)) {
         processValue(BitCast->getOperand(0), Called);
+    } else if (isa<Constant>(Val)) {
+        if (auto U = dyn_cast<User>(Val)) {
+            for (auto &UserOp : U->operands()) {
+                processValue(UserOp.get(), Called);
+            }
+        }
     }
 }


### PR DESCRIPTION
The value of the macros DEBUG_HASH and DEBUG_HASH2 is generated by
Kbuild, does not represent a semantic difference (other that for
debugging purposes) and breaks comparison, because the macro is outside
a call instruction and therefore can't be detected by SourceCodeUtils in
SimpLL.

Therefore the generate phase is modified not to use the generate value
and use 1 instead for all modules in the kernel.

Also includes a small enchancement of CalledFunctionsAnalysis.

Note: the debug hashes caused a large number of false positives between versions `2.6.32-696.el6` and `2.6.32-754.el6`.