### PR TITLE
Travis CI: use explicit address for testing PPA

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,7 +32,7 @@ jobs:
 addons:
   apt:
     sources:
-      - ubuntu-toolchain-r-test
+      - sourceline: "ppa:ubuntu-toolchain-r/test"
       - sourceline: "deb http://apt.llvm.org/xenial/ llvm-toolchain-xenial-5.0 main"
         key_url: "https://apt.llvm.org/llvm-snapshot.gpg.key"
       - sourceline: "deb http://apt.llvm.org/xenial/ llvm-toolchain-xenial-6.0 main"


### PR DESCRIPTION
The ubuntu-toolchain-r-test specifier does not seem to be supported anymore.