### PR TITLE
SimpLL: fix bug in SourceCodeUtils

### DIFF
--- a/diffkemp/simpll/SourceCodeUtils.cpp
+++ b/diffkemp/simpll/SourceCodeUtils.cpp
@@ -405,6 +405,8 @@ void MacroDiffAnalysis::collectMacroDefs(DICompileUnit *CompileUnit) {
 // Takes a string and the position of the first bracket and returns the
 // substring in the brackets.
 std::string getSubstringToMatchingBracket(std::string str, size_t position) {
+    if (position == std::string::npos)
+        return "";
     int bracketCounter = 0;
     std::string output;
 


### PR DESCRIPTION
The function `getSubstringToMatchingBracket` may receive position equal to `string::npos`. In such case, it must return an empty string to prevent crash.

This situation may happen when a function is used in code without brackets, which is, e.g., case for the function `__dynamic_dev_dbg` occurring as an argument of macro `_dynamic_func_call` in newer kernels.