### PR TITLE
Add colored compilation with Clang support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,13 +21,15 @@ jobs:
         - flake8 diffkemp --exclude=llreve --ignore=F403,F405,W504
         - flake8 tests
         - tools/check-clang-format.sh -d
-    - env: LLVM_VERSION=5.0
+    - env: LLVM_VERSION=5.0 CC=/usr/bin/gcc CXX=/usr/bin/g++
       if: type = cron
-    - env: LLVM_VERSION=6.0
-    - env: LLVM_VERSION=7
-    - env: LLVM_VERSION=8
-    - env: LLVM_VERSION=9
-    - env: LLVM_VERSION=10
+    - env: LLVM_VERSION=6.0 CC=/usr/bin/gcc CXX=/usr/bin/g++
+      if: type = cron
+    - env: LLVM_VERSION=7 CC=/usr/bin/gcc CXX=/usr/bin/g++
+    - env: LLVM_VERSION=8 CC=/usr/bin/gcc CXX=/usr/bin/g++
+    - env: LLVM_VERSION=9 CC=/usr/bin/gcc CXX=/usr/bin/g++
+    - env: LLVM_VERSION=10 CC=/usr/bin/gcc CXX=/usr/bin/g++
+    - env: LLVM_VERSION=10 CC=/usr/local/bin/clang CXX=/usr/local/bin/clang++
 
 addons:
   apt:
@@ -59,9 +61,12 @@ before_install:
   - sudo ln -s /usr/lib/llvm-$LLVM_VERSION/include/llvm-c /usr/local/include/llvm-c
   - sudo update-alternatives --install /usr/local/bin/llvm-config llvm-config /usr/bin/llvm-config-$LLVM_VERSION 100
   - sudo update-alternatives --install /usr/local/bin/clang clang /usr/bin/clang-$LLVM_VERSION 100
+  - sudo update-alternatives --install /usr/local/bin/clang++ clang++ /usr/bin/clang++-$LLVM_VERSION 100
   - sudo update-alternatives --install /usr/local/bin/opt opt /usr/bin/opt-$LLVM_VERSION 100
   - sudo update-alternatives --install /usr/local/bin/llvm-link llvm-link /usr/bin/llvm-link-$LLVM_VERSION 100
   - sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-7 100 --slave /usr/bin/g++ g++ /usr/bin/g++-7
+  - sudo update-alternatives --install /usr/bin/cc cc $CC 100
+  - sudo update-alternatives --install /usr/bin/c++ c++ $CXX 100
   - export PATH=`echo $PATH | sed -e 's#:/usr/local/clang-7.0.0/bin##'`
 
 install:

--- a/diffkemp/simpll/CMakeLists.txt
+++ b/diffkemp/simpll/CMakeLists.txt
@@ -6,6 +6,13 @@ execute_process(COMMAND ${CMAKE_COMMAND} -E create_symlink
   llvm-lib/${LLVM_VERSION_MAJOR}/FunctionComparator.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/FunctionComparator.cpp)
 
+# Add color coding to compiler diagnostics
+if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
+    add_compile_options (-fcolor-diagnostics)
+elseif ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
+    add_compile_options (-fdiagnostics-color=always)
+endif()
+
 file(GLOB srcs *.cpp)
 list(REMOVE_ITEM srcs SimpLL.cpp)
 file(GLOB passes passes/*.cpp)

--- a/diffkemp/simpll/DifferentialFunctionComparator.cpp
+++ b/diffkemp/simpll/DifferentialFunctionComparator.cpp
@@ -232,7 +232,8 @@ int DifferentialFunctionComparator::cmpOperations(
                     }
 
                     if (Result && config.ControlFlowOnly
-                        && abs(CL->getNumOperands() - CR->getNumOperands())
+                        && std::abs(static_cast<long>(CL->getNumOperands())
+                                    - CR->getNumOperands())
                                    == 1) {
                         needToCmpOperands = false;
                         return cmpCallsWithExtraArg(CL, CR);

--- a/diffkemp/simpll/Output.cpp
+++ b/diffkemp/simpll/Output.cpp
@@ -19,7 +19,8 @@
 using namespace llvm::yaml;
 
 // CallInfo to YAML
-namespace llvm::yaml {
+namespace llvm {
+namespace yaml {
 template <> struct MappingTraits<CallInfo> {
     static void mapping(IO &io, CallInfo &callinfo) {
         io.mapRequired("function", callinfo.fun);
@@ -28,14 +29,16 @@ template <> struct MappingTraits<CallInfo> {
         io.mapRequired("weak", callinfo.weak);
     }
 };
-} // namespace llvm::yaml
+} // namespace yaml
+} // namespace llvm
 
 // Vector of CallInfo objects to YAML (used both for callstacks and sets of
 // callees).
 LLVM_YAML_IS_SEQUENCE_VECTOR(CallInfo)
 
 // FunctionInfo to YAML
-namespace llvm::yaml {
+namespace llvm {
+namespace yaml {
 template <> struct MappingTraits<FunctionInfo> {
     static void mapping(IO &io, FunctionInfo &info) {
         std::string name = info.name;
@@ -47,10 +50,12 @@ template <> struct MappingTraits<FunctionInfo> {
         io.mapOptional("calls", calls);
     }
 };
-} // namespace llvm::yaml
+} // namespace yaml
+} // namespace llvm
 
 // NonFunctionDifference (stored in unique_ptr) to YAML
-namespace llvm::yaml {
+namespace llvm {
+namespace yaml {
 template <> struct MappingTraits<std::unique_ptr<NonFunctionDifference>> {
     static void mapping(IO &io, std::unique_ptr<NonFunctionDifference> &diff) {
         io.mapRequired("name", diff->name);
@@ -69,12 +74,14 @@ template <> struct MappingTraits<std::unique_ptr<NonFunctionDifference>> {
         }
     }
 };
-} // namespace llvm::yaml
+} // namespace yaml
+} // namespace llvm
 
 LLVM_YAML_IS_SEQUENCE_VECTOR(std::unique_ptr<NonFunctionDifference>)
 
 // Result::Kind to YAML
-namespace llvm::yaml {
+namespace llvm {
+namespace yaml {
 template <> struct ScalarEnumerationTraits<Result::Kind> {
     static void enumeration(IO &io, Result::Kind &kind) {
         io.enumCase(kind, "equal", Result::Kind::EQUAL);
@@ -83,10 +90,12 @@ template <> struct ScalarEnumerationTraits<Result::Kind> {
         io.enumCase(kind, "unknown", Result::Kind::UNKNOWN);
     }
 };
-} // namespace llvm::yaml
+} // namespace yaml
+} // namespace llvm
 
 // Result to YAML
-namespace llvm::yaml {
+namespace llvm {
+namespace yaml {
 template <> struct MappingTraits<Result> {
     static void mapping(IO &io, Result &result) {
         io.mapRequired("result", result.kind);
@@ -95,12 +104,14 @@ template <> struct MappingTraits<Result> {
         io.mapOptional("differing-objects", result.DifferingObjects);
     }
 };
-} // namespace llvm::yaml
+} // namespace yaml
+} // namespace llvm
 
 LLVM_YAML_IS_SEQUENCE_VECTOR(Result)
 
 // GlobalValue (used for missing definitions) to YAML
-namespace llvm::yaml {
+namespace llvm {
+namespace yaml {
 template <> struct MappingTraits<GlobalValuePair> {
     static void mapping(IO &io, GlobalValuePair &globvals) {
         std::string nameFirst = globvals.first ? globvals.first->getName() : "";
@@ -110,19 +121,22 @@ template <> struct MappingTraits<GlobalValuePair> {
         io.mapOptional("second", nameSecond, std::string());
     }
 };
-} // namespace llvm::yaml
+} // namespace yaml
+} // namespace llvm
 
 LLVM_YAML_IS_SEQUENCE_VECTOR(GlobalValuePair)
 
 // OverallResult to YAML
-namespace llvm::yaml {
+namespace llvm {
+namespace yaml {
 template <> struct MappingTraits<OverallResult> {
     static void mapping(IO &io, OverallResult &result) {
         io.mapOptional("function-results", result.functionResults);
         io.mapOptional("missing-defs", result.missingDefs);
     }
 };
-} // namespace llvm::yaml
+} // namespace yaml
+} // namespace llvm
 
 /// Report the overall result in YAML format to stdout.
 void reportOutput(Config &config, OverallResult &result) {


### PR DESCRIPTION
Includes three small changes concerning the compilation process:

- Add colour diagnostic flags to CMakeLists for both GCC and Clang since a pseudo-terminal gets used with Ninja, which disables output colour coding by default.
- Fix warnings reported ba Clang. These include the removal of template nesting in `Output.cpp` and an unsigned integer subtraction fix in `DifferentialFunctionComparator.cpp`.
- Add Clang compilation into the CI configuration (for the latest version of LLVM only).
