### PR TITLE
SimpLL: Add SeparateCallsToBitcastPass pass

### DIFF
--- a/diffkemp/simpll/ModuleAnalysis.cpp
+++ b/diffkemp/simpll/ModuleAnalysis.cpp
@@ -27,6 +27,7 @@
 #include "passes/ReduceFunctionMetadataPass.h"
 #include "passes/RemoveLifetimeCallsPass.h"
 #include "passes/RemoveUnusedReturnValuesPass.h"
+#include "passes/SeparateCallsToBitcastPass.h"
 #include "passes/SimplifyKernelFunctionCallsPass.h"
 #include "passes/SimplifyKernelGlobalsPass.h"
 #include "passes/StructHashGeneratorPass.h"
@@ -48,7 +49,7 @@
 ///    the value of the global variable.
 ///    This is only run if Var is specified.
 /// 2. Removal of the arguments of calls to printing functions.
-///    These arguments do not affect the code functionallity.
+///    These arguments do not affect the code functionality.
 ///    TODO: this should be switchable by a CLI option.
 /// 3. Unification of memcpy variants so that all use the llvm.memcpy intrinsic.
 /// 4. Dead code elimination.
@@ -81,6 +82,7 @@ void preprocessModule(Module &Mod,
     fpm.addPass(DCEPass{});
     fpm.addPass(LowerExpectIntrinsicPass{});
     fpm.addPass(ReduceFunctionMetadataPass{});
+    fpm.addPass(SeparateCallsToBitcastPass{});
 
     for (auto &Fun : Mod)
         fpm.run(Fun, fam);

--- a/diffkemp/simpll/Utils.cpp
+++ b/diffkemp/simpll/Utils.cpp
@@ -35,7 +35,7 @@
 static unsigned int debugIndentLevel = 0;
 
 // Invalid attributes for void functions and calls.
-std::vector<Attribute::AttrKind> badVoidAttributes = {
+static std::vector<Attribute::AttrKind> badVoidAttributes = {
         Attribute::AttrKind::ByVal,
         Attribute::AttrKind::InAlloca,
         Attribute::AttrKind::Nest,

--- a/diffkemp/simpll/Utils.h
+++ b/diffkemp/simpll/Utils.h
@@ -17,6 +17,7 @@
 #include <llvm/IR/Constants.h>
 #include <llvm/IR/DebugInfoMetadata.h>
 #include <llvm/IR/Function.h>
+#include <llvm/IR/Instructions.h>
 #include <unordered_map>
 
 using namespace llvm;
@@ -27,6 +28,9 @@ enum Program { First, Second };
 typedef std::pair<Function *, Function *> FunPair;
 typedef std::pair<const Function *, const Function *> ConstFunPair;
 typedef std::pair<const GlobalValue *, const GlobalValue *> GlobalValuePair;
+
+// Invalid attributes for void functions and calls.
+extern std::vector<Attribute::AttrKind> badVoidAttributes;
 
 /// Extract called function from a called value. Handles situation when the
 /// called value is a bitcast.
@@ -130,6 +134,12 @@ std::string getIdentifierForValue(
         const std::map<std::pair<StructType *, uint64_t>, StringRef>
                 &StructFieldNames,
         const Function *Parent = nullptr);
+
+/// Copies properties from one call instruction to another.
+void copyCallInstProperties(CallInst *srcCall, CallInst *destCall);
+
+/// Copies properties from one function to another.
+void copyFunctionProperties(Function *srcFun, Function *destFun);
 
 /// Converts value to its string representation.
 /// Note: Currently the only place that calls this is returns.gdb, which lacks

--- a/diffkemp/simpll/Utils.h
+++ b/diffkemp/simpll/Utils.h
@@ -29,9 +29,6 @@ typedef std::pair<Function *, Function *> FunPair;
 typedef std::pair<const Function *, const Function *> ConstFunPair;
 typedef std::pair<const GlobalValue *, const GlobalValue *> GlobalValuePair;
 
-// Invalid attributes for void functions and calls.
-extern std::vector<Attribute::AttrKind> badVoidAttributes;
-
 /// Extract called function from a called value. Handles situation when the
 /// called value is a bitcast.
 const Function *getCalledFunction(const Value *CalledValue);

--- a/diffkemp/simpll/passes/SeparateCallsToBitcastPass.cpp
+++ b/diffkemp/simpll/passes/SeparateCallsToBitcastPass.cpp
@@ -1,0 +1,141 @@
+//===----  SeparateCallsToBitcastPass.cpp - Separate calls to bitcasts ----===//
+//
+//       SimpLL - Program simplifier for analysis of semantic difference      //
+//
+// This file is published under Apache 2.0 license. See LICENSE for details.
+// Author: Petr Silling, psilling@redhat.com
+//===----------------------------------------------------------------------===//
+///
+/// \file
+/// This file contains the definition of the SeparateCallsToBitcastPass pass.
+/// The pass separates bitcasts from calls to bitcast operators by inserting
+/// new bitcast instructions that transform function arguments and the return
+/// value separately.
+///
+//===----------------------------------------------------------------------===//
+
+#include "SeparateCallsToBitcastPass.h"
+
+#include "Utils.h"
+#include <Config.h>
+#include <llvm/IR/Instructions.h>
+#include <llvm/IR/Operator.h>
+
+/// Separate bitcasts from calls to bitcast operators to make the calls
+/// inlinable.
+PreservedAnalyses
+        SeparateCallsToBitcastPass::run(Function &Fun,
+                                        FunctionAnalysisManager &fam) {
+    std::vector<Instruction *> toRemove;
+
+    for (auto &BB : Fun) {
+        for (auto &Inst : BB) {
+            if (auto Call = dyn_cast<CallInst>(&Inst)) {
+                // Find call instructions calling a bitcast
+                // operator that directly corresponds to a function.
+                auto BitCast =
+                        dyn_cast<BitCastOperator>(Call->getCalledValue());
+
+                if (BitCast && isa<Function>(BitCast->getOperand(0))) {
+                    // Get the bitcasted function.
+                    auto srcFun =
+                            dyn_cast<Function>(BitCast->stripPointerCasts());
+
+                    // Ignore the instruction if the number of
+                    // arguments is lower than the number of parameters.
+                    if (Call->getNumArgOperands()
+                        < srcFun->getFunctionType()->getNumParams()) {
+                        continue;
+                    }
+
+                    // Ignore the instruction if the source function returns
+                    // void and the return value is used.
+                    if (srcFun->getReturnType()->isVoidTy()
+                        && !Call->getType()->isVoidTy()) {
+                        continue;
+                    }
+
+                    // Bitcast all arguments to the types of source function
+                    // parameters. If the number of arguments is higher, use the
+                    // remaining arguments without bitcasting as a vargars is
+                    // present in the call instruction.
+                    std::vector<Value *> newArgs;
+                    auto arg = Call->arg_begin();
+
+                    for (auto paramType : srcFun->getFunctionType()->params()) {
+                        if ((*arg)->getType() == paramType) {
+                            newArgs.push_back(*arg);
+                        } else {
+                            // Bitcast the argument so that the types match.
+                            auto newArg = CastInst::Create(
+                                    Instruction::BitCast,
+                                    *arg,
+                                    paramType,
+                                    "",
+                                    newArgs.empty() ? cast<Instruction>(Call)
+                                                    : cast<Instruction>(
+                                                            newArgs.back()));
+
+                            newArg->setDebugLoc(Call->getDebugLoc());
+                            newArgs.push_back(newArg);
+                        }
+
+                        ++arg;
+                    }
+
+                    // Add the remaining arguments if there are any.
+                    while (arg != Call->arg_end()) {
+                        newArgs.push_back(*arg);
+                        ++arg;
+                    }
+
+                    // Create a new call instruction using the
+                    // source function and bitcasted arguments.
+                    auto newCall = CallInst::Create(srcFun, newArgs, "", Call);
+                    Instruction *replacementValue = newCall;
+
+                    // Copy properties of the original call instruction.
+                    newCall->setAttributes(Call->getAttributes());
+                    newCall->setDebugLoc(Call->getDebugLoc());
+                    newCall->setCallingConv(Call->getCallingConv());
+
+                    if (Call->isTailCall()) {
+                        newCall->setTailCall();
+                    }
+
+                    if (Call->getType() != newCall->getType()
+                        && !newCall->getType()->isVoidTy()) {
+                        // If return types do not match, bitcast the new
+                        // call result to the original result type.
+                        // Calls with a void return type are not bitcasted.
+                        auto returnBitCast =
+                                CastInst::Create(Instruction::BitCast,
+                                                 newCall,
+                                                 Call->getType(),
+                                                 "",
+                                                 Call);
+
+                        returnBitCast->setDebugLoc(Call->getDebugLoc());
+                        replacementValue = returnBitCast;
+                    }
+
+                    // Replace the old call instruction with the last generated
+                    // instruction.
+                    DEBUG_WITH_TYPE(DEBUG_SIMPLL,
+                                    dbgs() << "Replacing :" << *Call
+                                           << "\n   with :" << *replacementValue
+                                           << "\n");
+                    Call->replaceAllUsesWith(replacementValue);
+                    toRemove.push_back(Call);
+                }
+            }
+        }
+    }
+
+    // Remove replaced call instructions.
+    for (auto Call : toRemove) {
+        Call->eraseFromParent();
+    }
+
+    return PreservedAnalyses();
+}

--- a/diffkemp/simpll/passes/SeparateCallsToBitcastPass.cpp
+++ b/diffkemp/simpll/passes/SeparateCallsToBitcastPass.cpp
@@ -93,15 +93,7 @@ PreservedAnalyses
                     // source function and bitcasted arguments.
                     auto newCall = CallInst::Create(srcFun, newArgs, "", Call);
                     Instruction *replacementValue = newCall;
-
-                    // Copy properties of the original call instruction.
-                    newCall->setAttributes(Call->getAttributes());
-                    newCall->setDebugLoc(Call->getDebugLoc());
-                    newCall->setCallingConv(Call->getCallingConv());
-
-                    if (Call->isTailCall()) {
-                        newCall->setTailCall();
-                    }
+                    copyCallInstProperties(Call, newCall);
 
                     if (Call->getType() != newCall->getType()
                         && !newCall->getType()->isVoidTy()) {

--- a/diffkemp/simpll/passes/SeparateCallsToBitcastPass.h
+++ b/diffkemp/simpll/passes/SeparateCallsToBitcastPass.h
@@ -1,0 +1,28 @@
+//===-----  SeparateCallsToBitcastPass.h - Separate calls to bitcasts -----===//
+//
+//       SimpLL - Program simplifier for analysis of semantic difference      //
+//
+// This file is published under Apache 2.0 license. See LICENSE for details.
+// Author: Petr Silling, psilling@redhat.com
+//===----------------------------------------------------------------------===//
+///
+/// \file
+/// This file contains the declaration of the SeparateCallsToBitcastPass pass.
+///
+//===----------------------------------------------------------------------===//
+
+#ifndef DIFFKEMP_SIMPLL_SEPARATECALLSTOBITCASTPASS_H
+#define DIFFKEMP_SIMPLL_SEPARATECALLSTOBITCASTPASS_H
+
+#include <llvm/IR/PassManager.h>
+
+using namespace llvm;
+
+/// Separate bitcasts from calls to bitcast operators.
+class SeparateCallsToBitcastPass
+        : public PassInfoMixin<SeparateCallsToBitcastPass> {
+  public:
+    PreservedAnalyses run(Function &Fun, FunctionAnalysisManager &fam);
+};
+
+#endif // DIFFKEMP_SIMPLL_SEPARATECALLSTOBITCASTPASS_H

--- a/diffkemp/simpll/passes/SimplifyKernelFunctionCallsPass.cpp
+++ b/diffkemp/simpll/passes/SimplifyKernelFunctionCallsPass.cpp
@@ -85,7 +85,7 @@ PreservedAnalyses
                                               ConstantPointerNull::get(OpType)},
                                              "",
                                              &Instr);
-                    newCall->setDebugLoc(CallInstr->getDebugLoc());
+                    copyCallInstProperties(CallInstr, newCall);
                     CallInstr->replaceAllUsesWith(newCall);
                     toRemove.push_back(&Instr);
                 } else if (isPrintFunction(CalledFun->getName())) {
@@ -100,7 +100,7 @@ PreservedAnalyses
                              ConstantPointerNull::get(Op1Type)},
                             "",
                             &Instr);
-                    newCall->setDebugLoc(CallInstr->getDebugLoc());
+                    copyCallInstProperties(CallInstr, newCall);
                     CallInstr->replaceAllUsesWith(newCall);
                     toRemove.push_back(&Instr);
                 }


### PR DESCRIPTION
The SeparateCallsToBitcastPass pass separates bitcasts from calls to
bitcast operators by inserting new bitcast instructions that transform
function arguments and the return value separately.

This change makes these calls inlinable during the comparison phase. Fixes #42.

Example:
`call void bitcast (void (%struct.super_block.30*)* @fsnotify_unmount_inodes to void (%struct.super_block*)*)(%struct.super_block* %0), !dbg !25663`

will be changed to:
`%12 = bitcast %struct.super_block* %0 to %struct.super_block.30*, !dbg !25663`
`call void @fsnotify_unmount_inodes(%struct.super_block.30* %12), !dbg !25663`