### PR TITLE
Regression tests: separate control-flow-only tests

### DIFF
--- a/diffkemp/simpll/Utils.cpp
+++ b/diffkemp/simpll/Utils.cpp
@@ -292,7 +292,9 @@ void simplifyFunction(Function *Fun) {
     FunctionPassManager fpm(false);
     FunctionAnalysisManager fam(false);
     pb.registerFunctionAnalyses(fam);
+#if LLVM_VERSION_MAJOR > 5
     fpm.addPass(SimplifyCFGPass{});
+#endif
     fpm.addPass(DCEPass{});
     fpm.addPass(NewGVNPass{});
     fpm.run(*Fun, fam);

--- a/tests/regression/test_specs/rhel-73-74.yaml
+++ b/tests/regression/test_specs/rhel-73-74.yaml
@@ -1,11 +1,9 @@
 old_kernel: kernel/linux-3.10.0-514.el7
 new_kernel: kernel/linux-3.10.0-693.el7
 
-control_flow_only: true
-
 functions:
-        debugfs_create_u32: equal_syntax
-        up_read: equal_syntax
+  debugfs_create_u32: equal_syntax
+  up_read: equal_syntax
 
 syntax_diffs:
   - function: numa_node_id

--- a/tests/regression/test_specs/rhel-74-75-cfo.yaml
+++ b/tests/regression/test_specs/rhel-74-75-cfo.yaml
@@ -1,0 +1,9 @@
+old_kernel: kernel/linux-3.10.0-693.el7
+new_kernel: kernel/linux-3.10.0-862.el7
+
+control_flow_only: true
+
+functions:
+  skb_queue_head: equal_syntax
+  single_open: equal_syntax
+

--- a/tests/regression/test_specs/rhel-74-75.yaml
+++ b/tests/regression/test_specs/rhel-74-75.yaml
@@ -1,16 +1,12 @@
 old_kernel: kernel/linux-3.10.0-693.el7
 new_kernel: kernel/linux-3.10.0-862.el7
 
-control_flow_only: true
-
 functions:
-        __netif_schedule: equal_syntax
-        dev_trans_start: equal_syntax
-        single_open: equal_syntax
-        netif_free_tx_queues: equal_syntax
-        skb_queue_head: equal_syntax
-        dev_get_stats: equal_syntax
-        sprintf: equal_syntax
+  __netif_schedule: equal_syntax
+  dev_trans_start: equal_syntax
+  netif_free_tx_queues: equal_syntax
+  dev_get_stats: equal_syntax
+  sprintf: equal_syntax
 
 syntax_diffs:
   - function: pgd_present

--- a/tests/regression/test_specs/rhel-75-76-cfo.yaml
+++ b/tests/regression/test_specs/rhel-75-76-cfo.yaml
@@ -1,0 +1,16 @@
+old_kernel: kernel/linux-3.10.0-862.el7
+new_kernel: kernel/linux-3.10.0-957.el7
+
+control_flow_only: true
+
+functions:
+  fcoe_ctlr_init: equal_syntax
+  proc_put_char: equal_syntax
+  free_pages: equal_syntax
+  skb_csum_hwoffload_help: equal_syntax
+  ip6_route_output: equal_syntax
+  generic_file_llseek_size: equal_syntax
+  skb_clone: equal_syntax
+  ipmi_set_my_address: equal_syntax
+  __request_region: equal_syntax
+

--- a/tests/regression/test_specs/rhel-75-76.yaml
+++ b/tests/regression/test_specs/rhel-75-76.yaml
@@ -1,27 +1,16 @@
 old_kernel: kernel/linux-3.10.0-862.el7
 new_kernel: kernel/linux-3.10.0-957.el7
 
-control_flow_only: true
-
 functions:
-        ipmi_set_gets_events: equal_syntax
-        __wake_up: equal_syntax
-        skb_clone: equal_syntax
-        ipmi_set_my_address: equal_syntax
-        check_addr: equal_syntax
-        __alloc_workqueue_key: equal_syntax
-        blk_execute_rq_nowait: equal_syntax
-        ip6_route_output: equal_syntax
-        param_set_int: equal_syntax
-        param_set_long: equal_syntax
-        free_pages: equal_syntax
-        fcoe_ctlr_init: equal_syntax
-        __request_region: equal_syntax
-        generic_file_llseek_size: equal_syntax
-        __read_seqcount_begin: equal_syntax
-        skb_csum_hwoffload_help: equal_syntax
-        proc_put_char: equal_syntax
-        __alloc_percpu: equal_syntax
+  ipmi_set_gets_events: equal_syntax
+  __wake_up: equal_syntax
+  check_addr: equal_syntax
+  __alloc_workqueue_key: equal_syntax
+  blk_execute_rq_nowait: equal_syntax
+  param_set_int: equal_syntax
+  param_set_long: equal_syntax
+  __read_seqcount_begin: equal_syntax
+  __alloc_percpu: equal_syntax
 
 sysctls:
   - sysctl: net.core.netdev_rss_key


### PR DESCRIPTION
There are some bugs in control-flow-only slicing that cause some tests that do not need it to fail. Sometimes, this happens non-deterministically and on some LLVM versions only. Therefore, we put
all regression tests that require the control-flow-only flag into separate spec files.

Also, fix indentation of all YAML spec files to 2 spaces.