### PR TITLE
Tests for correctness of syntax diffs

### DIFF
--- a/tests/regression/syntax_diff_test.py
+++ b/tests/regression/syntax_diff_test.py
@@ -1,0 +1,100 @@
+"""
+Regression test using pytest.
+Tests are specified using YAML files in the tests/test_specs directory.
+This module runs tests for syntax differences using the "syntax_diffs" key in
+the YAML spec file.
+"""
+from diffkemp.semdiff.function_diff import functions_diff
+from .task_spec import SyntaxDiffSpec, specs_path, tasks_path
+import glob
+import os
+import pytest
+import re
+import yaml
+
+
+def collect_task_specs():
+    """Collecting and parsing YAML files with test specifications."""
+    result = list()
+    if not os.path.isdir(tasks_path):
+        os.mkdir(tasks_path)
+    cwd = os.getcwd()
+    os.chdir(specs_path)
+    for spec_file_path in glob.glob("*.yaml"):
+        with open(spec_file_path, "r") as spec_file:
+            try:
+                spec_yaml = yaml.safe_load(spec_file)
+                spec_file_name = os.path.splitext(spec_file_path)[0]
+                if "disabled" in spec_yaml and spec_yaml["disabled"] is True:
+                    continue
+                # Parse only the "syntax_diffs" key. Each syntax_diffs entry
+                # gets a single TaskSpec object.
+                if "syntax_diffs" in spec_yaml:
+                    for syntax_diff in spec_yaml["syntax_diffs"]:
+                        spec = SyntaxDiffSpec(
+                            spec=spec_yaml,
+                            task_name=syntax_diff["diff_symbol"],
+                            tasks_path=tasks_path,
+                            kernel_path=cwd)
+
+                        spec.add_function_spec(syntax_diff["function"],
+                                               "not_equal")
+                        spec.add_syntax_diff_spec(syntax_diff["diff_symbol"],
+                                                  syntax_diff["def_old"],
+                                                  syntax_diff["def_new"])
+
+                        spec_id = "{}_{}".format(spec_file_name,
+                                                 syntax_diff["diff_symbol"])
+                        result.append((spec_id, spec))
+
+            except yaml.YAMLError:
+                pass
+    os.chdir(cwd)
+    return result
+
+
+specs = collect_task_specs()
+
+
+@pytest.fixture(params=[x[1] for x in specs],
+                ids=[x[0] for x in specs])
+def task_spec(request):
+    """pytest fixture to prepare tasks"""
+    spec = request.param
+    for fun in spec.functions:
+        mod_old, mod_new = spec.build_modules_for_function(fun)
+        spec.prepare_dir(
+            old_module=mod_old,
+            old_src="{}.c".format(mod_old.llvm[:-3]),
+            new_module=mod_new,
+            new_src="{}.c".format(mod_new.llvm[:-3]))
+    yield spec
+    spec.finalize()
+
+
+def test_syntax_diff(task_spec):
+    """
+    Test correctness of the obtained syntax diff.
+    The expected difference is obtained by concatenation of symbol
+    definitions in the compared versions, which is the way that DiffKemp uses
+    for displaying diffs of macros and inline assemblies.
+    Function differences are displayed using the diff utility and this test
+    cannot be currently used to verify them.
+    """
+    for fun_spec in task_spec.functions.values():
+        result = functions_diff(
+            mod_first=fun_spec.old_module,
+            mod_second=fun_spec.new_module,
+            fun_first=fun_spec.name, fun_second=fun_spec.name,
+            glob_var=None, config=task_spec.config)
+        assert result.kind == fun_spec.result
+
+        for symbol, symbol_result in result.inner.items():
+            if symbol in task_spec.syntax_diffs:
+                diff_spec = task_spec.syntax_diffs[symbol]
+                # Compare the obtained diff with the expected one, omitting
+                # all whitespace
+                actual_diff = re.sub(r"\s+", "", symbol_result.diff)
+                expected_diff = re.sub(r"\s+", "",
+                                       diff_spec.def_old + diff_spec.def_new)
+                assert actual_diff == expected_diff

--- a/tests/regression/task_spec.py
+++ b/tests/regression/task_spec.py
@@ -180,3 +180,29 @@ class ModuleParamSpec(TaskSpec):
     def get_param(self):
         """Get the name of the global variable representing the parameter."""
         return self.old_module.find_param_var(self.param)
+
+
+class DiffSpec:
+    """
+    Specification of a syntax difference. Contains the name of the differing
+    symbol and its old and new definition.
+    """
+    def __init__(self, symbol, def_old, def_new):
+        self.symbol = symbol
+        self.def_old = def_old
+        self.def_new = def_new
+
+
+class SyntaxDiffSpec(TaskSpec):
+    """
+    Task specification for test of syntax difference.
+    Extends TaskSpec by concrete syntax differences that should be found by
+    DiffKemp. These are currently intended to be macros or inline assemblies.
+    """
+    def __init__(self, spec, task_name, tasks_path, kernel_path):
+        TaskSpec.__init__(self, spec, task_name, tasks_path, kernel_path)
+        self.syntax_diffs = dict()
+
+    def add_syntax_diff_spec(self, symbol, def_old, def_new):
+        """Add an expected syntax difference"""
+        self.syntax_diffs[symbol] = DiffSpec(symbol, def_old, def_new)

--- a/tests/regression/test_specs/rhel-73-74.yaml
+++ b/tests/regression/test_specs/rhel-73-74.yaml
@@ -7,3 +7,11 @@ functions:
         debugfs_create_u32: equal_syntax
         up_read: equal_syntax
 
+syntax_diffs:
+  - function: numa_node_id
+    diff_symbol: __this_cpu_read_8
+    def_old: >
+      percpu_from_op("mov", (pcp), "m"(pcp))
+    def_new: >
+      percpu_from_op("mov", pcp)
+

--- a/tests/regression/test_specs/rhel-74-75.yaml
+++ b/tests/regression/test_specs/rhel-74-75.yaml
@@ -11,3 +11,10 @@ functions:
         skb_queue_head: equal_syntax
         dev_get_stats: equal_syntax
 
+syntax_diffs:
+  - function: pgd_present
+    diff_symbol: __PHYSICAL_MASK
+    def_old: >
+      ((phys_addr_t)((1ULL << __PHYSICAL_MASK_SHIFT) - 1))
+    def_new: >
+      ((phys_addr_t)(__sme_clr((1ULL << __PHYSICAL_MASK_SHIFT) - 1)))

--- a/tests/regression/test_specs/rhel-75-76.yaml
+++ b/tests/regression/test_specs/rhel-75-76.yaml
@@ -31,3 +31,48 @@ sysctls:
       functions:
         netdev_rss_key_fill: equal_syntax
         proc_do_rss_key: equal_syntax
+
+syntax_diffs:
+  - function: __free_slab
+    diff_symbol: for_each_object
+    def_old: >
+      for (__p = (__addr);
+      __p < (__addr) + (__objects) * (__s)->size;
+      __p += (__s)->size)
+    def_new: >
+      for (__p = fixup_red_left(__s, __addr);
+      __p < (__addr) + (__objects) * (__s)->size;
+      __p += (__s)->size)
+
+  - function: pte_to_swp_entry
+    diff_symbol: __swp_offset
+    def_old: >
+      ((x).val >> SWP_OFFSET_FIRST_BIT)
+    def_new: >
+      (~(x).val << SWP_TYPE_BITS >> SWP_OFFSET_SHIFT)
+
+  - function: do_strncpy_from_user
+    diff_symbol: __get_user_asm
+    def_old: >
+      asm volatile(ASM_STAC "\n"
+                   "1:	mov"itype" %2,%"rtype"1\n"
+                   "2: " ASM_CLAC "\n"
+                   ".section .fixup,\"ax\"\n"
+                   "3:	mov %3,%0\n"
+                   "	xor"itype" %"rtype"1,%"rtype"1\n"
+                   "	jmp 2b\n" "
+                   .previous\n"
+                   _ASM_EXTABLE(1b, 3b)
+                   : "=r" (err), ltype(x)
+                   : "m" (__m(addr)), "i" (errret), "0" (err))
+    def_new: >
+      asm volatile("\n"
+                   "1:	mov"itype" %2,%"rtype"1\n"
+                   "2:\n"
+                   ".section .fixup,\"ax\"\n"
+                   "3:	mov %3,%0\n"
+                   "	xor"itype" %"rtype"1,%"rtype"1\n"
+                   "	jmp 2b\n" ".previous\n"
+                   _ASM_EXTABLE(1b, 3b)
+                   : "=r" (err), ltype(x)
+                   : "m" (__m(addr)), "i" (errret), "0" (err))


### PR DESCRIPTION
Add support for regression tests for checking correctness of syntax
diffs. This is implemented as an extension to the existing regression
test infrastructure.
The individual tests can be specified using the "syntax_diff" key in the
appropriate YAML spec file (see existing tests for inspiration).
Currently supports only checking of differences in macros and inline
assembly code.
Includes also few initial tests, tips for additional tests are welcome.