### PR TITLE
Fix bugs in comparing GEP instructions

### DIFF
--- a/diffkemp/simpll/DebugInfo.cpp
+++ b/diffkemp/simpll/DebugInfo.cpp
@@ -293,8 +293,11 @@ int DebugInfo::getTypeMemberIndex(const DICompositeType &type,
                 return index;
             nextOffset =
                     TypeElem->getOffsetInBits() + TypeElem->getSizeInBits();
+            if (TypeElem->getSizeInBits() > 0)
+                index++;
+        } else {
+            index++;
         }
-        index++;
     }
     return -1;
 }

--- a/diffkemp/simpll/DifferentialFunctionComparator.cpp
+++ b/diffkemp/simpll/DifferentialFunctionComparator.cpp
@@ -988,11 +988,11 @@ bool DifferentialFunctionComparator::accumulateAllOffsets(
         const BasicBlock &BB, uint64_t &Offset) const {
     for (auto &Inst : BB) {
         if (auto GEP = dyn_cast<GetElementPtrInst>(&Inst)) {
-            APInt Offset;
+            APInt InstOffset(32, 0);
             if (!GEP->accumulateConstantOffset(BB.getModule()->getDataLayout(),
-                                               Offset))
+                                               InstOffset))
                 return false;
-            Offset += Offset.getZExtValue();
+            Offset += InstOffset.getZExtValue();
         }
     }
     return true;
@@ -1009,7 +1009,7 @@ int DifferentialFunctionComparator::cmpFieldAccess(const Function *L,
     uint64_t OffsetL = 0, OffsetR = 0;
 
     if (!accumulateAllOffsets(L->front(), OffsetL)
-        || !accumulateAllOffsets(L->front(), OffsetR))
+        || !accumulateAllOffsets(R->front(), OffsetR))
         return 1;
 
     if (OffsetL == OffsetR)


### PR DESCRIPTION
The PR contains two parts:
- fix multiple bugs in comparison of field access abstractions that caused abstractions to be compared as equal even if they were not (ultimately causing false negatives)
- support finding index alignment in structures that contain padding fields (fields that have no size, just an alignment)