### PR TITLE
Docker: Add podman support to the starting script

### DIFF
--- a/docker/diffkemp-devel/run-container.sh
+++ b/docker/diffkemp-devel/run-container.sh
@@ -1,11 +1,19 @@
 #!/bin/bash
 
+COMMAND="docker"
+
+# Use podman if docker is not available.
+if [ ! -x "$(command -v docker)" ]; then
+    COMMAND="podman"
+fi
+
 # Prerequisity is an existing docker image called 'diffkemp-devel' built from
 # the provided Dockerfile
-docker run \
-	-ti --security-opt seccomp=unconfined \
+"$COMMAND" run \
+    -ti --security-opt seccomp=unconfined \
     -m 8g \
     --cpus 3 \
-	-v $PWD:/diffkemp:Z \
-	-w /diffkemp \
-	viktormalik/diffkemp-devel
+    -v $PWD:/diffkemp:Z \
+    -w /diffkemp \
+    viktormalik/diffkemp-devel
+


### PR DESCRIPTION
It is necessary that we support podman for eg. new versions of Fedora. If the docker command is not found on the host, the script will try to use podman instead.