### PR TITLE
SimpLL: fix bug in DifferentialFunctionComparator

### DIFF
--- a/diffkemp/simpll/DifferentialFunctionComparator.cpp
+++ b/diffkemp/simpll/DifferentialFunctionComparator.cpp
@@ -198,6 +198,8 @@ int DifferentialFunctionComparator::cmpOperations(
             if (CalledL && CalledR) {
                 if (isSimpllFieldAccessAbstraction(CalledL)
                     && isSimpllFieldAccessAbstraction(CalledR)
+                    && isa<PointerType>(CL->getType())
+                    && isa<PointerType>(CR->getType())
                     && (dyn_cast<PointerType>(CL->getType())->getElementType()
                         != dyn_cast<PointerType>(CR->getType())
                                    ->getElementType())) {

--- a/tests/regression/test_specs/rhel-75-76.yaml
+++ b/tests/regression/test_specs/rhel-75-76.yaml
@@ -21,6 +21,7 @@ functions:
         __read_seqcount_begin: equal_syntax
         skb_csum_hwoffload_help: equal_syntax
         proc_put_char: equal_syntax
+        __alloc_percpu: equal_syntax
 
 sysctls:
   - sysctl: net.core.netdev_rss_key


### PR DESCRIPTION
Due to previous commit, it is possible that a call instruction type is NULL while the called function can be found. Use type of the called function instead of the instruction type when needed.