### PR TITLE
Python optimisations

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -46,6 +46,7 @@ addons:
       - kmod
       - libelf-dev
       - libssl-dev
+      - libyaml-dev
       - ninja-build
       - rpm2cpio
 

--- a/diffkemp/simpll/simpll.py
+++ b/diffkemp/simpll/simpll.py
@@ -84,7 +84,9 @@ def run_simpll(first, second, fun_first, fun_second, var, suffix=None,
         missing_defs = None
         try:
             result_graph = ComparisonGraph()
-            simpll_result = yaml.safe_load(simpll_out)
+            yaml_loader = (yaml.CSafeLoader if "CSafeLoader" in yaml.__dict__
+                           else yaml.SafeLoader)
+            simpll_result = yaml.load(simpll_out, Loader=yaml_loader)
             if simpll_result is not None:
                 if "function-results" in simpll_result:
                     for fun_result in simpll_result["function-results"]:

--- a/diffkemp/snapshot.py
+++ b/diffkemp/snapshot.py
@@ -188,14 +188,19 @@ class Snapshot:
             self.kernel_source = KernelSource(yaml_dict["source_kernel_dir"],
                                               True)
 
-        for g in yaml_dict["list"]:
+        if "sysctl" in yaml_dict["list"][0]:
+            self.kind = "sysctl"
+            groups = yaml_dict["list"]
+        else:
+            groups = [yaml_dict["list"]]
+        for g in groups:
             if "sysctl" in g:
                 self.kind = "sysctl"
                 group = g["sysctl"]
                 functions = g["functions"]
             else:
                 group = None
-                functions = yaml_dict["list"]
+                functions = g
             self.fun_groups[group] = self.FunctionGroup()
             for f in functions:
                 self.add_fun(f["name"],

--- a/diffkemp/snapshot.py
+++ b/diffkemp/snapshot.py
@@ -177,7 +177,9 @@ class Snapshot:
         relative to the root directory.
         :param yaml_file: Contents of the YAML file.
         """
-        yaml_file = yaml.safe_load(yaml_file)
+        yaml_loader = (yaml.CSafeLoader if "CSafeLoader" in yaml.__dict__
+                       else yaml.SafeLoader)
+        yaml_file = yaml.load(yaml_file, Loader=yaml_loader)
         yaml_dict = yaml_file[0]
 
         self.created_time = yaml_dict["created_time"]


### PR DESCRIPTION
This PR contains several optimisations in the Python part of DiffKemp.

1. libyaml bindings are used to load YAMLs instead of the native Python implementation if available.
2. A bug causing the complexity of snapshot loading to be quadratic is fixed.
3. CScope results are cached, allowing them to be reused in the compare phase.

According to profiler results 97 % of the time in DiffKemp is now in external processes, most of it in SimpLL.