### PR TITLE
Linking externally defined global constants 

### DIFF
--- a/diffkemp/simpll/DifferentialFunctionComparator.cpp
+++ b/diffkemp/simpll/DifferentialFunctionComparator.cpp
@@ -965,7 +965,16 @@ int DifferentialFunctionComparator::cmpGlobalValues(GlobalValue *L,
                 }
             }
             return 0;
-        } else
+
+        } else if (NameL != NameR && GVarL && GVarR && GVarL->isConstant()
+                   && GVarR->isConstant() && !GVarL->hasInitializer()
+                   && !GVarR->hasInitializer()) {
+            // Externally defined constants (those without initializer
+            // and with different names) need to have their definitions linked.
+            ModComparator->MissingDefs.push_back({GVarL, GVarR});
+        }
+
+        else
             return 1;
     } else
         return L != R;

--- a/diffkemp/simpll/ModuleComparator.h
+++ b/diffkemp/simpll/ModuleComparator.h
@@ -111,7 +111,7 @@ class ModuleComparator {
     // Counter of assembly diffs
     int asmDifferenceCounter = 0;
 
-    std::vector<ConstFunPair> MissingDefs;
+    std::vector<GlobalValuePair> MissingDefs;
 
     /// DebugInfo class storing results from analysing debug information
     const DebugInfo *DI;

--- a/diffkemp/simpll/Transforms.h
+++ b/diffkemp/simpll/Transforms.h
@@ -42,7 +42,7 @@ void preprocessModule(Module &Mod,
 /// several vectors that are all outputs of ModuleComparator.
 struct ComparisonResult {
     std::vector<FunPair> nonequalFuns;
-    std::vector<ConstFunPair> missingDefs;
+    std::vector<GlobalValuePair> missingDefs;
     std::vector<std::unique_ptr<NonFunctionDifference>> differingObjects;
     std::set<std::string> coveredFuns;
 };

--- a/diffkemp/simpll/Utils.h
+++ b/diffkemp/simpll/Utils.h
@@ -26,6 +26,7 @@ enum Program { First, Second };
 
 typedef std::pair<Function *, Function *> FunPair;
 typedef std::pair<const Function *, const Function *> ConstFunPair;
+typedef std::pair<const GlobalValue *, const GlobalValue *> GlobalValuePair;
 
 /// Type for call stack entry: contains the called function and its call
 /// location (file and line).

--- a/tests/regression/test_specs/rhel-74-75.yaml
+++ b/tests/regression/test_specs/rhel-74-75.yaml
@@ -10,6 +10,7 @@ functions:
         netif_free_tx_queues: equal_syntax
         skb_queue_head: equal_syntax
         dev_get_stats: equal_syntax
+        sprintf: equal_syntax
 
 syntax_diffs:
   - function: pgd_present


### PR DESCRIPTION
If there is a syntactic difference in names of constant global variables
that are declared as external, sources that define these constants are
found, linked to the current module, and the analysis rerun. 
This closes #43.

Note: Implementation of MissingDefs is changed from const *Function pair
to const *GlobalValue pair.
