### PR TITLE
SimpLL optimisations

### DIFF
--- a/diffkemp/diffkemp.py
+++ b/diffkemp/diffkemp.py
@@ -380,7 +380,8 @@ def print_syntax_diff(snapshot_dir_old, snapshot_dir_new, fun, fun_result,
                 output.write(text_indent("{}:\n".format(fun), initial_indent))
             indent = initial_indent + 4
 
-        for called_res in fun_result.inner.values():
+        for called_res in sorted(fun_result.inner.values(),
+                                 key=lambda r: r.first.name):
             if called_res.diff == "" and called_res.first.covered:
                 # Do not print empty diffs
                 continue

--- a/diffkemp/semdiff/result.py
+++ b/diffkemp/semdiff/result.py
@@ -113,13 +113,13 @@ class Result:
         if show_errors:
             if unkwn > 0:
                 print("\nFunctions that are unknown: ")
-                for f, r in iter(self.inner.items()):
+                for f, r in sorted(self.inner.items()):
                     if r.kind == Result.Kind.UNKNOWN:
                         print(f)
                 print()
             if errs > 0:
                 print("\nFunctions whose comparison ended with an error: ")
-                for f, r in iter(self.inner.items()):
+                for f, r in sorted(self.inner.items()):
                     if r.kind == Result.Kind.ERROR:
                         print(f)
                 print()

--- a/diffkemp/simpll/Config.cpp
+++ b/diffkemp/simpll/Config.cpp
@@ -46,6 +46,9 @@ cl::opt<bool> PrintCallstacksOpt(
 cl::opt<bool>
         VerboseOpt("verbose",
                    cl::desc("Show verbose output (debugging information)."));
+cl::opt<bool> VerboseMacrosOpt("verbose-macros",
+                               cl::desc("Show debugging information for "
+                                        "discovering macro differences"));
 cl::opt<bool> PrintAsmDiffsOpt(
         "print-asm-diffs",
         cl::desc("Print raw differences in inline assembly code "
@@ -99,10 +102,25 @@ Config::Config()
         // Parse --cache-dir option - directory with cache diles from DiffKemp.
         CacheDir = CacheDirOpt;
     }
+
+    std::vector<std::string> debugTypes;
     if (VerboseOpt) {
         // Enable debugging output in passes
+        debugTypes.emplace_back(DEBUG_SIMPLL);
+    }
+    if (VerboseMacrosOpt) {
+        // Enable debugging output when finding macro differences
+        debugTypes.emplace_back(DEBUG_SIMPLL_MACROS);
+    }
+    if (!debugTypes.empty()) {
         DebugFlag = true;
-        setCurrentDebugType(DEBUG_SIMPLL);
+        // Transform vector of strings into char ** (array of char *)
+        std::vector<const char *> types;
+        std::transform(debugTypes.begin(),
+                       debugTypes.end(),
+                       std::back_inserter(types),
+                       [](const std::string &s) { return s.c_str(); });
+        setCurrentDebugTypes(&types[0], debugTypes.size());
     }
 }
 

--- a/diffkemp/simpll/Config.h
+++ b/diffkemp/simpll/Config.h
@@ -21,6 +21,7 @@
 #include <llvm/Support/SourceMgr.h>
 
 #define DEBUG_SIMPLL "debug-simpll"
+#define DEBUG_SIMPLL_MACROS "debug-simpll-macros"
 
 using namespace llvm;
 
@@ -33,6 +34,7 @@ extern cl::opt<std::string> SuffixOpt;
 extern cl::opt<bool> ControlFlowOpt;
 extern cl::opt<bool> PrintCallstacksOpt;
 extern cl::opt<bool> VerboseOpt;
+extern cl::opt<bool> VerboseMacrosOpt;
 
 /// Tool configuration parsed from CLI options.
 class Config {

--- a/diffkemp/simpll/DifferentialFunctionComparator.cpp
+++ b/diffkemp/simpll/DifferentialFunctionComparator.cpp
@@ -1015,6 +1015,15 @@ int DifferentialFunctionComparator::cmpFieldAccess(const Function *L,
     // be also equal in machine code).
     uint64_t OffsetL = 0, OffsetR = 0;
 
+    // If both field access abstractions contain just a single GEP, these can be
+    // compared normally using the cmpGEPs method.
+    if (L->front().size() == 1 && R->front().size() == 1
+        && isa<GetElementPtrInst>(L->front().front())
+        && isa<GetElementPtrInst>(R->front().front())) {
+        return cmpGEPs(dyn_cast<GEPOperator>(&L->front().front()),
+                       dyn_cast<GEPOperator>(&R->front().front()));
+    }
+
     if (!accumulateAllOffsets(L->front(), OffsetL)
         || !accumulateAllOffsets(R->front(), OffsetR))
         return 1;

--- a/diffkemp/simpll/DifferentialFunctionComparator.h
+++ b/diffkemp/simpll/DifferentialFunctionComparator.h
@@ -31,12 +31,10 @@ class DifferentialFunctionComparator : public FunctionComparator {
   public:
     DifferentialFunctionComparator(const Function *F1,
                                    const Function *F2,
-                                   bool controlFlowOnly,
-                                   bool showAsmDiff,
+                                   const Config &config,
                                    const DebugInfo *DI,
                                    ModuleComparator *MC)
-            : FunctionComparator(F1, F2, nullptr), DI(DI),
-              controlFlowOnly(controlFlowOnly), showAsmDiff(showAsmDiff),
+            : FunctionComparator(F1, F2, nullptr), config(config), DI(DI),
               LayoutL(F1->getParent()->getDataLayout()),
               LayoutR(F2->getParent()->getDataLayout()), ModComparator(MC) {}
 
@@ -96,8 +94,8 @@ class DifferentialFunctionComparator : public FunctionComparator {
                                       const Value *Const) const;
 
   private:
+    const Config &config;
     const DebugInfo *DI;
-    bool controlFlowOnly, showAsmDiff;
 
     const DataLayout &LayoutL, &LayoutR;
 

--- a/diffkemp/simpll/ModuleComparator.cpp
+++ b/diffkemp/simpll/ModuleComparator.cpp
@@ -36,7 +36,7 @@ void ModuleComparator::compareFunctions(Function *FirstFun,
                          Result(FirstFun, SecondFun));
 
     // Check if the functions is in the ignored list.
-    if (ResCache->isFunctionPairCached(FirstFun, SecondFun)) {
+    if (ResCache.isFunctionPairCached(FirstFun, SecondFun)) {
         ComparedFuns.at({FirstFun, SecondFun}).kind = Result::UNKNOWN;
         return;
     }
@@ -54,7 +54,7 @@ void ModuleComparator::compareFunctions(Function *FirstFun,
         if (hasSuffix(SecondFunName))
             SecondFunName = dropSuffix(SecondFunName);
 
-        if (controlFlowOnly) {
+        if (config.ControlFlowOnly) {
             // If checking control flow only, it suffices that one of the
             // functions is a declaration to treat them equal.
             if (FirstFunName == SecondFunName)
@@ -99,8 +99,7 @@ void ModuleComparator::compareFunctions(Function *FirstFun,
     }
 
     // Comparing functions with bodies using custom FunctionComparator.
-    DifferentialFunctionComparator fComp(
-            FirstFun, SecondFun, controlFlowOnly, showAsmDiffs, DI, this);
+    DifferentialFunctionComparator fComp(FirstFun, SecondFun, config, DI, this);
     int result = fComp.compare();
 
     DEBUG_WITH_TYPE(DEBUG_SIMPLL, decreaseDebugIndentLevel());
@@ -201,12 +200,8 @@ void ModuleComparator::compareFunctions(Function *FirstFun,
             // Reset the function diff result
             ComparedFuns.at({FirstFun, SecondFun}).kind = Result::UNKNOWN;
             // Re-run the comparison
-            DifferentialFunctionComparator fCompSecond(FirstFun,
-                                                       SecondFun,
-                                                       controlFlowOnly,
-                                                       showAsmDiffs,
-                                                       DI,
-                                                       this);
+            DifferentialFunctionComparator fCompSecond(
+                    FirstFun, SecondFun, config, DI, this);
             result = fCompSecond.compare();
             // If the functions are equal after the inlining and there is a
             // call to the inlined function, mark it as weak.

--- a/diffkemp/simpll/ModuleComparator.h
+++ b/diffkemp/simpll/ModuleComparator.h
@@ -15,6 +15,7 @@
 #ifndef DIFFKEMP_SIMPLL_MODULECOMPARATOR_H
 #define DIFFKEMP_SIMPLL_MODULECOMPARATOR_H
 
+#include "Config.h"
 #include "DebugInfo.h"
 #include "Result.h"
 #include "ResultsCache.h"
@@ -30,7 +31,7 @@ using namespace llvm;
 class ModuleComparator {
     Module &First;
     Module &Second;
-    bool controlFlowOnly, showAsmDiffs;
+    const Config &config;
 
   public:
     /// Storing results of function comparisons.
@@ -51,23 +52,21 @@ class ModuleComparator {
 
     /// Cache used for dynamic lookup of already compared functions using
     /// data passed from DiffKemp.
-    ResultsCache *ResCache;
+    ResultsCache ResCache;
 
-    MacroDiffAnalysis *MacroDiffs;
+    /// Analysis of differences in macros
+    MacroDiffAnalysis MacroDiffs;
 
     ModuleComparator(Module &First,
                      Module &Second,
-                     bool controlFlowOnly,
-                     bool showAsmDiffs,
+                     const Config &config,
                      const DebugInfo *DI,
-                     ResultsCache *ResCache,
-                     MacroDiffAnalysis *MD,
                      StructureSizeAnalysis::Result &StructSizeMapL,
                      StructureSizeAnalysis::Result &StructSizeMapR,
                      StructureDebugInfoAnalysis::Result &StructDIMapL,
                      StructureDebugInfoAnalysis::Result &StructDIMapR)
-            : First(First), Second(Second), controlFlowOnly(controlFlowOnly),
-              showAsmDiffs(showAsmDiffs), DI(DI), ResCache(ResCache), MacroDiffs(MD),
+            : First(First), Second(Second), config(config), DI(DI),
+              ResCache(config.CacheDir), MacroDiffs(),
               StructSizeMapL(StructSizeMapL), StructSizeMapR(StructSizeMapR),
               StructDIMapL(StructDIMapL), StructDIMapR(StructDIMapR) {}
 

--- a/diffkemp/simpll/ModuleComparator.h
+++ b/diffkemp/simpll/ModuleComparator.h
@@ -18,6 +18,7 @@
 #include "DebugInfo.h"
 #include "Result.h"
 #include "ResultsCache.h"
+#include "SourceCodeUtils.h"
 #include "Utils.h"
 #include "passes/StructureDebugInfoAnalysis.h"
 #include "passes/StructureSizeAnalysis.h"
@@ -52,18 +53,21 @@ class ModuleComparator {
     /// data passed from DiffKemp.
     ResultsCache *ResCache;
 
+    MacroDiffAnalysis *MacroDiffs;
+
     ModuleComparator(Module &First,
                      Module &Second,
                      bool controlFlowOnly,
                      bool showAsmDiffs,
                      const DebugInfo *DI,
                      ResultsCache *ResCache,
+                     MacroDiffAnalysis *MD,
                      StructureSizeAnalysis::Result &StructSizeMapL,
                      StructureSizeAnalysis::Result &StructSizeMapR,
                      StructureDebugInfoAnalysis::Result &StructDIMapL,
                      StructureDebugInfoAnalysis::Result &StructDIMapR)
             : First(First), Second(Second), controlFlowOnly(controlFlowOnly),
-              showAsmDiffs(showAsmDiffs), DI(DI), ResCache(ResCache),
+              showAsmDiffs(showAsmDiffs), DI(DI), ResCache(ResCache), MacroDiffs(MD),
               StructSizeMapL(StructSizeMapL), StructSizeMapR(StructSizeMapR),
               StructDIMapL(StructDIMapL), StructDIMapR(StructDIMapR) {}
 

--- a/diffkemp/simpll/SourceCodeUtils.cpp
+++ b/diffkemp/simpll/SourceCodeUtils.cpp
@@ -32,13 +32,13 @@ void MacroDiffAnalysis::collectMacroUsesAtLocation(
     std::string line = extractLineFromLocation(Loc, lineOffset);
     if (line.empty()) {
         // Source line was not found
-        DEBUG_WITH_TYPE(DEBUG_SIMPLL,
+        DEBUG_WITH_TYPE(DEBUG_SIMPLL_MACROS,
                         dbgs() << getDebugIndent()
                                << "Source for macro not found\n");
         return;
     }
 
-    DEBUG_WITH_TYPE(DEBUG_SIMPLL,
+    DEBUG_WITH_TYPE(DEBUG_SIMPLL_MACROS,
                     dbgs() << getDebugIndent()
                            << "Looking for all macros on line:" << line
                            << "\n");
@@ -117,7 +117,7 @@ void MacroDiffAnalysis::collectMacroUsesAtLocation(
                         // If the macro use is new (it was not in the result
                         // map, yet), add its body into the toExpand queue.
                         DEBUG_WITH_TYPE(
-                                DEBUG_SIMPLL,
+                                DEBUG_SIMPLL_MACROS,
                                 dbgs() << getDebugIndent() << "Adding macro "
                                        << newMacroUse.def->name << " : "
                                        << newMacroUse.def->body
@@ -227,7 +227,7 @@ const StringMap<MacroUse> &
                                                      int lineOffset) {
     if (!Loc || Loc->getNumOperands() == 0) {
         // DILocation has no scope or is not present - cannot get macro stack
-        DEBUG_WITH_TYPE(DEBUG_SIMPLL,
+        DEBUG_WITH_TYPE(DEBUG_SIMPLL_MACROS,
                         dbgs() << getDebugIndent()
                                << "Scope for macro not found\n");
         MacroUsesAtLocation.emplace(Loc, StringMap<MacroUse>());
@@ -294,7 +294,7 @@ std::vector<std::unique_ptr<SyntaxDifference>>
             std::reverse(StackR.begin(), StackR.end());
 
             DEBUG_WITH_TYPE(
-                    DEBUG_SIMPLL,
+                    DEBUG_SIMPLL_MACROS,
                     dbgs() << getDebugIndent() << "Left stack:\n\t";
                     dbgs() << getDebugIndent() << MacroUseL.second.def->body
                            << "\n";
@@ -305,7 +305,7 @@ std::vector<std::unique_ptr<SyntaxDifference>>
                                << elem.line << "\n";
                     });
             DEBUG_WITH_TYPE(
-                    DEBUG_SIMPLL,
+                    DEBUG_SIMPLL_MACROS,
                     dbgs() << getDebugIndent() << "Right stack:\n\t";
                     dbgs() << getDebugIndent() << MacroUseR->second.def->body
                            << "\n";

--- a/diffkemp/simpll/Transforms.cpp
+++ b/diffkemp/simpll/Transforms.cpp
@@ -17,6 +17,7 @@
 #include "DifferentialFunctionComparator.h"
 #include "ModuleComparator.h"
 #include "ResultsCache.h"
+#include "SourceCodeUtils.h"
 #include "Utils.h"
 #include "passes/CalledFunctionsAnalysis.h"
 #include "passes/ControlFlowSlicer.h"
@@ -160,12 +161,14 @@ void simplifyModulesDiff(Config &config, OverallResult &Result) {
     ResultsCache ResCache(config.CacheDir);
 
     // Compare functions for syntactical equivalence
+    MacroDiffAnalysis MD;
     ModuleComparator modComp(*config.First,
                              *config.Second,
                              config.ControlFlowOnly,
                              config.PrintAsmDiffs,
                              &DI,
                              &ResCache,
+                             &MD,
                              StructSizeMapL,
                              StructSizeMapR,
                              StructDIL,

--- a/diffkemp/simpll/Transforms.cpp
+++ b/diffkemp/simpll/Transforms.cpp
@@ -158,17 +158,12 @@ void simplifyModulesDiff(Config &config, OverallResult &Result) {
                                                         config.FirstFun),
                  mam.getResult<CalledFunctionsAnalysis>(*config.Second,
                                                         config.SecondFun));
-    ResultsCache ResCache(config.CacheDir);
 
     // Compare functions for syntactical equivalence
-    MacroDiffAnalysis MD;
     ModuleComparator modComp(*config.First,
                              *config.Second,
-                             config.ControlFlowOnly,
-                             config.PrintAsmDiffs,
+                             config,
                              &DI,
-                             &ResCache,
-                             &MD,
                              StructSizeMapL,
                              StructSizeMapR,
                              StructDIL,

--- a/diffkemp/simpll/passes/FieldAccessFunctionGenerator.cpp
+++ b/diffkemp/simpll/passes/FieldAccessFunctionGenerator.cpp
@@ -104,6 +104,11 @@ void FieldAccessFunctionGenerator::processStack(
     // only by other instructions in the stack.
     // If not, do not generate an abstraction, since this would break the code.
     for (Instruction *Inst : Stack) {
+        if (auto *GEP = dyn_cast<GetElementPtrInst>(Inst)) {
+            // All GEP operands must be constant
+            if (!GEP->hasAllConstantIndices())
+                return;
+        }
         if (Inst == Stack.back())
             continue;
         for (User *U : Inst->users()) {


### PR DESCRIPTION
This PR features two major SimpLL optimisations:
- finding macro differences: macro definitions extracted from debug info and macro usages for each program location are cached so that every macro and every line needs to be parsed only once
- field access abstractions: abstractions are created only if all GEPs have constant indices and comparison of two abstractions having a single instruction is done using the original `cmpGEPs` method

Also, the diffs found within a KABI symbol are sorted so that comparison of large logs is easier.