### PR TITLE
SimpLL: bitcast calls: fix order of casted args

### DIFF
--- a/diffkemp/simpll/passes/SeparateCallsToBitcastPass.cpp
+++ b/diffkemp/simpll/passes/SeparateCallsToBitcastPass.cpp
@@ -67,14 +67,11 @@ PreservedAnalyses
                             newArgs.push_back(*arg);
                         } else {
                             // Bitcast the argument so that the types match.
-                            auto newArg = CastInst::Create(
-                                    Instruction::BitCast,
-                                    *arg,
-                                    paramType,
-                                    "",
-                                    newArgs.empty() ? cast<Instruction>(Call)
-                                                    : cast<Instruction>(
-                                                            newArgs.back()));
+                            auto newArg = CastInst::Create(Instruction::BitCast,
+                                                           *arg,
+                                                           paramType,
+                                                           "",
+                                                           Call);
 
                             newArg->setDebugLoc(Call->getDebugLoc());
                             newArgs.push_back(newArg);


### PR DESCRIPTION
The new instructions with bitcasted arguments should be always inserted before the old call instruction to get them in the correct order.

Moreover, if an argument is not transformed into an instruction (since it is not casted), the cast in the original code may fail.