### PR TITLE
Pass forgotten param output_llvm_ir to run_simpll

### DIFF
--- a/diffkemp/semdiff/function_diff.py
+++ b/diffkemp/semdiff/function_diff.py
@@ -211,6 +211,7 @@ def functions_diff(mod_first, mod_second,
                                cache_dir=function_cache.directory
                                if function_cache else None,
                                control_flow_only=config.control_flow_only,
+                               output_llvm_ir=config.output_llvm_ir,
                                print_asm_diffs=config.print_asm_diffs,
                                verbose=config.verbosity,
                                use_ffi=config.use_ffi)


### PR DESCRIPTION
This error caused that the `--output-llvm-ir` CLI option did not work.