### PR TITLE
Several improvements and fixes

### DIFF
--- a/diffkemp/llvm_ir/build_llvm.py
+++ b/diffkemp/llvm_ir/build_llvm.py
@@ -305,7 +305,7 @@ class LlvmKernelBuilder:
             cwd = os.getcwd()
             os.chdir(self.kernel_dir)
 
-            name = source_file[:-2]
+            name = os.path.relpath(source_file, self.kernel_dir)[:-2]
             try:
                 # Get GCC command for building the .o file
                 command = self.kbuild_object_command("{}.o".format(name))

--- a/diffkemp/llvm_ir/kernel_source.py
+++ b/diffkemp/llvm_ir/kernel_source.py
@@ -405,6 +405,8 @@ class KernelSource:
             # Copy linked sources and headers.
             for source in mod.get_included_sources():
                 src_source = source
+                if not src_source.startswith(self.kernel_dir):
+                    continue
                 dest_source = os.path.join(
                     target_dir, os.path.relpath(source, self.kernel_dir))
                 if not os.path.isfile(dest_source):

--- a/diffkemp/semdiff/caching.py
+++ b/diffkemp/semdiff/caching.py
@@ -574,26 +574,12 @@ class SimpLLCache:
             self.filename = os.path.join(directory,
                                          left_module.replace("/", "$") + ":" +
                                          right_module.replace("/", "$"))
-            self.rollback_cache = 0
 
         def add_function_pairs(self, pairs):
             with open(self.filename, "a") as file:
                 for pair in pairs:
                     text = "{0}:{1}\n".format(pair[0], pair[1])
                     file.write(text)
-                    self.rollback_cache += len(text)
-
-        def rollback(self):
-            if self.rollback_cache > 0:
-                # For repeated comparison after linking; remove lines generated
-                # at the previous run from cache.
-                with open(self.filename, "a") as file:
-                    file.truncate(file.tell() - self.rollback_cache)
-                    file.seek(0, os.SEEK_END)
-                    self.reset_rollback_cache()
-
-        def reset_rollback_cache(self):
-            self.rollback_cache = 0
 
         def clear(self):
             os.remove(self.filename)
@@ -624,14 +610,6 @@ class SimpLLCache:
                                                               files[1])
             cache_file = self.cache_map[files]
             cache_file.add_function_pairs([v.names for v in vertices_in_file])
-
-    def rollback(self):
-        for cache_file in self.cache_map.values():
-            cache_file.rollback()
-
-    def reset_rollback_cache(self):
-        for cache_file in self.cache_map.values():
-            cache_file.reset_rollback_cache()
 
     def clear(self):
         for cache_file in self.cache_map.values():

--- a/tests/unit_tests/caching_test.py
+++ b/tests/unit_tests/caching_test.py
@@ -360,24 +360,6 @@ def test_cache_file_add_function_pairs(cache_file):
         assert file.readlines() == ["f1:f2\n", "g1:g2\n"]
 
 
-def test_cache_file_rollback(cache_file):
-    """Tests cache file rollback for a single cache file."""
-    cache_file.add_function_pairs([("f1", "f2"), ("g1", "g2")])
-    cache_file.rollback()
-    with open(cache_file.filename, "r") as file:
-        assert file.readlines() == []
-
-
-def test_cache_file_reset_rollback_cache(cache_file):
-    """Tests rollback cache reset for a single cache file."""
-    cache_file.add_function_pairs([("f1", "f2"), ("g1", "g2")])
-    cache_file.reset_rollback_cache()
-    cache_file.add_function_pairs([("h1", "h2"), ("i1", "i2")])
-    cache_file.rollback()
-    with open(cache_file.filename, "r") as file:
-        assert file.readlines() == ["f1:f2\n", "g1:g2\n"]
-
-
 def test_cache_file_clear(cache_file):
     """Tests the clear method which deletes the cache file."""
     cache_file.add_function_pairs([("f1", "f2")])
@@ -413,29 +395,6 @@ def test_simpll_cache_update(simpll_cache, vertices):
     with open(os.path.join(simpll_cache.directory,
                            "$test$f1$1.ll:$test$f2$2.ll"), "r") as file:
         assert file.readlines() == ["f:f\n", "g:g\n"]
-    with open(os.path.join(simpll_cache.directory,
-                           "$test$f1$1.ll:$test$f2$3.ll"), "r") as file:
-        assert file.readlines() == ["h:h\n"]
-
-
-def test_simpll_cache_rollback(simpll_cache, vertices):
-    """Tests cache rollback for an entire SimpLLCache."""
-    simpll_cache.update(vertices)
-    simpll_cache.rollback()
-    for name in ["$test$f1$1.ll:$test$f2$2.ll", "$test$f1$1.ll:$test$f2$3.ll"]:
-        with open(os.path.join(simpll_cache.directory, name), "r") as file:
-            assert file.readlines() == []
-
-
-def test_simpll_cache_reset_rollback_cache(simpll_cache, vertices):
-    """Tests rollback cache reset for an entire SimpLLCache."""
-    simpll_cache.update(vertices[1:])
-    simpll_cache.reset_rollback_cache()
-    simpll_cache.update(vertices[:1])
-    simpll_cache.rollback()
-    with open(os.path.join(simpll_cache.directory,
-                           "$test$f1$1.ll:$test$f2$2.ll"), "r") as file:
-        assert file.readlines() == ["g:g\n"]
     with open(os.path.join(simpll_cache.directory,
                            "$test$f1$1.ll:$test$f2$3.ll"), "r") as file:
         assert file.readlines() == ["h:h\n"]


### PR DESCRIPTION
The proposed fixes are:
- disable `asm inline` constructs not supported by older LLVM versions
- always pass relative path to the object file to `make`
- if an LLVM module includes a file outside of the kernel source tree, do not copy it into the snapshot
- when missing definitions are found, and the linking is successful, do not merge the comparison graphs since the new one contains invalid results that will be re-computed