### PR TITLE
SimpLL: Fix bug in cmpGlobalValues.

### DIFF
--- a/diffkemp/simpll/DifferentialFunctionComparator.cpp
+++ b/diffkemp/simpll/DifferentialFunctionComparator.cpp
@@ -981,6 +981,7 @@ int DifferentialFunctionComparator::cmpGlobalValues(GlobalValue *L,
             // Externally defined constants (those without initializer
             // and with different names) need to have their definitions linked.
             ModComparator->MissingDefs.push_back({GVarL, GVarR});
+            return 1;
         }
 
         else


### PR DESCRIPTION
In the case when two constant global variables with a different name and
without an initializer are compared, an explicit return statement is
necessary, otherwise undefined behavior will occur.