### PR TITLE
Handle refactoring by inverting if conditions

### DIFF
--- a/diffkemp/llvm_ir/build_llvm.py
+++ b/diffkemp/llvm_ir/build_llvm.py
@@ -170,7 +170,8 @@ class LlvmKernelBuilder:
         """
         opt_command = ["opt", "-S", llvm_file, "-o", llvm_file]
         opt_command.extend(["-lowerswitch", "-mem2reg", "-loop-simplify",
-                            "-simplifycfg", "-gvn", "-dce", "-constmerge"])
+                            "-simplifycfg", "-gvn", "-dce", "-constmerge",
+                            "-mergereturn", "-simplifycfg"])
         try:
             with open(os.devnull, "w") as devnull:
                 check_call(opt_command, stderr=devnull)

--- a/diffkemp/simpll/DifferentialFunctionComparator.h
+++ b/diffkemp/simpll/DifferentialFunctionComparator.h
@@ -100,6 +100,7 @@ class DifferentialFunctionComparator : public FunctionComparator {
     const DataLayout &LayoutL, &LayoutR;
 
     mutable const DebugLoc *CurrentLocL, *CurrentLocR;
+    mutable std::set<std::pair<const Value *, const Value *>> inverseConditions;
 
     ModuleComparator *ModComparator;
 

--- a/diffkemp/simpll/DifferentialFunctionComparator.h
+++ b/diffkemp/simpll/DifferentialFunctionComparator.h
@@ -38,6 +38,8 @@ class DifferentialFunctionComparator : public FunctionComparator {
               LayoutL(F1->getParent()->getDataLayout()),
               LayoutR(F2->getParent()->getDataLayout()), ModComparator(MC) {}
 
+    int compare() override;
+
   protected:
     /// Specific comparison of GEP instructions/operators.
     /// Handles situation when there is an offset between matching GEP indices
@@ -92,6 +94,8 @@ class DifferentialFunctionComparator : public FunctionComparator {
     /// Comparing of a structure size with a constant
     int cmpStructTypeSizeWithConstant(StructType *Type,
                                       const Value *Const) const;
+    /// Comparing PHI instructions
+    int cmpPHIs(const PHINode *PhiL, const PHINode *PhiR) const;
 
   private:
     const Config &config;
@@ -101,6 +105,8 @@ class DifferentialFunctionComparator : public FunctionComparator {
 
     mutable const DebugLoc *CurrentLocL, *CurrentLocR;
     mutable std::set<std::pair<const Value *, const Value *>> inverseConditions;
+    mutable std::vector<std::pair<const PHINode *, const PHINode *>>
+            phisToCompare;
 
     ModuleComparator *ModComparator;
 

--- a/diffkemp/simpll/llvm-lib/10/FunctionComparator.h
+++ b/diffkemp/simpll/llvm-lib/10/FunctionComparator.h
@@ -97,7 +97,7 @@ public:
       : FnL(F1), FnR(F2), GlobalNumbers(GN) {}
 
   /// Test whether the two functions have equivalent behaviour.
-  int compare();
+  virtual int compare();
 
   /// Hash a function. Equivalent functions will have the same hash, and unequal
   /// functions will have different hashes with high probability.

--- a/diffkemp/simpll/llvm-lib/5/FunctionComparator.h
+++ b/diffkemp/simpll/llvm-lib/5/FunctionComparator.h
@@ -82,7 +82,7 @@ public:
       : FnL(F1), FnR(F2), GlobalNumbers(GN) {}
 
   /// Test whether the two functions have equivalent behaviour.
-  int compare();
+  virtual int compare();
   /// Hash a function. Equivalent functions will have the same hash, and unequal
   /// functions will have different hashes with high probability.
   typedef uint64_t FunctionHash;

--- a/diffkemp/simpll/llvm-lib/6/FunctionComparator.h
+++ b/diffkemp/simpll/llvm-lib/6/FunctionComparator.h
@@ -98,7 +98,7 @@ public:
       : FnL(F1), FnR(F2), GlobalNumbers(GN) {}
 
   /// Test whether the two functions have equivalent behaviour.
-  int compare();
+  virtual int compare();
 
   /// Hash a function. Equivalent functions will have the same hash, and unequal
   /// functions will have different hashes with high probability.

--- a/diffkemp/simpll/llvm-lib/7/FunctionComparator.h
+++ b/diffkemp/simpll/llvm-lib/7/FunctionComparator.h
@@ -98,7 +98,7 @@ public:
       : FnL(F1), FnR(F2), GlobalNumbers(GN) {}
 
   /// Test whether the two functions have equivalent behaviour.
-  int compare();
+  virtual int compare();
 
   /// Hash a function. Equivalent functions will have the same hash, and unequal
   /// functions will have different hashes with high probability.

--- a/diffkemp/simpll/llvm-lib/8/FunctionComparator.h
+++ b/diffkemp/simpll/llvm-lib/8/FunctionComparator.h
@@ -98,7 +98,7 @@ public:
       : FnL(F1), FnR(F2), GlobalNumbers(GN) {}
 
   /// Test whether the two functions have equivalent behaviour.
-  int compare();
+  virtual int compare();
 
   /// Hash a function. Equivalent functions will have the same hash, and unequal
   /// functions will have different hashes with high probability.

--- a/diffkemp/simpll/llvm-lib/9/FunctionComparator.h
+++ b/diffkemp/simpll/llvm-lib/9/FunctionComparator.h
@@ -97,7 +97,7 @@ public:
       : FnL(F1), FnR(F2), GlobalNumbers(GN) {}
 
   /// Test whether the two functions have equivalent behaviour.
-  int compare();
+  virtual int compare();
 
   /// Hash a function. Equivalent functions will have the same hash, and unequal
   /// functions will have different hashes with high probability.


### PR DESCRIPTION
This change allows to handle refactorings of the form:

    if (C) {B1} {B2} -> if (!C) {B2} {B1}

including cases when `return` or `continue` is used in one of the branches.

The PR contains several features:
- Handling comparison of inverse branch conditions. This is done by collecting pairs of `cmp` instructions with inverse predicates and if such instructions are used as conditions in `br` instructions, successors for one of the branches are swapped.
- Improved comparison of PHI instructions that have reordered incoming value/block pairs. This is done by postponing PHI comparison into the end after all other values and blocks were compared.
- Running the `-mergereturn` pass in `opt`. This is to improve handling of situations when an additional `return` is added due to refactoring.

See individual commits for more implementation details.