### PR TITLE
Always use UTC time in snapshots

### DIFF
--- a/diffkemp/snapshot.py
+++ b/diffkemp/snapshot.py
@@ -183,6 +183,8 @@ class Snapshot:
         yaml_dict = yaml_file[0]
 
         self.created_time = yaml_dict["created_time"]
+        self.created_time = self.created_time.replace(
+            tzinfo=datetime.timezone.utc)
 
         if os.path.isdir(yaml_dict["source_kernel_dir"]):
             self.kernel_source = KernelSource(yaml_dict["source_kernel_dir"],
@@ -236,7 +238,7 @@ class Snapshot:
         # Create the top level YAML structure.
         yaml_dict = [{
             "diffkemp_version": pkg_resources.require("diffkemp")[0].version,
-            "created_time": datetime.datetime.utcnow(),
+            "created_time": datetime.datetime.now(datetime.timezone.utc),
             "kind": "function_list" if self.fun_kind is None else
             "systcl_group_list",
             "list": fun_yaml_dict[0]["functions"] if None in self.fun_groups

--- a/tests/unit_tests/snapshot_test.py
+++ b/tests/unit_tests/snapshot_test.py
@@ -45,7 +45,7 @@ def test_load_snapshot_from_dir_functions():
                                dir=snap_dir) as config_file:
         # Populate the temporary snapshot configuration file.
         config_file.writelines("""
-        - created_time: 2020-01-01 00:00:00.000001
+        - created_time: 2020-01-01 00:00:00.000001+00:00
           diffkemp_version: '0.1'
           kind: function_list
           list:
@@ -65,7 +65,7 @@ def test_load_snapshot_from_dir_functions():
         config_filename = os.path.basename(config_file.name)
         snap = Snapshot.load_from_dir(snap_dir, config_filename)
 
-        assert str(snap.created_time) == "2020-01-01 00:00:00.000001"
+        assert str(snap.created_time) == "2020-01-01 00:00:00.000001+00:00"
         assert isinstance(snap.snapshot_source, KernelSource)
         assert snap.snapshot_source.kernel_dir == snap_dir
         assert len(snap.fun_groups) == 1
@@ -98,7 +98,7 @@ def test_load_snapshot_from_dir_sysctls():
                                dir=snap_dir) as config_file:
         # Populate the temporary sysctl snapshot configuration file.
         config_file.writelines("""
-        - created_time: 2020-01-01 00:00:00.000001
+        - created_time: 2020-01-01 00:00:00.000001+00:00
           diffkemp_version: '0.1'
           kind: function_list
           list:
@@ -122,7 +122,7 @@ def test_load_snapshot_from_dir_sysctls():
         config_filename = os.path.basename(config_file.name)
         snap = Snapshot.load_from_dir(snap_dir, config_filename)
 
-        assert str(snap.created_time) == "2020-01-01 00:00:00.000001"
+        assert str(snap.created_time) == "2020-01-01 00:00:00.000001+00:00"
         assert len(snap.fun_groups) == 2
         assert set(snap.fun_groups.keys()) == {"kernel.sched_latency_ns",
                                                "kernel.timer_migration"}


### PR DESCRIPTION
By default, datetime objects are treated as local times which may cause problems when compared to source file mtime that is in UTC.

These changes force to always use UTC in snapshots.