### PR TITLE
Refactor comparing of instructions and basic blocks

### DIFF
--- a/diffkemp/simpll/DifferentialFunctionComparator.h
+++ b/diffkemp/simpll/DifferentialFunctionComparator.h
@@ -113,6 +113,12 @@ class DifferentialFunctionComparator : public FunctionComparator {
 
     ModuleComparator *ModComparator;
 
+    /// Try to find a syntax difference that could be causing the semantic
+    /// difference that was found. Looks for differences that cannot be detected
+    /// by simply diffing the compared functions - differences in macros, inline
+    /// assembly code, or in types.
+    void findDifference(const Instruction *L, const Instruction *R) const;
+
     /// Looks for inline assembly differences between the certain values.
     /// Note: passing the parent function is necessary in order to properly
     /// generate the SyntaxDifference object.
@@ -131,6 +137,10 @@ class DifferentialFunctionComparator : public FunctionComparator {
                             StructType *R,
                             const Function *FL,
                             const Function *FR) const;
+
+    /// Find type differences between calls to field access abstractions.
+    void findTypeDifferenceInChainedFieldAccess(const CallInst *CL,
+                                                const CallInst *CR) const;
 
     /// Detects a change from a function to a macro between two instructions.
     /// This is necessary because such a change isn't visible in C source.

--- a/diffkemp/simpll/DifferentialFunctionComparator.h
+++ b/diffkemp/simpll/DifferentialFunctionComparator.h
@@ -73,6 +73,9 @@ class DifferentialFunctionComparator : public FunctionComparator {
                                      Value *OpL,
                                      Value *OpR,
                                      unsigned i) const;
+    /// Compare two instructions along with their operands.
+    int cmpOperationsWithOperands(const Instruction *L,
+                                  const Instruction *R) const;
     /// Detect cast instructions and ignore them when comparing the control flow
     /// only. (The rest is the same as in LLVM.)
     int cmpBasicBlocks(const BasicBlock *BBL,


### PR DESCRIPTION
This PR implements two related refactorings:
1. Move the code for comparison of instructions and of all their operands from `cmpBasicBlocks` into a newly created function `cmpOperationsWithOperands`. This enables the point 2, since the functions for finding syntax differences (differences in macros, inline assembly code, and in types) do not have to be called from two places (once from `cmpOperations` and once from `cmpBasicBlocks` for arguments) anymore.
2. Move all the code for finding syntax differences and for setting functions to be inlined into a single function `findDifferences` that is called from `cmpBasicBlocks` after `cmpOperationsWithOperands` returns a difference. 
Also, a separate function `findTypeDifferenceInFieldAccess` for finding differences in chained field abstractions is introduced since these have to be searched for even if the comparison of operations is equal.

Due to moving all the code for setting `toInline` into `cmpBasicBlocks`, the `CmpOperationsInlining` is merged into the `CmpBasicBlocksInlining`.