### PR TITLE
Support kernel 5.x compilation

### DIFF
--- a/diffkemp/simpll/passes/SimplifyKernelFunctionCallsPass.cpp
+++ b/diffkemp/simpll/passes/SimplifyKernelFunctionCallsPass.cpp
@@ -29,7 +29,7 @@
 /// Checks if the argument is of integer type.
 void replaceArgByZero(CallInst *Call, unsigned index) {
     auto OldArg = dyn_cast<ConstantInt>(Call->getArgOperand(index));
-    if (OldArg->getType()->isIntegerTy()) {
+    if (OldArg && OldArg->getType()->isIntegerTy()) {
         Call->setArgOperand(index,
                             ConstantInt::get(OldArg->getType(),
                                              APInt(OldArg->getBitWidth(), 0)));
@@ -40,7 +40,7 @@ void replaceArgByZero(CallInst *Call, unsigned index) {
 /// Checks if the argument is of integer type.
 void replaceArgByNull(CallInst *Call, unsigned index) {
     auto OldArg = Call->getArgOperand(index);
-    if (OldArg->getType()->isPointerTy()) {
+    if (OldArg && OldArg->getType()->isPointerTy()) {
         Call->setArgOperand(index,
                             ConstantPointerNull::get(
                                     dyn_cast<PointerType>(OldArg->getType())));
@@ -110,6 +110,7 @@ PreservedAnalyses
                 if (CalledFun->getName() == "warn_slowpath_null"
                     || CalledFun->getName() == "warn_slowpath_fmt"
                     || CalledFun->getName() == "__might_sleep"
+                    || CalledFun->getName() == "__might_fault"
                     || CalledFun->getName() == "acpi_ut_predefined_warning") {
                     replaceArgByNull(CallInstr, 0);
                     replaceArgByZero(CallInstr, 1);


### PR DESCRIPTION
There are 2 features implemented:
- `asm goto` is used in multiple headers in kernel 5.x - all occurrences are now replaced
- when compiling a single file into LLVM, it is needed to find a `gcc` command (until now, also `ld` commands were searched for, which caused the compilation to fail)

Also a bug occurring in comparison of 5.2 and 5.3 kernels is fixed.