### PR TITLE
SimpLL: fix bug in marking inlined call as weak

### DIFF
--- a/diffkemp/simpll/ModuleComparator.cpp
+++ b/diffkemp/simpll/ModuleComparator.cpp
@@ -209,26 +209,14 @@ void ModuleComparator::compareFunctions(Function *FirstFun,
                 if (InlinedFunFirst)
                     for (const CallInfo &CI :
                          ComparedFuns.at({FirstFun, SecondFun}).First.calls) {
-                        if (CI.fun == InlinedFunFirst->getName().str()) {
-                            CallInfo NewCI = CI;
-                            ComparedFuns.at({FirstFun, SecondFun})
-                                    .First.calls.erase(CI);
-                            NewCI.weak = true;
-                            ComparedFuns.at({FirstFun, SecondFun})
-                                    .First.calls.insert(NewCI);
-                        }
+                        if (CI.fun == InlinedFunFirst->getName().str())
+                            CI.weak = true;
                     }
                 if (InlinedFunSecond)
                     for (const CallInfo &CI :
                          ComparedFuns.at({FirstFun, SecondFun}).Second.calls) {
-                        if (CI.fun == InlinedFunSecond->getName().str()) {
-                            CallInfo NewCI = CI;
-                            ComparedFuns.at({FirstFun, SecondFun})
-                                    .Second.calls.erase(CI);
-                            NewCI.weak = true;
-                            ComparedFuns.at({FirstFun, SecondFun})
-                                    .Second.calls.insert(NewCI);
-                        }
+                        if (CI.fun == InlinedFunSecond->getName().str())
+                            CI.weak = true;
                     }
             }
 

--- a/diffkemp/simpll/Result.h
+++ b/diffkemp/simpll/Result.h
@@ -30,7 +30,7 @@ struct CallInfo {
     std::string fun;
     std::string file;
     unsigned line;
-    bool weak;
+    mutable bool weak;
 
     // Default constructor needed for YAML serialisation.
     CallInfo() {}


### PR DESCRIPTION
The bug is caused by updating a set representing a call stack while iterating it. Previously, an element was removed out of the set, altered (marked as weak), and then inserted again. This fix marks the updated field as mutable and does the update in-place.

This bug occurred at Fedora 30 while testing comparison of 4.18.0-80 -> 4.18.0-147.