### PR TITLE
Support LLVM 11

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,13 +16,13 @@ jobs:
     runs-on: ubuntu-16.04
     strategy:
       matrix:
-        llvm: ["5.0", "6.0", 7, 8, 9, 10]
+        llvm: ["5.0", "6.0", 7, 8, 9, 10, 11]
         env:
           - CC: gcc-9
             CXX: g++-9
 
         include:
-          - llvm: 10
+          - llvm: 11
             env:
               CC: clang
               CXX: clang++

--- a/diffkemp/simpll/DebugInfo.h
+++ b/diffkemp/simpll/DebugInfo.h
@@ -160,6 +160,8 @@ bool isDebugInfo(const Instruction &Instr);
 /// Get name of a struct type as it is specified in the C source.
 std::string getStructTypeName(const StructType *type);
 
+std::string getEnumValue(const DIEnumerator *Enum);
+
 /// Get type of given Value
 /// \param Val Value of variable.
 /// \return Variable type debug info.

--- a/diffkemp/simpll/ModuleAnalysis.cpp
+++ b/diffkemp/simpll/ModuleAnalysis.cpp
@@ -35,6 +35,9 @@
 #include "passes/UnifyMemcpyPass.h"
 #include "passes/VarDependencySlicer.h"
 #include <llvm/IR/PassManager.h>
+#if LLVM_VERSION_MAJOR >= 11
+#include <llvm/IR/PassManagerImpl.h>
+#endif
 #include <llvm/Passes/PassBuilder.h>
 #include <llvm/Support/FileSystem.h>
 #include <llvm/Support/raw_ostream.h>

--- a/diffkemp/simpll/ModuleComparator.cpp
+++ b/diffkemp/simpll/ModuleComparator.cpp
@@ -121,19 +121,14 @@ void ModuleComparator::compareFunctions(Function *FirstFun,
             ConstFunPair missingDefs;
             bool inlined = false;
             Function *InlinedFunFirst =
-                    !inlineFirst
-                            ? nullptr
-                            : getCalledFunction(inlineFirst->getCalledValue());
+                    !inlineFirst ? nullptr : getCalledFunction(inlineFirst);
             Function *InlinedFunSecond =
-                    !inlineSecond
-                            ? nullptr
-                            : getCalledFunction(inlineSecond->getCalledValue());
+                    !inlineSecond ? nullptr : getCalledFunction(inlineSecond);
             // If the called function is a declaration, add it to missingDefs.
             // Otherwise, inline the call and simplify the function.
             // The above is done for the first and the second call to inline.
             if (inlineFirst) {
-                const Function *toInline =
-                        getCalledFunction(inlineFirst->getCalledValue());
+                const Function *toInline = getCalledFunction(inlineFirst);
                 DEBUG_WITH_TYPE(DEBUG_SIMPLL,
                                 dbgs() << getDebugIndent() << "Try to inline "
                                        << toInline->getName() << " in first\n");
@@ -146,13 +141,12 @@ void ModuleComparator::compareFunctions(Function *FirstFun,
                         missingDefs.first = toInline;
                 } else {
                     InlineFunctionInfo ifi;
-                    if (InlineFunction(inlineFirst, ifi, nullptr, false))
+                    if (inlineCall(inlineFirst))
                         inlined = true;
                 }
             }
             if (inlineSecond) {
-                const Function *toInline =
-                        getCalledFunction(inlineSecond->getCalledValue());
+                const Function *toInline = getCalledFunction(inlineSecond);
                 DEBUG_WITH_TYPE(DEBUG_SIMPLL,
                                 dbgs() << getDebugIndent() << "Try to inline "
                                        << toInline->getName()
@@ -166,7 +160,7 @@ void ModuleComparator::compareFunctions(Function *FirstFun,
                         missingDefs.second = toInline;
                 } else {
                     InlineFunctionInfo ifi;
-                    if (InlineFunction(inlineSecond, ifi, nullptr, false))
+                    if (inlineCall(inlineSecond))
                         inlined = true;
                 }
             }

--- a/diffkemp/simpll/Output.cpp
+++ b/diffkemp/simpll/Output.cpp
@@ -114,10 +114,11 @@ namespace llvm {
 namespace yaml {
 template <> struct MappingTraits<GlobalValuePair> {
     static void mapping(IO &io, GlobalValuePair &globvals) {
-        std::string nameFirst = globvals.first ? globvals.first->getName() : "";
+        std::string nameFirst =
+                globvals.first ? globvals.first->getName().str() : "";
         io.mapOptional("first", nameFirst, std::string());
         std::string nameSecond =
-                globvals.second ? globvals.second->getName() : "";
+                globvals.second ? globvals.second->getName().str() : "";
         io.mapOptional("second", nameSecond, std::string());
     }
 };

--- a/diffkemp/simpll/Result.cpp
+++ b/diffkemp/simpll/Result.cpp
@@ -16,11 +16,11 @@
 #include "Utils.h"
 
 Result::Result(Function *FirstFun, Function *SecondFun)
-        : First(FirstFun->getName(),
+        : First(FirstFun->getName().str(),
                 getFileForFun(FirstFun),
                 FirstFun->getSubprogram() ? FirstFun->getSubprogram()->getLine()
                                           : 0),
-          Second(SecondFun->getName(),
+          Second(SecondFun->getName().str(),
                  getFileForFun(SecondFun),
                  SecondFun->getSubprogram()
                          ? SecondFun->getSubprogram()->getLine()

--- a/diffkemp/simpll/Result.h
+++ b/diffkemp/simpll/Result.h
@@ -64,7 +64,7 @@ struct FunctionInfo {
     /// @param Callee Called function.
     /// @param Call line.
     void addCall(const Function *Callee, int l) {
-        calls.insert(CallInfo(Callee->getName(), file, l));
+        calls.insert(CallInfo(Callee->getName().str(), file, l));
     }
 };
 

--- a/diffkemp/simpll/SourceCodeUtils.cpp
+++ b/diffkemp/simpll/SourceCodeUtils.cpp
@@ -322,7 +322,7 @@ std::vector<std::unique_ptr<SyntaxDifference>>
                     MacroUseR->second.def->body.str(),
                     StackL,
                     StackR,
-                    L->getFunction()->getName()));
+                    L->getFunction()->getName().str()));
         }
     }
 
@@ -521,7 +521,7 @@ std::vector<std::string>
     // Collect all inputs in which we want to search for the inline asm.
     inputs.push_back(line);
     for (auto &Elem : MacroMap)
-        inputs.push_back(Elem.second.def->body);
+        inputs.push_back(Elem.second.def->body.str());
 
     // Extract the candidates (i.e. the inputs that contain inline asm).
     for (auto input : inputs) {
@@ -637,7 +637,7 @@ std::vector<std::string>
     // Collect all inputs in which we want to search for the function call.
     inputs.push_back(line);
     for (auto &Elem : MacroMap)
-        inputs.push_back(Elem.second.def->body);
+        inputs.push_back(Elem.second.def->body.str());
 
     // Extract the function calls from them
     for (auto input : inputs) {

--- a/diffkemp/simpll/Utils.h
+++ b/diffkemp/simpll/Utils.h
@@ -29,13 +29,20 @@ typedef std::pair<Function *, Function *> FunPair;
 typedef std::pair<const Function *, const Function *> ConstFunPair;
 typedef std::pair<const GlobalValue *, const GlobalValue *> GlobalValuePair;
 
-/// Extract called function from a called value. Handles situation when the
-/// called value is a bitcast.
-const Function *getCalledFunction(const Value *CalledValue);
+/// Convert a value to a function.
+/// Handles situation then the actual function is inside a bitcast or alias.
+const Function *valueToFunction(const Value *Value);
 
 /// Extract called function from a called value. Handles situation when the
 /// called value is a bitcast.
-Function *getCalledFunction(Value *CalledValue);
+const Function *getCalledFunction(const CallInst *Call);
+
+/// Extract called function from a called value. Handles situation when the
+/// called value is a bitcast.
+Function *getCalledFunction(CallInst *Call);
+
+Value *getCallee(CallInst *Call);
+const Value *getCallee(const CallInst *Call);
 
 /// Extracts value from an arbitrary number of casts.
 const Value *stripAllCasts(const Value *Val);
@@ -89,7 +96,7 @@ std::string valueAsString(const Constant *Val);
 StructType *getStructType(const Value *Value);
 
 /// Removes empty attribute sets from an attribute list.
-AttributeList cleanAttributeList(AttributeList AL);
+AttributeList cleanAttributeList(AttributeList AL, LLVMContext &Context);
 
 /// Get a non-const pointer to a call instruction in a function
 CallInst *findCallInst(const CallInst *Call, Function *Fun);
@@ -156,5 +163,8 @@ void increaseDebugIndentLevel();
 
 /// Decrease the level of debug indentation by one.
 void decreaseDebugIndentLevel();
+
+/// Inline a function call and return true if inlining succeeded.
+bool inlineCall(CallInst *Call);
 
 #endif // DIFFKEMP_SIMPLL_UTILS_H

--- a/diffkemp/simpll/library/FFI.cpp
+++ b/diffkemp/simpll/library/FFI.cpp
@@ -105,7 +105,6 @@ void *loadModule(const char *Path) {
 
 void freeModule(void *ModRaw) {
     Module *Mod = (Module *)ModRaw;
-    std::string name = Mod->getName();
     ModuleMap.erase(Mod);
     ContextMap.erase(Mod);
 }

--- a/diffkemp/simpll/library/SysctlTable.cpp
+++ b/diffkemp/simpll/library/SysctlTable.cpp
@@ -102,7 +102,7 @@ std::vector<std::string>
         if (!StringConst || !StringConst->isString())
             continue;
         // Remove \0 from the end of the string.
-        std::string Name = StringConst->getAsString().rtrim('\0');
+        std::string Name = StringConst->getAsString().rtrim('\0').str();
 
         // Parse sysctl pattern.
         std::istringstream SysctlPatternStream;

--- a/diffkemp/simpll/llvm-lib/11/FunctionComparator.cpp
+++ b/diffkemp/simpll/llvm-lib/11/FunctionComparator.cpp
@@ -1,0 +1,969 @@
+//===- FunctionComparator.h - Function Comparator -------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// This file implements the FunctionComparator and GlobalNumberState classes
+// which are used by the MergeFunctions pass for comparing functions.
+//
+//===----------------------------------------------------------------------===//
+
+#include "FunctionComparator.h"
+#include "llvm/ADT/APFloat.h"
+#include "llvm/ADT/APInt.h"
+#include "llvm/ADT/ArrayRef.h"
+#include "llvm/ADT/Hashing.h"
+#include "llvm/ADT/SmallPtrSet.h"
+#include "llvm/ADT/SmallVector.h"
+#include "llvm/IR/Attributes.h"
+#include "llvm/IR/BasicBlock.h"
+#include "llvm/IR/Constant.h"
+#include "llvm/IR/Constants.h"
+#include "llvm/IR/DataLayout.h"
+#include "llvm/IR/DerivedTypes.h"
+#include "llvm/IR/Function.h"
+#include "llvm/IR/GlobalValue.h"
+#include "llvm/IR/InlineAsm.h"
+#include "llvm/IR/InstrTypes.h"
+#include "llvm/IR/Instruction.h"
+#include "llvm/IR/Instructions.h"
+#include "llvm/IR/LLVMContext.h"
+#include "llvm/IR/Metadata.h"
+#include "llvm/IR/Module.h"
+#include "llvm/IR/Operator.h"
+#include "llvm/IR/Type.h"
+#include "llvm/IR/Value.h"
+#include "llvm/Support/Casting.h"
+#include "llvm/Support/Compiler.h"
+#include "llvm/Support/Debug.h"
+#include "llvm/Support/ErrorHandling.h"
+#include "llvm/Support/raw_ostream.h"
+#include <cassert>
+#include <cstddef>
+#include <cstdint>
+#include <utility>
+
+using namespace llvm;
+
+#define DEBUG_TYPE "functioncomparator"
+
+int FunctionComparator::cmpNumbers(uint64_t L, uint64_t R) const {
+  if (L < R)
+    return -1;
+  if (L > R)
+    return 1;
+  return 0;
+}
+
+int FunctionComparator::cmpOrderings(AtomicOrdering L, AtomicOrdering R) const {
+  if ((int)L < (int)R)
+    return -1;
+  if ((int)L > (int)R)
+    return 1;
+  return 0;
+}
+
+int FunctionComparator::cmpAPInts(const APInt &L, const APInt &R) const {
+  if (int Res = cmpNumbers(L.getBitWidth(), R.getBitWidth()))
+    return Res;
+  if (L.ugt(R))
+    return 1;
+  if (R.ugt(L))
+    return -1;
+  return 0;
+}
+
+int FunctionComparator::cmpAPFloats(const APFloat &L, const APFloat &R) const {
+  // Floats are ordered first by semantics (i.e. float, double, half, etc.),
+  // then by value interpreted as a bitstring (aka APInt).
+  const fltSemantics &SL = L.getSemantics(), &SR = R.getSemantics();
+  if (int Res = cmpNumbers(APFloat::semanticsPrecision(SL),
+                           APFloat::semanticsPrecision(SR)))
+    return Res;
+  if (int Res = cmpNumbers(APFloat::semanticsMaxExponent(SL),
+                           APFloat::semanticsMaxExponent(SR)))
+    return Res;
+  if (int Res = cmpNumbers(APFloat::semanticsMinExponent(SL),
+                           APFloat::semanticsMinExponent(SR)))
+    return Res;
+  if (int Res = cmpNumbers(APFloat::semanticsSizeInBits(SL),
+                           APFloat::semanticsSizeInBits(SR)))
+    return Res;
+  return cmpAPInts(L.bitcastToAPInt(), R.bitcastToAPInt());
+}
+
+int FunctionComparator::cmpMem(StringRef L, StringRef R) const {
+  // Prevent heavy comparison, compare sizes first.
+  if (int Res = cmpNumbers(L.size(), R.size()))
+    return Res;
+
+  // Compare strings lexicographically only when it is necessary: only when
+  // strings are equal in size.
+  return L.compare(R);
+}
+
+int FunctionComparator::cmpAttrs(const AttributeList L,
+                                 const AttributeList R) const {
+  if (int Res = cmpNumbers(L.getNumAttrSets(), R.getNumAttrSets()))
+    return Res;
+
+  for (unsigned i = L.index_begin(), e = L.index_end(); i != e; ++i) {
+    AttributeSet LAS = L.getAttributes(i);
+    AttributeSet RAS = R.getAttributes(i);
+    AttributeSet::iterator LI = LAS.begin(), LE = LAS.end();
+    AttributeSet::iterator RI = RAS.begin(), RE = RAS.end();
+    for (; LI != LE && RI != RE; ++LI, ++RI) {
+      Attribute LA = *LI;
+      Attribute RA = *RI;
+      if (LA.isTypeAttribute() && RA.isTypeAttribute()) {
+        if (LA.getKindAsEnum() != RA.getKindAsEnum())
+          return cmpNumbers(LA.getKindAsEnum(), RA.getKindAsEnum());
+
+        Type *TyL = LA.getValueAsType();
+        Type *TyR = RA.getValueAsType();
+        if (TyL && TyR)
+          return cmpTypes(TyL, TyR);
+
+        // Two pointers, at least one null, so the comparison result is
+        // independent of the value of a real pointer.
+        return cmpNumbers((uint64_t)TyL, (uint64_t)TyR);
+      }
+      if (LA < RA)
+        return -1;
+      if (RA < LA)
+        return 1;
+    }
+    if (LI != LE)
+      return 1;
+    if (RI != RE)
+      return -1;
+  }
+  return 0;
+}
+
+int FunctionComparator::cmpRangeMetadata(const MDNode *L,
+                                         const MDNode *R) const {
+  if (L == R)
+    return 0;
+  if (!L)
+    return -1;
+  if (!R)
+    return 1;
+  // Range metadata is a sequence of numbers. Make sure they are the same
+  // sequence.
+  // TODO: Note that as this is metadata, it is possible to drop and/or merge
+  // this data when considering functions to merge. Thus this comparison would
+  // return 0 (i.e. equivalent), but merging would become more complicated
+  // because the ranges would need to be unioned. It is not likely that
+  // functions differ ONLY in this metadata if they are actually the same
+  // function semantically.
+  if (int Res = cmpNumbers(L->getNumOperands(), R->getNumOperands()))
+    return Res;
+  for (size_t I = 0; I < L->getNumOperands(); ++I) {
+    ConstantInt *LLow = mdconst::extract<ConstantInt>(L->getOperand(I));
+    ConstantInt *RLow = mdconst::extract<ConstantInt>(R->getOperand(I));
+    if (int Res = cmpAPInts(LLow->getValue(), RLow->getValue()))
+      return Res;
+  }
+  return 0;
+}
+
+int FunctionComparator::cmpOperandBundlesSchema(const CallBase &LCS,
+                                                const CallBase &RCS) const {
+  assert(LCS.getOpcode() == RCS.getOpcode() && "Can't compare otherwise!");
+
+  if (int Res =
+          cmpNumbers(LCS.getNumOperandBundles(), RCS.getNumOperandBundles()))
+    return Res;
+
+  for (unsigned I = 0, E = LCS.getNumOperandBundles(); I != E; ++I) {
+    auto OBL = LCS.getOperandBundleAt(I);
+    auto OBR = RCS.getOperandBundleAt(I);
+
+    if (int Res = OBL.getTagName().compare(OBR.getTagName()))
+      return Res;
+
+    if (int Res = cmpNumbers(OBL.Inputs.size(), OBR.Inputs.size()))
+      return Res;
+  }
+
+  return 0;
+}
+
+/// Constants comparison:
+/// 1. Check whether type of L constant could be losslessly bitcasted to R
+/// type.
+/// 2. Compare constant contents.
+/// For more details see declaration comments.
+int FunctionComparator::cmpConstants(const Constant *L,
+                                     const Constant *R) const {
+  Type *TyL = L->getType();
+  Type *TyR = R->getType();
+
+  // Check whether types are bitcastable. This part is just re-factored
+  // Type::canLosslesslyBitCastTo method, but instead of returning true/false,
+  // we also pack into result which type is "less" for us.
+  int TypesRes = cmpTypes(TyL, TyR);
+  if (TypesRes != 0) {
+    // Types are different, but check whether we can bitcast them.
+    if (!TyL->isFirstClassType()) {
+      if (TyR->isFirstClassType())
+        return -1;
+      // Neither TyL nor TyR are values of first class type. Return the result
+      // of comparing the types
+      return TypesRes;
+    }
+    if (!TyR->isFirstClassType()) {
+      if (TyL->isFirstClassType())
+        return 1;
+      return TypesRes;
+    }
+
+    // Vector -> Vector conversions are always lossless if the two vector types
+    // have the same size, otherwise not.
+    unsigned TyLWidth = 0;
+    unsigned TyRWidth = 0;
+
+    if (auto *VecTyL = dyn_cast<VectorType>(TyL))
+      TyLWidth = VecTyL->getPrimitiveSizeInBits().getFixedSize();
+    if (auto *VecTyR = dyn_cast<VectorType>(TyR))
+      TyRWidth = VecTyR->getPrimitiveSizeInBits().getFixedSize();
+
+    if (TyLWidth != TyRWidth)
+      return cmpNumbers(TyLWidth, TyRWidth);
+
+    // Zero bit-width means neither TyL nor TyR are vectors.
+    if (!TyLWidth) {
+      PointerType *PTyL = dyn_cast<PointerType>(TyL);
+      PointerType *PTyR = dyn_cast<PointerType>(TyR);
+      if (PTyL && PTyR) {
+        unsigned AddrSpaceL = PTyL->getAddressSpace();
+        unsigned AddrSpaceR = PTyR->getAddressSpace();
+        if (int Res = cmpNumbers(AddrSpaceL, AddrSpaceR))
+          return Res;
+      }
+      if (PTyL)
+        return 1;
+      if (PTyR)
+        return -1;
+
+      // TyL and TyR aren't vectors, nor pointers. We don't know how to
+      // bitcast them.
+      return TypesRes;
+    }
+  }
+
+  // OK, types are bitcastable, now check constant contents.
+
+  if (L->isNullValue() && R->isNullValue())
+    return TypesRes;
+  if (L->isNullValue() && !R->isNullValue())
+    return 1;
+  if (!L->isNullValue() && R->isNullValue())
+    return -1;
+
+  auto GlobalValueL = const_cast<GlobalValue *>(dyn_cast<GlobalValue>(L));
+  auto GlobalValueR = const_cast<GlobalValue *>(dyn_cast<GlobalValue>(R));
+  if (GlobalValueL && GlobalValueR) {
+    return cmpGlobalValues(GlobalValueL, GlobalValueR);
+  }
+
+  if (int Res = cmpNumbers(L->getValueID(), R->getValueID()))
+    return Res;
+
+  if (const auto *SeqL = dyn_cast<ConstantDataSequential>(L)) {
+    const auto *SeqR = cast<ConstantDataSequential>(R);
+    // This handles ConstantDataArray and ConstantDataVector. Note that we
+    // compare the two raw data arrays, which might differ depending on the host
+    // endianness. This isn't a problem though, because the endiness of a module
+    // will affect the order of the constants, but this order is the same
+    // for a given input module and host platform.
+    return cmpMem(SeqL->getRawDataValues(), SeqR->getRawDataValues());
+  }
+
+  switch (L->getValueID()) {
+  case Value::UndefValueVal:
+  case Value::ConstantTokenNoneVal:
+    return TypesRes;
+  case Value::ConstantIntVal: {
+    const APInt &LInt = cast<ConstantInt>(L)->getValue();
+    const APInt &RInt = cast<ConstantInt>(R)->getValue();
+    return cmpAPInts(LInt, RInt);
+  }
+  case Value::ConstantFPVal: {
+    const APFloat &LAPF = cast<ConstantFP>(L)->getValueAPF();
+    const APFloat &RAPF = cast<ConstantFP>(R)->getValueAPF();
+    return cmpAPFloats(LAPF, RAPF);
+  }
+  case Value::ConstantArrayVal: {
+    const ConstantArray *LA = cast<ConstantArray>(L);
+    const ConstantArray *RA = cast<ConstantArray>(R);
+    uint64_t NumElementsL = cast<ArrayType>(TyL)->getNumElements();
+    uint64_t NumElementsR = cast<ArrayType>(TyR)->getNumElements();
+    if (int Res = cmpNumbers(NumElementsL, NumElementsR))
+      return Res;
+    for (uint64_t i = 0; i < NumElementsL; ++i) {
+      if (int Res = cmpConstants(cast<Constant>(LA->getOperand(i)),
+                                 cast<Constant>(RA->getOperand(i))))
+        return Res;
+    }
+    return 0;
+  }
+  case Value::ConstantStructVal: {
+    const ConstantStruct *LS = cast<ConstantStruct>(L);
+    const ConstantStruct *RS = cast<ConstantStruct>(R);
+    unsigned NumElementsL = cast<StructType>(TyL)->getNumElements();
+    unsigned NumElementsR = cast<StructType>(TyR)->getNumElements();
+    if (int Res = cmpNumbers(NumElementsL, NumElementsR))
+      return Res;
+    for (unsigned i = 0; i != NumElementsL; ++i) {
+      if (int Res = cmpConstants(cast<Constant>(LS->getOperand(i)),
+                                 cast<Constant>(RS->getOperand(i))))
+        return Res;
+    }
+    return 0;
+  }
+  case Value::ConstantVectorVal: {
+    const ConstantVector *LV = cast<ConstantVector>(L);
+    const ConstantVector *RV = cast<ConstantVector>(R);
+    unsigned NumElementsL = cast<FixedVectorType>(TyL)->getNumElements();
+    unsigned NumElementsR = cast<FixedVectorType>(TyR)->getNumElements();
+    if (int Res = cmpNumbers(NumElementsL, NumElementsR))
+      return Res;
+    for (uint64_t i = 0; i < NumElementsL; ++i) {
+      if (int Res = cmpConstants(cast<Constant>(LV->getOperand(i)),
+                                 cast<Constant>(RV->getOperand(i))))
+        return Res;
+    }
+    return 0;
+  }
+  case Value::ConstantExprVal: {
+    const ConstantExpr *LE = cast<ConstantExpr>(L);
+    const ConstantExpr *RE = cast<ConstantExpr>(R);
+    unsigned NumOperandsL = LE->getNumOperands();
+    unsigned NumOperandsR = RE->getNumOperands();
+    if (int Res = cmpNumbers(NumOperandsL, NumOperandsR))
+      return Res;
+    for (unsigned i = 0; i < NumOperandsL; ++i) {
+      if (int Res = cmpConstants(cast<Constant>(LE->getOperand(i)),
+                                 cast<Constant>(RE->getOperand(i))))
+        return Res;
+    }
+    return 0;
+  }
+  case Value::BlockAddressVal: {
+    const BlockAddress *LBA = cast<BlockAddress>(L);
+    const BlockAddress *RBA = cast<BlockAddress>(R);
+    if (int Res = cmpValues(LBA->getFunction(), RBA->getFunction()))
+      return Res;
+    if (LBA->getFunction() == RBA->getFunction()) {
+      // They are BBs in the same function. Order by which comes first in the
+      // BB order of the function. This order is deterministic.
+      Function *F = LBA->getFunction();
+      BasicBlock *LBB = LBA->getBasicBlock();
+      BasicBlock *RBB = RBA->getBasicBlock();
+      if (LBB == RBB)
+        return 0;
+      for (BasicBlock &BB : F->getBasicBlockList()) {
+        if (&BB == LBB) {
+          assert(&BB != RBB);
+          return -1;
+        }
+        if (&BB == RBB)
+          return 1;
+      }
+      llvm_unreachable("Basic Block Address does not point to a basic block in "
+                       "its function.");
+      return -1;
+    } else {
+      // cmpValues said the functions are the same. So because they aren't
+      // literally the same pointer, they must respectively be the left and
+      // right functions.
+      assert(LBA->getFunction() == FnL && RBA->getFunction() == FnR);
+      // cmpValues will tell us if these are equivalent BasicBlocks, in the
+      // context of their respective functions.
+      return cmpValues(LBA->getBasicBlock(), RBA->getBasicBlock());
+    }
+  }
+  default: // Unknown constant, abort.
+    LLVM_DEBUG(dbgs() << "Looking at valueID " << L->getValueID() << "\n");
+    llvm_unreachable("Constant ValueID not recognized.");
+    return -1;
+  }
+}
+
+int FunctionComparator::cmpGlobalValues(GlobalValue *L, GlobalValue *R) const {
+  uint64_t LNumber = GlobalNumbers->getNumber(L);
+  uint64_t RNumber = GlobalNumbers->getNumber(R);
+  return cmpNumbers(LNumber, RNumber);
+}
+
+/// cmpType - compares two types,
+/// defines total ordering among the types set.
+/// See method declaration comments for more details.
+int FunctionComparator::cmpTypes(Type *TyL, Type *TyR) const {
+  PointerType *PTyL = dyn_cast<PointerType>(TyL);
+  PointerType *PTyR = dyn_cast<PointerType>(TyR);
+
+  const DataLayout &DL = FnL->getParent()->getDataLayout();
+  if (PTyL && PTyL->getAddressSpace() == 0)
+    TyL = DL.getIntPtrType(TyL);
+  if (PTyR && PTyR->getAddressSpace() == 0)
+    TyR = DL.getIntPtrType(TyR);
+
+  if (TyL == TyR)
+    return 0;
+
+  if (int Res = cmpNumbers(TyL->getTypeID(), TyR->getTypeID()))
+    return Res;
+
+  switch (TyL->getTypeID()) {
+  default:
+    llvm_unreachable("Unknown type!");
+  case Type::IntegerTyID:
+    return cmpNumbers(cast<IntegerType>(TyL)->getBitWidth(),
+                      cast<IntegerType>(TyR)->getBitWidth());
+  // TyL == TyR would have returned true earlier, because types are uniqued.
+  case Type::VoidTyID:
+  case Type::FloatTyID:
+  case Type::DoubleTyID:
+  case Type::X86_FP80TyID:
+  case Type::FP128TyID:
+  case Type::PPC_FP128TyID:
+  case Type::LabelTyID:
+  case Type::MetadataTyID:
+  case Type::TokenTyID:
+    return 0;
+
+  case Type::PointerTyID:
+    assert(PTyL && PTyR && "Both types must be pointers here.");
+    return cmpNumbers(PTyL->getAddressSpace(), PTyR->getAddressSpace());
+
+  case Type::StructTyID: {
+    StructType *STyL = cast<StructType>(TyL);
+    StructType *STyR = cast<StructType>(TyR);
+    if (STyL->getNumElements() != STyR->getNumElements())
+      return cmpNumbers(STyL->getNumElements(), STyR->getNumElements());
+
+    if (STyL->isPacked() != STyR->isPacked())
+      return cmpNumbers(STyL->isPacked(), STyR->isPacked());
+
+    for (unsigned i = 0, e = STyL->getNumElements(); i != e; ++i) {
+      if (int Res = cmpTypes(STyL->getElementType(i), STyR->getElementType(i)))
+        return Res;
+    }
+    return 0;
+  }
+
+  case Type::FunctionTyID: {
+    FunctionType *FTyL = cast<FunctionType>(TyL);
+    FunctionType *FTyR = cast<FunctionType>(TyR);
+    if (FTyL->getNumParams() != FTyR->getNumParams())
+      return cmpNumbers(FTyL->getNumParams(), FTyR->getNumParams());
+
+    if (FTyL->isVarArg() != FTyR->isVarArg())
+      return cmpNumbers(FTyL->isVarArg(), FTyR->isVarArg());
+
+    if (int Res = cmpTypes(FTyL->getReturnType(), FTyR->getReturnType()))
+      return Res;
+
+    for (unsigned i = 0, e = FTyL->getNumParams(); i != e; ++i) {
+      if (int Res = cmpTypes(FTyL->getParamType(i), FTyR->getParamType(i)))
+        return Res;
+    }
+    return 0;
+  }
+
+  case Type::ArrayTyID: {
+    auto *STyL = cast<ArrayType>(TyL);
+    auto *STyR = cast<ArrayType>(TyR);
+    if (STyL->getNumElements() != STyR->getNumElements())
+      return cmpNumbers(STyL->getNumElements(), STyR->getNumElements());
+    return cmpTypes(STyL->getElementType(), STyR->getElementType());
+  }
+  case Type::FixedVectorTyID:
+  case Type::ScalableVectorTyID: {
+    auto *STyL = cast<VectorType>(TyL);
+    auto *STyR = cast<VectorType>(TyR);
+    if (STyL->getElementCount().Scalable != STyR->getElementCount().Scalable)
+      return cmpNumbers(STyL->getElementCount().Scalable,
+                        STyR->getElementCount().Scalable);
+    if (STyL->getElementCount().Min != STyR->getElementCount().Min)
+      return cmpNumbers(STyL->getElementCount().Min,
+                        STyR->getElementCount().Min);
+    return cmpTypes(STyL->getElementType(), STyR->getElementType());
+  }
+  }
+}
+
+// Determine whether the two operations are the same except that pointer-to-A
+// and pointer-to-B are equivalent. This should be kept in sync with
+// Instruction::isSameOperationAs.
+// Read method declaration comments for more details.
+int FunctionComparator::cmpOperations(const Instruction *L,
+                                      const Instruction *R,
+                                      bool &needToCmpOperands) const {
+  needToCmpOperands = true;
+  if (int Res = cmpValues(L, R))
+    return Res;
+
+  // Differences from Instruction::isSameOperationAs:
+  //  * replace type comparison with calls to cmpTypes.
+  //  * we test for I->getRawSubclassOptionalData (nuw/nsw/tail) at the top.
+  //  * because of the above, we don't test for the tail bit on calls later on.
+  if (int Res = cmpNumbers(L->getOpcode(), R->getOpcode()))
+    return Res;
+
+  if (const GetElementPtrInst *GEPL = dyn_cast<GetElementPtrInst>(L)) {
+    needToCmpOperands = false;
+    const GetElementPtrInst *GEPR = cast<GetElementPtrInst>(R);
+    if (int Res =
+            cmpValues(GEPL->getPointerOperand(), GEPR->getPointerOperand()))
+      return Res;
+    return cmpGEPs(GEPL, GEPR);
+  }
+
+  if (int Res = cmpNumbers(L->getNumOperands(), R->getNumOperands()))
+    return Res;
+
+  if (int Res = cmpTypes(L->getType(), R->getType()))
+    return Res;
+
+  if (int Res = cmpNumbers(L->getRawSubclassOptionalData(),
+                           R->getRawSubclassOptionalData()))
+    return Res;
+
+  // We have two instructions of identical opcode and #operands.  Check to see
+  // if all operands are the same type
+  for (unsigned i = 0, e = L->getNumOperands(); i != e; ++i) {
+    if (int Res =
+            cmpTypes(L->getOperand(i)->getType(), R->getOperand(i)->getType()))
+      return Res;
+  }
+
+  // Check special state that is a part of some instructions.
+  if (const AllocaInst *AI = dyn_cast<AllocaInst>(L)) {
+    if (int Res = cmpTypes(AI->getAllocatedType(),
+                           cast<AllocaInst>(R)->getAllocatedType()))
+      return Res;
+    return cmpNumbers(AI->getAlignment(), cast<AllocaInst>(R)->getAlignment());
+  }
+  if (const LoadInst *LI = dyn_cast<LoadInst>(L)) {
+    if (int Res = cmpNumbers(LI->isVolatile(), cast<LoadInst>(R)->isVolatile()))
+      return Res;
+    if (int Res =
+            cmpNumbers(LI->getAlignment(), cast<LoadInst>(R)->getAlignment()))
+      return Res;
+    if (int Res =
+            cmpOrderings(LI->getOrdering(), cast<LoadInst>(R)->getOrdering()))
+      return Res;
+    if (int Res = cmpNumbers(LI->getSyncScopeID(),
+                             cast<LoadInst>(R)->getSyncScopeID()))
+      return Res;
+    return cmpRangeMetadata(
+        LI->getMetadata(LLVMContext::MD_range),
+        cast<LoadInst>(R)->getMetadata(LLVMContext::MD_range));
+  }
+  if (const StoreInst *SI = dyn_cast<StoreInst>(L)) {
+    if (int Res =
+            cmpNumbers(SI->isVolatile(), cast<StoreInst>(R)->isVolatile()))
+      return Res;
+    if (int Res =
+            cmpNumbers(SI->getAlignment(), cast<StoreInst>(R)->getAlignment()))
+      return Res;
+    if (int Res =
+            cmpOrderings(SI->getOrdering(), cast<StoreInst>(R)->getOrdering()))
+      return Res;
+    return cmpNumbers(SI->getSyncScopeID(),
+                      cast<StoreInst>(R)->getSyncScopeID());
+  }
+  if (const CmpInst *CI = dyn_cast<CmpInst>(L))
+    return cmpNumbers(CI->getPredicate(), cast<CmpInst>(R)->getPredicate());
+  if (auto *CBL = dyn_cast<CallBase>(L)) {
+    auto *CBR = cast<CallBase>(R);
+    if (int Res = cmpNumbers(CBL->getCallingConv(), CBR->getCallingConv()))
+      return Res;
+    if (int Res = cmpAttrs(CBL->getAttributes(), CBR->getAttributes()))
+      return Res;
+    if (int Res = cmpOperandBundlesSchema(*CBL, *CBR))
+      return Res;
+    if (const CallInst *CI = dyn_cast<CallInst>(L))
+      if (int Res = cmpNumbers(CI->getTailCallKind(),
+                               cast<CallInst>(R)->getTailCallKind()))
+        return Res;
+    return cmpRangeMetadata(L->getMetadata(LLVMContext::MD_range),
+                            R->getMetadata(LLVMContext::MD_range));
+  }
+  if (const InsertValueInst *IVI = dyn_cast<InsertValueInst>(L)) {
+    ArrayRef<unsigned> LIndices = IVI->getIndices();
+    ArrayRef<unsigned> RIndices = cast<InsertValueInst>(R)->getIndices();
+    if (int Res = cmpNumbers(LIndices.size(), RIndices.size()))
+      return Res;
+    for (size_t i = 0, e = LIndices.size(); i != e; ++i) {
+      if (int Res = cmpNumbers(LIndices[i], RIndices[i]))
+        return Res;
+    }
+    return 0;
+  }
+  if (const ExtractValueInst *EVI = dyn_cast<ExtractValueInst>(L)) {
+    ArrayRef<unsigned> LIndices = EVI->getIndices();
+    ArrayRef<unsigned> RIndices = cast<ExtractValueInst>(R)->getIndices();
+    if (int Res = cmpNumbers(LIndices.size(), RIndices.size()))
+      return Res;
+    for (size_t i = 0, e = LIndices.size(); i != e; ++i) {
+      if (int Res = cmpNumbers(LIndices[i], RIndices[i]))
+        return Res;
+    }
+  }
+  if (const FenceInst *FI = dyn_cast<FenceInst>(L)) {
+    if (int Res =
+            cmpOrderings(FI->getOrdering(), cast<FenceInst>(R)->getOrdering()))
+      return Res;
+    return cmpNumbers(FI->getSyncScopeID(),
+                      cast<FenceInst>(R)->getSyncScopeID());
+  }
+  if (const AtomicCmpXchgInst *CXI = dyn_cast<AtomicCmpXchgInst>(L)) {
+    if (int Res = cmpNumbers(CXI->isVolatile(),
+                             cast<AtomicCmpXchgInst>(R)->isVolatile()))
+      return Res;
+    if (int Res =
+            cmpNumbers(CXI->isWeak(), cast<AtomicCmpXchgInst>(R)->isWeak()))
+      return Res;
+    if (int Res =
+            cmpOrderings(CXI->getSuccessOrdering(),
+                         cast<AtomicCmpXchgInst>(R)->getSuccessOrdering()))
+      return Res;
+    if (int Res =
+            cmpOrderings(CXI->getFailureOrdering(),
+                         cast<AtomicCmpXchgInst>(R)->getFailureOrdering()))
+      return Res;
+    return cmpNumbers(CXI->getSyncScopeID(),
+                      cast<AtomicCmpXchgInst>(R)->getSyncScopeID());
+  }
+  if (const AtomicRMWInst *RMWI = dyn_cast<AtomicRMWInst>(L)) {
+    if (int Res = cmpNumbers(RMWI->getOperation(),
+                             cast<AtomicRMWInst>(R)->getOperation()))
+      return Res;
+    if (int Res = cmpNumbers(RMWI->isVolatile(),
+                             cast<AtomicRMWInst>(R)->isVolatile()))
+      return Res;
+    if (int Res = cmpOrderings(RMWI->getOrdering(),
+                               cast<AtomicRMWInst>(R)->getOrdering()))
+      return Res;
+    return cmpNumbers(RMWI->getSyncScopeID(),
+                      cast<AtomicRMWInst>(R)->getSyncScopeID());
+  }
+  if (const ShuffleVectorInst *SVI = dyn_cast<ShuffleVectorInst>(L)) {
+    ArrayRef<int> LMask = SVI->getShuffleMask();
+    ArrayRef<int> RMask = cast<ShuffleVectorInst>(R)->getShuffleMask();
+    if (int Res = cmpNumbers(LMask.size(), RMask.size()))
+      return Res;
+    for (size_t i = 0, e = LMask.size(); i != e; ++i) {
+      if (int Res = cmpNumbers(LMask[i], RMask[i]))
+        return Res;
+    }
+  }
+  if (const PHINode *PNL = dyn_cast<PHINode>(L)) {
+    const PHINode *PNR = cast<PHINode>(R);
+    // Ensure that in addition to the incoming values being identical
+    // (checked by the caller of this function), the incoming blocks
+    // are also identical.
+    for (unsigned i = 0, e = PNL->getNumIncomingValues(); i != e; ++i) {
+      if (int Res =
+              cmpValues(PNL->getIncomingBlock(i), PNR->getIncomingBlock(i)))
+        return Res;
+    }
+  }
+  return 0;
+}
+
+// Determine whether two GEP operations perform the same underlying arithmetic.
+// Read method declaration comments for more details.
+int FunctionComparator::cmpGEPs(const GEPOperator *GEPL,
+                                const GEPOperator *GEPR) const {
+  unsigned int ASL = GEPL->getPointerAddressSpace();
+  unsigned int ASR = GEPR->getPointerAddressSpace();
+
+  if (int Res = cmpNumbers(ASL, ASR))
+    return Res;
+
+  // When we have target data, we can reduce the GEP down to the value in bytes
+  // added to the address.
+  const DataLayout &DL = FnL->getParent()->getDataLayout();
+  unsigned BitWidth = DL.getPointerSizeInBits(ASL);
+  APInt OffsetL(BitWidth, 0), OffsetR(BitWidth, 0);
+  if (GEPL->accumulateConstantOffset(DL, OffsetL) &&
+      GEPR->accumulateConstantOffset(DL, OffsetR))
+    return cmpAPInts(OffsetL, OffsetR);
+  if (int Res =
+          cmpTypes(GEPL->getSourceElementType(), GEPR->getSourceElementType()))
+    return Res;
+
+  if (int Res = cmpNumbers(GEPL->getNumOperands(), GEPR->getNumOperands()))
+    return Res;
+
+  for (unsigned i = 0, e = GEPL->getNumOperands(); i != e; ++i) {
+    if (int Res = cmpValues(GEPL->getOperand(i), GEPR->getOperand(i)))
+      return Res;
+  }
+
+  return 0;
+}
+
+int FunctionComparator::cmpInlineAsm(const InlineAsm *L,
+                                     const InlineAsm *R) const {
+  // InlineAsm's are uniqued. If they are the same pointer, obviously they are
+  // the same, otherwise compare the fields.
+  if (L == R)
+    return 0;
+  if (int Res = cmpTypes(L->getFunctionType(), R->getFunctionType()))
+    return Res;
+  if (int Res = cmpMem(L->getAsmString(), R->getAsmString()))
+    return Res;
+  if (int Res = cmpMem(L->getConstraintString(), R->getConstraintString()))
+    return Res;
+  if (int Res = cmpNumbers(L->hasSideEffects(), R->hasSideEffects()))
+    return Res;
+  if (int Res = cmpNumbers(L->isAlignStack(), R->isAlignStack()))
+    return Res;
+  if (int Res = cmpNumbers(L->getDialect(), R->getDialect()))
+    return Res;
+  assert(L->getFunctionType() != R->getFunctionType());
+  return 0;
+}
+
+/// Compare two values used by the two functions under pair-wise comparison. If
+/// this is the first time the values are seen, they're added to the mapping so
+/// that we will detect mismatches on next use.
+/// See comments in declaration for more details.
+int FunctionComparator::cmpValues(const Value *L, const Value *R) const {
+  // Catch self-reference case.
+  if (L == FnL) {
+    if (R == FnR)
+      return 0;
+    return -1;
+  }
+  if (R == FnR) {
+    if (L == FnL)
+      return 0;
+    return 1;
+  }
+
+  const Constant *ConstL = dyn_cast<Constant>(L);
+  const Constant *ConstR = dyn_cast<Constant>(R);
+  if (ConstL && ConstR) {
+    if (L == R)
+      return 0;
+    return cmpConstants(ConstL, ConstR);
+  }
+
+  if (ConstL)
+    return 1;
+  if (ConstR)
+    return -1;
+
+  const InlineAsm *InlineAsmL = dyn_cast<InlineAsm>(L);
+  const InlineAsm *InlineAsmR = dyn_cast<InlineAsm>(R);
+
+  if (InlineAsmL && InlineAsmR)
+    return cmpInlineAsm(InlineAsmL, InlineAsmR);
+  if (InlineAsmL)
+    return 1;
+  if (InlineAsmR)
+    return -1;
+
+  auto LeftSN = sn_mapL.insert(std::make_pair(L, sn_mapL.size())),
+       RightSN = sn_mapR.insert(std::make_pair(R, sn_mapR.size()));
+
+  return cmpNumbers(LeftSN.first->second, RightSN.first->second);
+}
+
+// Test whether two basic blocks have equivalent behaviour.
+int FunctionComparator::cmpBasicBlocks(const BasicBlock *BBL,
+                                       const BasicBlock *BBR) const {
+  BasicBlock::const_iterator InstL = BBL->begin(), InstLE = BBL->end();
+  BasicBlock::const_iterator InstR = BBR->begin(), InstRE = BBR->end();
+
+  do {
+    bool needToCmpOperands = true;
+    if (int Res = cmpOperations(&*InstL, &*InstR, needToCmpOperands))
+      return Res;
+    if (needToCmpOperands) {
+      assert(InstL->getNumOperands() == InstR->getNumOperands());
+
+      for (unsigned i = 0, e = InstL->getNumOperands(); i != e; ++i) {
+        Value *OpL = InstL->getOperand(i);
+        Value *OpR = InstR->getOperand(i);
+        if (int Res = cmpValues(OpL, OpR))
+          return Res;
+        // cmpValues should ensure this is true.
+        assert(cmpTypes(OpL->getType(), OpR->getType()) == 0);
+      }
+    }
+
+    ++InstL;
+    ++InstR;
+  } while (InstL != InstLE && InstR != InstRE);
+
+  if (InstL != InstLE && InstR == InstRE)
+    return 1;
+  if (InstL == InstLE && InstR != InstRE)
+    return -1;
+  return 0;
+}
+
+int FunctionComparator::compareSignature() const {
+  if (int Res = cmpAttrs(FnL->getAttributes(), FnR->getAttributes()))
+    return Res;
+
+  if (int Res = cmpNumbers(FnL->hasGC(), FnR->hasGC()))
+    return Res;
+
+  if (FnL->hasGC()) {
+    if (int Res = cmpMem(FnL->getGC(), FnR->getGC()))
+      return Res;
+  }
+
+  if (int Res = cmpNumbers(FnL->hasSection(), FnR->hasSection()))
+    return Res;
+
+  if (FnL->hasSection()) {
+    if (int Res = cmpMem(FnL->getSection(), FnR->getSection()))
+      return Res;
+  }
+
+  if (int Res = cmpNumbers(FnL->isVarArg(), FnR->isVarArg()))
+    return Res;
+
+  // TODO: if it's internal and only used in direct calls, we could handle this
+  // case too.
+  if (int Res = cmpNumbers(FnL->getCallingConv(), FnR->getCallingConv()))
+    return Res;
+
+  if (int Res = cmpTypes(FnL->getFunctionType(), FnR->getFunctionType()))
+    return Res;
+
+  assert(FnL->arg_size() == FnR->arg_size() &&
+         "Identically typed functions have different numbers of args!");
+
+  // Visit the arguments so that they get enumerated in the order they're
+  // passed in.
+  for (Function::const_arg_iterator ArgLI = FnL->arg_begin(),
+                                    ArgRI = FnR->arg_begin(),
+                                    ArgLE = FnL->arg_end();
+       ArgLI != ArgLE; ++ArgLI, ++ArgRI) {
+    if (cmpValues(&*ArgLI, &*ArgRI) != 0)
+      llvm_unreachable("Arguments repeat!");
+  }
+  return 0;
+}
+
+// Test whether the two functions have equivalent behaviour.
+int FunctionComparator::compare() {
+  beginCompare();
+
+  if (int Res = compareSignature())
+    return Res;
+
+  // We do a CFG-ordered walk since the actual ordering of the blocks in the
+  // linked list is immaterial. Our walk starts at the entry block for both
+  // functions, then takes each block from each terminator in order. As an
+  // artifact, this also means that unreachable blocks are ignored.
+  SmallVector<const BasicBlock *, 8> FnLBBs, FnRBBs;
+  SmallPtrSet<const BasicBlock *, 32> VisitedBBs; // in terms of F1.
+
+  FnLBBs.push_back(&FnL->getEntryBlock());
+  FnRBBs.push_back(&FnR->getEntryBlock());
+
+  VisitedBBs.insert(FnLBBs[0]);
+  while (!FnLBBs.empty()) {
+    const BasicBlock *BBL = FnLBBs.pop_back_val();
+    const BasicBlock *BBR = FnRBBs.pop_back_val();
+
+    if (int Res = cmpValues(BBL, BBR))
+      return Res;
+
+    if (int Res = cmpBasicBlocks(BBL, BBR))
+      return Res;
+
+    const Instruction *TermL = BBL->getTerminator();
+    const Instruction *TermR = BBR->getTerminator();
+
+    assert(TermL->getNumSuccessors() == TermR->getNumSuccessors());
+    for (unsigned i = 0, e = TermL->getNumSuccessors(); i != e; ++i) {
+      if (!VisitedBBs.insert(TermL->getSuccessor(i)).second)
+        continue;
+
+      FnLBBs.push_back(TermL->getSuccessor(i));
+      FnRBBs.push_back(TermR->getSuccessor(i));
+    }
+  }
+  return 0;
+}
+
+namespace {
+
+// Accumulate the hash of a sequence of 64-bit integers. This is similar to a
+// hash of a sequence of 64bit ints, but the entire input does not need to be
+// available at once. This interface is necessary for functionHash because it
+// needs to accumulate the hash as the structure of the function is traversed
+// without saving these values to an intermediate buffer. This form of hashing
+// is not often needed, as usually the object to hash is just read from a
+// buffer.
+class HashAccumulator64 {
+  uint64_t Hash;
+
+public:
+  // Initialize to random constant, so the state isn't zero.
+  HashAccumulator64() { Hash = 0x6acaa36bef8325c5ULL; }
+
+  void add(uint64_t V) { Hash = hashing::detail::hash_16_bytes(Hash, V); }
+
+  // No finishing is required, because the entire hash value is used.
+  uint64_t getHash() { return Hash; }
+};
+
+} // end anonymous namespace
+
+// A function hash is calculated by considering only the number of arguments and
+// whether a function is varargs, the order of basic blocks (given by the
+// successors of each basic block in depth first order), and the order of
+// opcodes of each instruction within each of these basic blocks. This mirrors
+// the strategy compare() uses to compare functions by walking the BBs in depth
+// first order and comparing each instruction in sequence. Because this hash
+// does not look at the operands, it is insensitive to things such as the
+// target of calls and the constants used in the function, which makes it useful
+// when possibly merging functions which are the same modulo constants and call
+// targets.
+FunctionComparator::FunctionHash FunctionComparator::functionHash(Function &F) {
+  HashAccumulator64 H;
+  H.add(F.isVarArg());
+  H.add(F.arg_size());
+
+  SmallVector<const BasicBlock *, 8> BBs;
+  SmallPtrSet<const BasicBlock *, 16> VisitedBBs;
+
+  // Walk the blocks in the same order as FunctionComparator::cmpBasicBlocks(),
+  // accumulating the hash of the function "structure." (BB and opcode sequence)
+  BBs.push_back(&F.getEntryBlock());
+  VisitedBBs.insert(BBs[0]);
+  while (!BBs.empty()) {
+    const BasicBlock *BB = BBs.pop_back_val();
+    // This random value acts as a block header, as otherwise the partition of
+    // opcodes into BBs wouldn't affect the hash, only the order of the opcodes
+    H.add(45798);
+    for (auto &Inst : *BB) {
+      H.add(Inst.getOpcode());
+    }
+    const Instruction *Term = BB->getTerminator();
+    for (unsigned i = 0, e = Term->getNumSuccessors(); i != e; ++i) {
+      if (!VisitedBBs.insert(Term->getSuccessor(i)).second)
+        continue;
+      BBs.push_back(Term->getSuccessor(i));
+    }
+  }
+  return H.getHash();
+}

--- a/diffkemp/simpll/llvm-lib/11/FunctionComparator.h
+++ b/diffkemp/simpll/llvm-lib/11/FunctionComparator.h
@@ -1,0 +1,393 @@
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// This file defines the FunctionComparator and GlobalNumberState classes which
+// are used by the MergeFunctions pass for comparing functions.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_TRANSFORMS_UTILS_FUNCTIONCOMPARATOR_H
+#define LLVM_TRANSFORMS_UTILS_FUNCTIONCOMPARATOR_H
+
+#include "llvm/ADT/DenseMap.h"
+#include "llvm/ADT/StringRef.h"
+#include "llvm/IR/Attributes.h"
+#include "llvm/IR/Instructions.h"
+#include "llvm/IR/Operator.h"
+#include "llvm/IR/ValueMap.h"
+#include "llvm/Support/AtomicOrdering.h"
+#include "llvm/Support/Casting.h"
+#include <cstdint>
+#include <tuple>
+
+namespace llvm {
+
+class APFloat;
+class APInt;
+class BasicBlock;
+class Constant;
+class Function;
+class GlobalValue;
+class InlineAsm;
+class Instruction;
+class MDNode;
+class Type;
+class Value;
+
+/// GlobalNumberState assigns an integer to each global value in the program,
+/// which is used by the comparison routine to order references to globals. This
+/// state must be preserved throughout the pass, because Functions and other
+/// globals need to maintain their relative order. Globals are assigned a number
+/// when they are first visited. This order is deterministic, and so the
+/// assigned numbers are as well. When two functions are merged, neither number
+/// is updated. If the symbols are weak, this would be incorrect. If they are
+/// strong, then one will be replaced at all references to the other, and so
+/// direct callsites will now see one or the other symbol, and no update is
+/// necessary. Note that if we were guaranteed unique names, we could just
+/// compare those, but this would not work for stripped bitcodes or for those
+/// few symbols without a name.
+class GlobalNumberState {
+  struct Config : ValueMapConfig<GlobalValue *> {
+    enum { FollowRAUW = false };
+  };
+
+  // Each GlobalValue is mapped to an identifier. The Config ensures when RAUW
+  // occurs, the mapping does not change. Tracking changes is unnecessary, and
+  // also problematic for weak symbols (which may be overwritten).
+  using ValueNumberMap = ValueMap<GlobalValue *, uint64_t, Config>;
+  ValueNumberMap GlobalNumbers;
+
+  // The next unused serial number to assign to a global.
+  uint64_t NextNumber = 0;
+
+public:
+  GlobalNumberState() = default;
+
+  virtual uint64_t getNumber(GlobalValue* Global) {
+    ValueNumberMap::iterator MapIter;
+    bool Inserted;
+    std::tie(MapIter, Inserted) = GlobalNumbers.insert({Global, NextNumber});
+    if (Inserted)
+      NextNumber++;
+    return MapIter->second;
+  }
+
+  virtual void erase(GlobalValue *Global) {
+    GlobalNumbers.erase(Global);
+  }
+
+  virtual void clear() {
+    GlobalNumbers.clear();
+  }
+};
+
+/// FunctionComparator - Compares two functions to determine whether or not
+/// they will generate machine code with the same behaviour. DataLayout is
+/// used if available. The comparator always fails conservatively (erring on the
+/// side of claiming that two functions are different).
+class FunctionComparator {
+public:
+  FunctionComparator(const Function *F1, const Function *F2,
+                     GlobalNumberState* GN)
+      : FnL(F1), FnR(F2), GlobalNumbers(GN) {}
+
+  /// Test whether the two functions have equivalent behaviour.
+  virtual int compare();
+
+  /// Hash a function. Equivalent functions will have the same hash, and unequal
+  /// functions will have different hashes with high probability.
+  using FunctionHash = uint64_t;
+  static FunctionHash functionHash(Function &);
+
+protected:
+  /// Start the comparison.
+  void beginCompare() {
+    sn_mapL.clear();
+    sn_mapR.clear();
+  }
+
+  /// Compares the signature and other general attributes of the two functions.
+  virtual int compareSignature() const;
+
+  /// Test whether two basic blocks have equivalent behaviour.
+  virtual int cmpBasicBlocks(const BasicBlock *BBL, const BasicBlock *BBR)
+      const;
+
+  /// Constants comparison.
+  /// Its analog to lexicographical comparison between hypothetical numbers
+  /// of next format:
+  /// <bitcastability-trait><raw-bit-contents>
+  ///
+  /// 1. Bitcastability.
+  /// Check whether L's type could be losslessly bitcasted to R's type.
+  /// On this stage method, in case when lossless bitcast is not possible
+  /// method returns -1 or 1, thus also defining which type is greater in
+  /// context of bitcastability.
+  /// Stage 0: If types are equal in terms of cmpTypes, then we can go straight
+  ///          to the contents comparison.
+  ///          If types differ, remember types comparison result and check
+  ///          whether we still can bitcast types.
+  /// Stage 1: Types that satisfies isFirstClassType conditions are always
+  ///          greater then others.
+  /// Stage 2: Vector is greater then non-vector.
+  ///          If both types are vectors, then vector with greater bitwidth is
+  ///          greater.
+  ///          If both types are vectors with the same bitwidth, then types
+  ///          are bitcastable, and we can skip other stages, and go to contents
+  ///          comparison.
+  /// Stage 3: Pointer types are greater than non-pointers. If both types are
+  ///          pointers of the same address space - go to contents comparison.
+  ///          Different address spaces: pointer with greater address space is
+  ///          greater.
+  /// Stage 4: Types are neither vectors, nor pointers. And they differ.
+  ///          We don't know how to bitcast them. So, we better don't do it,
+  ///          and return types comparison result (so it determines the
+  ///          relationship among constants we don't know how to bitcast).
+  ///
+  /// Just for clearance, let's see how the set of constants could look
+  /// on single dimension axis:
+  ///
+  /// [NFCT], [FCT, "others"], [FCT, pointers], [FCT, vectors]
+  /// Where: NFCT - Not a FirstClassType
+  ///        FCT - FirstClassTyp:
+  ///
+  /// 2. Compare raw contents.
+  /// It ignores types on this stage and only compares bits from L and R.
+  /// Returns 0, if L and R has equivalent contents.
+  /// -1 or 1 if values are different.
+  /// Pretty trivial:
+  /// 2.1. If contents are numbers, compare numbers.
+  ///    Ints with greater bitwidth are greater. Ints with same bitwidths
+  ///    compared by their contents.
+  /// 2.2. "And so on". Just to avoid discrepancies with comments
+  /// perhaps it would be better to read the implementation itself.
+  /// 3. And again about overall picture. Let's look back at how the ordered set
+  /// of constants will look like:
+  /// [NFCT], [FCT, "others"], [FCT, pointers], [FCT, vectors]
+  ///
+  /// Now look, what could be inside [FCT, "others"], for example:
+  /// [FCT, "others"] =
+  /// [
+  ///   [double 0.1], [double 1.23],
+  ///   [i32 1], [i32 2],
+  ///   { double 1.0 },       ; StructTyID, NumElements = 1
+  ///   { i32 1 },            ; StructTyID, NumElements = 1
+  ///   { double 1, i32 1 },  ; StructTyID, NumElements = 2
+  ///   { i32 1, double 1 }   ; StructTyID, NumElements = 2
+  /// ]
+  ///
+  /// Let's explain the order. Float numbers will be less than integers, just
+  /// because of cmpType terms: FloatTyID < IntegerTyID.
+  /// Floats (with same fltSemantics) are sorted according to their value.
+  /// Then you can see integers, and they are, like a floats,
+  /// could be easy sorted among each others.
+  /// The structures. Structures are grouped at the tail, again because of their
+  /// TypeID: StructTyID > IntegerTyID > FloatTyID.
+  /// Structures with greater number of elements are greater. Structures with
+  /// greater elements going first are greater.
+  /// The same logic with vectors, arrays and other possible complex types.
+  ///
+  /// Bitcastable constants.
+  /// Let's assume, that some constant, belongs to some group of
+  /// "so-called-equal" values with different types, and at the same time
+  /// belongs to another group of constants with equal types
+  /// and "really" equal values.
+  ///
+  /// Now, prove that this is impossible:
+  ///
+  /// If constant A with type TyA is bitcastable to B with type TyB, then:
+  /// 1. All constants with equal types to TyA, are bitcastable to B. Since
+  ///    those should be vectors (if TyA is vector), pointers
+  ///    (if TyA is pointer), or else (if TyA equal to TyB), those types should
+  ///    be equal to TyB.
+  /// 2. All constants with non-equal, but bitcastable types to TyA, are
+  ///    bitcastable to B.
+  ///    Once again, just because we allow it to vectors and pointers only.
+  ///    This statement could be expanded as below:
+  /// 2.1. All vectors with equal bitwidth to vector A, has equal bitwidth to
+  ///      vector B, and thus bitcastable to B as well.
+  /// 2.2. All pointers of the same address space, no matter what they point to,
+  ///      bitcastable. So if C is pointer, it could be bitcasted to A and to B.
+  /// So any constant equal or bitcastable to A is equal or bitcastable to B.
+  /// QED.
+  ///
+  /// In another words, for pointers and vectors, we ignore top-level type and
+  /// look at their particular properties (bit-width for vectors, and
+  /// address space for pointers).
+  /// If these properties are equal - compare their contents.
+  virtual int cmpConstants(const Constant *L, const Constant *R) const;
+
+  /// Compares two global values by number. Uses the GlobalNumbersState to
+  /// identify the same gobals across function calls.
+  virtual int cmpGlobalValues(GlobalValue *L, GlobalValue *R) const;
+
+  /// Assign or look up previously assigned numbers for the two values, and
+  /// return whether the numbers are equal. Numbers are assigned in the order
+  /// visited.
+  /// Comparison order:
+  /// Stage 0: Value that is function itself is always greater then others.
+  ///          If left and right values are references to their functions, then
+  ///          they are equal.
+  /// Stage 1: Constants are greater than non-constants.
+  ///          If both left and right are constants, then the result of
+  ///          cmpConstants is used as cmpValues result.
+  /// Stage 2: InlineAsm instances are greater than others. If both left and
+  ///          right are InlineAsm instances, InlineAsm* pointers casted to
+  ///          integers and compared as numbers.
+  /// Stage 3: For all other cases we compare order we meet these values in
+  ///          their functions. If right value was met first during scanning,
+  ///          then left value is greater.
+  ///          In another words, we compare serial numbers, for more details
+  ///          see comments for sn_mapL and sn_mapR.
+  virtual int cmpValues(const Value *L, const Value *R) const;
+
+  /// Compare two Instructions for equivalence, similar to
+  /// Instruction::isSameOperationAs.
+  ///
+  /// Stages are listed in "most significant stage first" order:
+  /// On each stage below, we do comparison between some left and right
+  /// operation parts. If parts are non-equal, we assign parts comparison
+  /// result to the operation comparison result and exit from method.
+  /// Otherwise we proceed to the next stage.
+  /// Stages:
+  /// 1. Operations opcodes. Compared as numbers.
+  /// 2. Number of operands.
+  /// 3. Operation types. Compared with cmpType method.
+  /// 4. Compare operation subclass optional data as stream of bytes:
+  /// just convert it to integers and call cmpNumbers.
+  /// 5. Compare in operation operand types with cmpType in
+  /// most significant operand first order.
+  /// 6. Last stage. Check operations for some specific attributes.
+  /// For example, for Load it would be:
+  /// 6.1.Load: volatile (as boolean flag)
+  /// 6.2.Load: alignment (as integer numbers)
+  /// 6.3.Load: ordering (as underlying enum class value)
+  /// 6.4.Load: synch-scope (as integer numbers)
+  /// 6.5.Load: range metadata (as integer ranges)
+  /// On this stage its better to see the code, since its not more than 10-15
+  /// strings for particular instruction, and could change sometimes.
+  ///
+  /// Sets \p needToCmpOperands to true if the operands of the instructions
+  /// still must be compared afterwards. In this case it's already guaranteed
+  /// that both instructions have the same number of operands.
+  virtual int cmpOperations(const Instruction *L, const Instruction *R,
+                            bool &needToCmpOperands) const;
+
+  /// cmpType - compares two types,
+  /// defines total ordering among the types set.
+  ///
+  /// Return values:
+  /// 0 if types are equal,
+  /// -1 if Left is less than Right,
+  /// +1 if Left is greater than Right.
+  ///
+  /// Description:
+  /// Comparison is broken onto stages. Like in lexicographical comparison
+  /// stage coming first has higher priority.
+  /// On each explanation stage keep in mind total ordering properties.
+  ///
+  /// 0. Before comparison we coerce pointer types of 0 address space to
+  /// integer.
+  /// We also don't bother with same type at left and right, so
+  /// just return 0 in this case.
+  ///
+  /// 1. If types are of different kind (different type IDs).
+  ///    Return result of type IDs comparison, treating them as numbers.
+  /// 2. If types are integers, check that they have the same width. If they
+  /// are vectors, check that they have the same count and subtype.
+  /// 3. Types have the same ID, so check whether they are one of:
+  /// * Void
+  /// * Float
+  /// * Double
+  /// * X86_FP80
+  /// * FP128
+  /// * PPC_FP128
+  /// * Label
+  /// * Metadata
+  /// We can treat these types as equal whenever their IDs are same.
+  /// 4. If Left and Right are pointers, return result of address space
+  /// comparison (numbers comparison). We can treat pointer types of same
+  /// address space as equal.
+  /// 5. If types are complex.
+  /// Then both Left and Right are to be expanded and their element types will
+  /// be checked with the same way. If we get Res != 0 on some stage, return it.
+  /// Otherwise return 0.
+  /// 6. For all other cases put llvm_unreachable.
+  virtual int cmpTypes(Type *TyL, Type *TyR) const;
+
+  virtual int cmpNumbers(uint64_t L, uint64_t R) const;
+  virtual int cmpAPInts(const APInt &L, const APInt &R) const;
+  virtual int cmpAPFloats(const APFloat &L, const APFloat &R) const;
+  virtual int cmpMem(StringRef L, StringRef R) const;
+
+  // The two functions undergoing comparison.
+  const Function *FnL, *FnR;
+
+  virtual int cmpOrderings(AtomicOrdering L, AtomicOrdering R) const;
+  virtual int cmpInlineAsm(const InlineAsm *L, const InlineAsm *R) const;
+  virtual int cmpAttrs(const AttributeList L, const AttributeList R) const;
+  virtual int cmpRangeMetadata(const MDNode *L, const MDNode *R) const;
+  virtual int cmpOperandBundlesSchema(const CallBase &LCS,
+                                      const CallBase &RCS) const;
+
+  /// Compare two GEPs for equivalent pointer arithmetic.
+  /// Parts to be compared for each comparison stage,
+  /// most significant stage first:
+  /// 1. Address space. As numbers.
+  /// 2. Constant offset, (using GEPOperator::accumulateConstantOffset method).
+  /// 3. Pointer operand type (using cmpType method).
+  /// 4. Number of operands.
+  /// 5. Compare operands, using cmpValues method.
+  virtual int cmpGEPs(const GEPOperator *GEPL, const GEPOperator *GEPR) const;
+  int cmpGEPs(const GetElementPtrInst *GEPL,
+              const GetElementPtrInst *GEPR) const {
+    return cmpGEPs(cast<GEPOperator>(GEPL), cast<GEPOperator>(GEPR));
+  }
+
+  /// Assign serial numbers to values from left function, and values from
+  /// right function.
+  /// Explanation:
+  /// Being comparing functions we need to compare values we meet at left and
+  /// right sides.
+  /// Its easy to sort things out for external values. It just should be
+  /// the same value at left and right.
+  /// But for local values (those were introduced inside function body)
+  /// we have to ensure they were introduced at exactly the same place,
+  /// and plays the same role.
+  /// Let's assign serial number to each value when we meet it first time.
+  /// Values that were met at same place will be with same serial numbers.
+  /// In this case it would be good to explain few points about values assigned
+  /// to BBs and other ways of implementation (see below).
+  ///
+  /// 1. Safety of BB reordering.
+  /// It's safe to change the order of BasicBlocks in function.
+  /// Relationship with other functions and serial numbering will not be
+  /// changed in this case.
+  /// As follows from FunctionComparator::compare(), we do CFG walk: we start
+  /// from the entry, and then take each terminator. So it doesn't matter how in
+  /// fact BBs are ordered in function. And since cmpValues are called during
+  /// this walk, the numbering depends only on how BBs located inside the CFG.
+  /// So the answer is - yes. We will get the same numbering.
+  ///
+  /// 2. Impossibility to use dominance properties of values.
+  /// If we compare two instruction operands: first is usage of local
+  /// variable AL from function FL, and second is usage of local variable AR
+  /// from FR, we could compare their origins and check whether they are
+  /// defined at the same place.
+  /// But, we are still not able to compare operands of PHI nodes, since those
+  /// could be operands from further BBs we didn't scan yet.
+  /// So it's impossible to use dominance properties in general.
+  mutable DenseMap<const Value*, int> sn_mapL, sn_mapR;
+
+private:
+  // The global state we will use
+  GlobalNumberState* GlobalNumbers;
+};
+
+} // end namespace llvm
+
+#endif // LLVM_TRANSFORMS_UTILS_FUNCTIONCOMPARATOR_H

--- a/diffkemp/simpll/llvm-lib/11/LICENSE
+++ b/diffkemp/simpll/llvm-lib/11/LICENSE
@@ -1,0 +1,278 @@
+==============================================================================
+The LLVM Project is under the Apache License v2.0 with LLVM Exceptions:
+==============================================================================
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+    TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+    1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+    2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+    3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+    4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+    5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+    6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+    7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+    8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+    9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+    END OF TERMS AND CONDITIONS
+
+    APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+    Copyright [yyyy] [name of copyright owner]
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+
+---- LLVM Exceptions to the Apache 2.0 License ----
+
+As an exception, if, as a result of your compiling your source code, portions
+of this Software are embedded into an Object form of such source code, you
+may redistribute such embedded portions in such Object form without complying
+with the conditions of Sections 4(a), 4(b) and 4(d) of the License.
+
+In addition, if you combine or link compiled forms of this Software with
+software that is licensed under the GPLv2 ("Combined Software") and if a
+court of competent jurisdiction determines that the patent provision (Section
+3), the indemnity provision (Section 9) or other Section of the License
+conflicts with the conditions of the GPLv2, you may retroactively and
+prospectively choose to deem waived or otherwise exclude such Section(s) of
+the License, but only in their entirety and only with respect to the Combined
+Software.
+
+==============================================================================
+Software from third parties included in the LLVM Project:
+==============================================================================
+The LLVM Project contains third party software which is under different license
+terms. All such code will be identified clearly using at least one of two
+mechanisms:
+1) It will be in a separate directory tree with its own `LICENSE.txt` or
+   `LICENSE` file at the top containing the specific license and restrictions
+   which apply to that software, or
+2) It will contain specific license and restriction terms at the top of every
+   file.
+
+==============================================================================
+Legacy LLVM License (https://llvm.org/docs/DeveloperPolicy.html#legacy):
+==============================================================================
+University of Illinois/NCSA
+Open Source License
+
+Copyright (c) 2003-2019 University of Illinois at Urbana-Champaign.
+All rights reserved.
+
+Developed by:
+
+    LLVM Team
+
+    University of Illinois at Urbana-Champaign
+
+    http://llvm.org
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal with
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+of the Software, and to permit persons to whom the Software is furnished to do
+so, subject to the following conditions:
+
+    * Redistributions of source code must retain the above copyright notice,
+      this list of conditions and the following disclaimers.
+
+    * Redistributions in binary form must reproduce the above copyright notice,
+      this list of conditions and the following disclaimers in the
+      documentation and/or other materials provided with the distribution.
+
+    * Neither the names of the LLVM Team, University of Illinois at
+      Urbana-Champaign, nor the names of its contributors may be used to
+      endorse or promote products derived from this Software without specific
+      prior written permission.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
+CONTRIBUTORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS WITH THE
+SOFTWARE.

--- a/diffkemp/simpll/passes/CalledFunctionsAnalysis.cpp
+++ b/diffkemp/simpll/passes/CalledFunctionsAnalysis.cpp
@@ -40,8 +40,7 @@ void CalledFunctionsAnalysis::collectCalled(const Function *Fun,
     for (auto &BB : *Fun) {
         for (auto &Inst : BB) {
             if (auto Call = dyn_cast<CallInst>(&Inst)) {
-                if (auto *CalledFun =
-                            getCalledFunction(Call->getCalledValue())) {
+                if (auto *CalledFun = getCalledFunction(Call)) {
                     collectCalled(CalledFun, Called);
                 }
             }
@@ -55,7 +54,7 @@ void CalledFunctionsAnalysis::collectCalled(const Function *Fun,
 /// Looks for functions in a value (either a function itself, or a composite
 /// type constant).
 void CalledFunctionsAnalysis::processValue(const Value *Val, Result &Called) {
-    if (auto Fun = getCalledFunction(Val))
+    if (auto Fun = valueToFunction(Val))
         collectCalled(Fun, Called);
     else if (auto GV = dyn_cast<GlobalVariable>(Val)) {
         if (GV->hasInitializer() && GV->isConstant())

--- a/diffkemp/simpll/passes/CalledFunctionsAnalysis.h
+++ b/diffkemp/simpll/passes/CalledFunctionsAnalysis.h
@@ -16,6 +16,9 @@
 #define DIFFKEMP_SIMPLL_CALLEDFUNCTIONSANALYSIS_H
 
 #include <llvm/IR/PassManager.h>
+#if LLVM_VERSION_MAJOR >= 11
+#include <llvm/IR/PassManagerImpl.h>
+#endif
 #include <set>
 
 using namespace llvm;

--- a/diffkemp/simpll/passes/ControlFlowSlicer.cpp
+++ b/diffkemp/simpll/passes/ControlFlowSlicer.cpp
@@ -54,7 +54,7 @@ bool hasIndirectCall(const Function &Fun) {
                 // For indirect call, check if the called value is ever used
                 // (apart from debug instructions and the call itself).
                 // If not, do not return true.
-                const Value *called = Call->getCalledValue();
+                const Value *called = getCallee(Call);
                 for (auto &Use : called->uses()) {
                     if (Use.getUser() == Call)
                         continue;

--- a/diffkemp/simpll/passes/MergeNumberedFunctionsPass.cpp
+++ b/diffkemp/simpll/passes/MergeNumberedFunctionsPass.cpp
@@ -31,7 +31,7 @@ PreservedAnalyses
         if (isSimpllAbstraction(&Fun) || Fun.getName().startswith("llvm."))
             // Do not merge LLVM intrinsics and SimpLL abstractions.
             continue;
-        std::string originalName = Fun.getName();
+        std::string originalName = Fun.getName().str();
         std::string strippedName = hasSuffix(originalName)
                                            ? dropSuffix(originalName)
                                            : originalName;

--- a/diffkemp/simpll/passes/RemoveUnusedReturnValuesPass.cpp
+++ b/diffkemp/simpll/passes/RemoveUnusedReturnValuesPass.cpp
@@ -83,7 +83,7 @@ PreservedAnalyses RemoveUnusedReturnValuesPass::run(
         // clone. (Another solution would be to replace the uses manually, but
         // this is an easier solution.)
         ValueToValueMapTy Map;
-        std::string OriginalName = Fun->getName();
+        std::string OriginalName = Fun->getName().str();
         if (hasSuffix(OriginalName))
             OriginalName = dropSuffix(OriginalName);
         Fun->setName("");

--- a/diffkemp/simpll/passes/SeparateCallsToBitcastPass.cpp
+++ b/diffkemp/simpll/passes/SeparateCallsToBitcastPass.cpp
@@ -33,8 +33,7 @@ PreservedAnalyses
             if (auto Call = dyn_cast<CallInst>(&Inst)) {
                 // Find call instructions calling a bitcast
                 // operator that directly corresponds to a function.
-                auto BitCast =
-                        dyn_cast<BitCastOperator>(Call->getCalledValue());
+                auto BitCast = dyn_cast<BitCastOperator>(getCallee(Call));
 
                 if (BitCast && isa<Function>(BitCast->getOperand(0))) {
                     // Get the bitcasted function.

--- a/diffkemp/simpll/passes/SimplifyKernelFunctionCallsPass.cpp
+++ b/diffkemp/simpll/passes/SimplifyKernelFunctionCallsPass.cpp
@@ -60,7 +60,7 @@ PreservedAnalyses
                     // For inline asm containing __bug_table:
                     //  - replace the first argument byt null (is a file name)
                     //  - replace the second argument by 0 (is a line number)
-                    auto CalledVal = CallInstr->getCalledValue();
+                    auto CalledVal = getCallee(CallInstr);
                     if (auto Asm = dyn_cast<InlineAsm>(CalledVal)) {
                         if (Asm->getAsmString().find("__bug_table")
                             != std::string::npos) {
@@ -88,7 +88,7 @@ PreservedAnalyses
                     copyCallInstProperties(CallInstr, newCall);
                     CallInstr->replaceAllUsesWith(newCall);
                     toRemove.push_back(&Instr);
-                } else if (isPrintFunction(CalledFun->getName())) {
+                } else if (isPrintFunction(CalledFun->getName().str())) {
                     // Functions with 2 mandatory arguments
                     auto Op0Type = dyn_cast<PointerType>(
                             CallInstr->getOperand(0)->getType());

--- a/diffkemp/simpll/passes/SimplifyKernelGlobalsPass.cpp
+++ b/diffkemp/simpll/passes/SimplifyKernelGlobalsPass.cpp
@@ -94,7 +94,7 @@ PreservedAnalyses SimplifyKernelGlobalsPass::run(Module &Mod,
     }
 
     for (auto &Fun : Mod) {
-        std::string Name = Fun.getName();
+        std::string Name = Fun.getName().str();
         if (Name.find("__compiletime_assert") != std::string::npos
             && Name != "__compiletime_assert") {
             std::string OrigName = "__compiletime_assert";

--- a/diffkemp/simpll/passes/StructureDebugInfoAnalysis.cpp
+++ b/diffkemp/simpll/passes/StructureDebugInfoAnalysis.cpp
@@ -60,7 +60,7 @@ StructureDebugInfoAnalysis::Result StructureDebugInfoAnalysis::run(
                 if (DCTy->getTag() == dwarf::DW_TAG_structure_type
                     && DCTy->getName() != "") {
                     // The type is a structure type, add entry to map.
-                    Res[DCTy->getName()] = DCTy;
+                    Res[DCTy->getName().str()] = DCTy;
                 }
                 // Go through all types inside the composite type.
                 DINodeArray Elems = DCTy->getElements();

--- a/diffkemp/simpll/passes/StructureSizeAnalysis.cpp
+++ b/diffkemp/simpll/passes/StructureSizeAnalysis.cpp
@@ -29,10 +29,10 @@ StructureSizeAnalysis::Result StructureSizeAnalysis::run(
             uint64_t STySize = Mod.getDataLayout().getTypeAllocSize(STy);
             auto Elem = Res.find(STySize);
             if (Elem != Res.end()) {
-                Elem->second.insert(STy->getStructName());
+                Elem->second.insert(STy->getStructName().str());
             } else {
                 std::set<std::string> Set;
-                Set.insert(STy->getStructName());
+                Set.insert(STy->getStructName().str());
                 Res[STySize] = Set;
             }
         }

--- a/diffkemp/simpll/passes/UnifyMemcpyPass.cpp
+++ b/diffkemp/simpll/passes/UnifyMemcpyPass.cpp
@@ -66,20 +66,23 @@ PreservedAnalyses UnifyMemcpyPass::run(Function &Fun,
                                     ConstantInt::get(
                                             MemcpyAlign->getType(), 1, false));
                     }
-#else
+#elif LLVM_VERSION_MAJOR < 10
                     for (int i : {0, 1}) {
                         if (Call->getParamAlignment(i) == 0) {
                             Call->removeParamAttr(i, Attribute::Alignment);
-#if LLVM_VERSION_MAJOR < 10
                             Call->addParamAttr(i,
                                                Attribute::getWithAlignment(
                                                        Call->getContext(), 1));
+                        }
+                    }
 #else
+                    for (int i : {0, 1}) {
+                        if (Call->getParamAlign(i) == 0) {
+                            Call->removeParamAttr(i, Attribute::Alignment);
                             Call->addParamAttr(
                                     i,
                                     Attribute::getWithAlignment(
                                             Call->getContext(), Align(1)));
-#endif
                         }
                     }
 #endif

--- a/docker/diffkemp-devel/Dockerfile
+++ b/docker/diffkemp-devel/Dockerfile
@@ -1,11 +1,18 @@
 FROM ubuntu:xenial
 MAINTAINER Viktor Malik <vmalik@redhat.com>
-RUN apt-get update && apt-get install -y software-properties-common wget
+RUN apt-get update && \
+    apt-get install -y \
+      apt-transport-https \
+      software-properties-common \
+      wget
 RUN wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | apt-key add - && \
-    add-apt-repository ppa:ubuntu-toolchain-r/test && \
-    add-apt-repository "deb http://apt.llvm.org/xenial/ llvm-toolchain-xenial-7 main" && \
-    add-apt-repository "deb http://apt.llvm.org/xenial/ llvm-toolchain-xenial-8 main" && \
-    add-apt-repository "deb http://apt.llvm.org/xenial/ llvm-toolchain-xenial-9 main"
+    add-apt-repository -y ppa:ubuntu-toolchain-r/test && \
+    add-apt-repository -y "deb http://apt.llvm.org/xenial/ llvm-toolchain-xenial-7 main" && \
+    add-apt-repository -y "deb http://apt.llvm.org/xenial/ llvm-toolchain-xenial-8 main" && \
+    add-apt-repository -y "deb http://apt.llvm.org/xenial/ llvm-toolchain-xenial-9 main" && \
+    add-apt-repository -y "deb http://apt.llvm.org/xenial/ llvm-toolchain-xenial-10 main" && \
+    add-apt-repository -y "deb http://apt.llvm.org/xenial/ llvm-toolchain-xenial-11 main" && \
+    add-apt-repository -y ppa:deadsnakes/ppa
 RUN apt-get update && \
     apt-get install -y \
       autoconf \
@@ -17,6 +24,8 @@ RUN apt-get update && \
       clang-7 \
       clang-8 \
       clang-9 \
+      clang-10 \
+      clang-11 \
       clang-format-8 \
       cmake \
       cpio \
@@ -37,18 +46,23 @@ RUN apt-get update && \
       llvm-6.0 \
       llvm-7 \
       llvm-8 \
+      llvm-9 \
+      llvm-10 \
+      llvm-11 \
       llvm-5.0-dev \
       llvm-6.0-dev \
       llvm-7-dev \
       llvm-8-dev \
       llvm-9-dev \
+      llvm-10-dev \
+      llvm-11-dev \
       make \
       module-init-tools \
       ninja-build \
-      python3 \
-      python3-cffi \
-      python3-pip \
-      python3-pytest \
+      python3.8 \
+      python3.8-dev \
+      python3.8-distutils \
+      python3-setuptools \
       rpm2cpio \
       vim \
       xz-utils \
@@ -74,6 +88,14 @@ RUN update-alternatives --install /usr/local/bin/llvm-config llvm-config /usr/bi
     update-alternatives --install /usr/local/bin/clang clang /usr/bin/clang-9 40 && \
     update-alternatives --install /usr/local/bin/opt opt /usr/bin/opt-9 40 && \
     update-alternatives --install /usr/local/bin/llvm-link llvm-link /usr/bin/llvm-link-9 40 && \
+    update-alternatives --install /usr/local/bin/llvm-config llvm-config /usr/bin/llvm-config-10 50 && \
+    update-alternatives --install /usr/local/bin/clang clang /usr/bin/clang-10 50 && \
+    update-alternatives --install /usr/local/bin/opt opt /usr/bin/opt-10 50 && \
+    update-alternatives --install /usr/local/bin/llvm-link llvm-link /usr/bin/llvm-link-10 50 && \
+    update-alternatives --install /usr/local/bin/llvm-config llvm-config /usr/bin/llvm-config-11 60 && \
+    update-alternatives --install /usr/local/bin/clang clang /usr/bin/clang-11 60 && \
+    update-alternatives --install /usr/local/bin/opt opt /usr/bin/opt-11 60 && \
+    update-alternatives --install /usr/local/bin/llvm-link llvm-link /usr/bin/llvm-link-11 60 && \
     update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-7 100 --slave /usr/bin/g++ g++ /usr/bin/g++-7
 # Configure links for the clang-format checker script
 RUN update-alternatives --install /usr/local/bin/clang-format clang-format /usr/bin/clang-format-8 40 && \
@@ -81,13 +103,17 @@ RUN update-alternatives --install /usr/local/bin/clang-format clang-format /usr/
 # Copy script for changing default LLVM version
 COPY switch-llvm.sh /switch-llvm.sh
 RUN chmod +x /switch-llvm.sh
-# Default LLVM is 8
-RUN /switch-llvm.sh 8
-RUN pip3 install \
+# Default LLVM is 11
+RUN /switch-llvm.sh 11
+# Setup Python 3.8 and install pip packages
+RUN update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.8 100
+RUN python3 -m easy_install pip
+RUN python3 -m pip install \
       --upgrade pip \
       llvmcpy \
       pytest \
-      pyyaml
+      pyyaml \
+      --ignore-installed
 RUN git clone https://github.com/viktormalik/rhel-kernel-get.git && \
-    pip3 install -r rhel-kernel-get/requirements.txt
-ENTRYPOINT pip3 install -e .; /bin/bash
+    python3 -m pip install -r rhel-kernel-get/requirements.txt
+ENTRYPOINT python3 -m pip install -e .; /bin/bash

--- a/docker/diffkemp-devel/run-container.sh
+++ b/docker/diffkemp-devel/run-container.sh
@@ -10,7 +10,7 @@ fi
 # Prerequisity is an existing docker image called 'diffkemp-devel' built from
 # the provided Dockerfile
 "$COMMAND" run \
-    -ti --security-opt seccomp=unconfined \
+    -ti --security-opt seccomp=unconfined --security-opt label=disable \
     -m 8g \
     --cpus 3 \
     -v $PWD:/diffkemp:Z \

--- a/tests/unit_tests/simpll/DifferentialFunctionComparatorTest.cpp
+++ b/tests/unit_tests/simpll/DifferentialFunctionComparatorTest.cpp
@@ -18,6 +18,7 @@
 #include <ModuleComparator.h>
 #include <ResultsCache.h>
 #include <gtest/gtest.h>
+#include <llvm/IR/DIBuilder.h>
 #include <passes/StructureDebugInfoAnalysis.h>
 #include <passes/StructureSizeAnalysis.h>
 
@@ -215,76 +216,20 @@ class DifferentialFunctionComparatorTest : public ::testing::Test {
                                DICompositeTypeArray DTyArrR = {},
                                DIMacroNodeArray DMacArrL = {},
                                DIMacroNodeArray DMacArrR = {}) {
-        DIFile *DScoL = DIFile::get(CtxL, "test", "test");
-        DIFile *DScoR = DIFile::get(CtxR, "test", "test");
-        DICompileUnit *DCUL = DICompileUnit::getDistinct(
-                CtxL,
-                0,
-                DScoL,
-                "test",
-                false,
-                "",
-                0,
-                "test",
-                DICompileUnit::DebugEmissionKind::FullDebug,
-                DTyArrL,
-                DIScopeArray{},
-                DIGlobalVariableExpressionArray{},
-                DIImportedEntityArray{},
-                DMacArrL,
-                0,
-                false,
-                false,
-                DICompileUnit::DebugNameTableKind::Default,
-                0);
-        DICompileUnit *DCUR = DICompileUnit::getDistinct(
-                CtxR,
-                0,
-                DScoR,
-                "test",
-                false,
-                "",
-                0,
-                "test",
-                DICompileUnit::DebugEmissionKind::FullDebug,
-                DTyArrR,
-                DIScopeArray{},
-                DIGlobalVariableExpressionArray{},
-                DIImportedEntityArray{},
-                DMacArrR,
-                0,
-                false,
-                false,
-                DICompileUnit::DebugNameTableKind::Default,
-                0);
-        DSubL = DISubprogram::get(CtxL,
-                                  DScoL,
-                                  "test",
-                                  "test",
-                                  DScoL,
-                                  1,
-                                  nullptr,
-                                  1,
-                                  nullptr,
-                                  0,
-                                  0,
-                                  DINode::DIFlags{},
-                                  DISubprogram::DISPFlags{},
-                                  DCUL);
-        DSubR = DISubprogram::get(CtxR,
-                                  DScoR,
-                                  "test",
-                                  "test",
-                                  DScoR,
-                                  1,
-                                  nullptr,
-                                  1,
-                                  nullptr,
-                                  0,
-                                  0,
-                                  DINode::DIFlags{},
-                                  DISubprogram::DISPFlags{},
-                                  DCUR);
+
+        DIBuilder builderL(ModL);
+        DIFile *DScoL = builderL.createFile("test", "test");
+        DICompileUnit *DCUL =
+                builderL.createCompileUnit(0, DScoL, "test", false, "", 0);
+        DSubL = builderL.createFunction(
+                DScoL, "test", "test", DScoL, 1, nullptr, 1);
+
+        DIBuilder builderR(ModR);
+        DIFile *DScoR = builderR.createFile("test", "test");
+        DICompileUnit *DCUR =
+                builderR.createCompileUnit(0, DScoR, "test", false, "", 0);
+        DSubR = builderR.createFunction(
+                DScoR, "test", "test", DScoR, 1, nullptr, 1);
     }
 
     /// Compares two functions using cmpGlobalValues called through

--- a/tests/unit_tests/simpll/passes/CalledFunctionsAnalysisTest.cpp
+++ b/tests/unit_tests/simpll/passes/CalledFunctionsAnalysisTest.cpp
@@ -16,6 +16,9 @@
 #include <llvm/IR/Module.h>
 #include <llvm/IR/PassManager.h>
 #include <llvm/Passes/PassBuilder.h>
+#if LLVM_VERSION_MAJOR >= 11
+#include <llvm/IR/PassManagerImpl.h>
+#endif
 #include <passes/CalledFunctionsAnalysis.h>
 
 using namespace llvm;

--- a/tests/unit_tests/simpll/passes/FunctionAbstractionsGeneratorTest.cpp
+++ b/tests/unit_tests/simpll/passes/FunctionAbstractionsGeneratorTest.cpp
@@ -11,12 +11,16 @@
 ///
 //===----------------------------------------------------------------------===//
 
+#include <Utils.h>
 #include <gtest/gtest.h>
 #include <llvm/IR/InlineAsm.h>
 #include <llvm/IR/Instructions.h>
 #include <llvm/IR/Module.h>
 #include <llvm/IR/PassManager.h>
 #include <llvm/Passes/PassBuilder.h>
+#if LLVM_VERSION_MAJOR >= 11
+#include <llvm/IR/PassManagerImpl.h>
+#endif
 #include <passes/CalledFunctionsAnalysis.h>
 #include <passes/FunctionAbstractionsGenerator.h>
 
@@ -79,7 +83,7 @@ TEST(FunctionAbstractionsGeneratorTest, InlineAsm) {
     for (int i = 0; i < 4; i++) {
         ASSERT_TRUE(isa<CallInst>(FunBody[i]));
         auto Call = dyn_cast<CallInst>(FunBody[i]);
-        ASSERT_TRUE(isa<Function>(Call->getCalledValue()));
+        ASSERT_TRUE(isa<Function>(getCallee(Call)));
         ASSERT_EQ(Call->getNumArgOperands(), 1);
         ASSERT_TRUE(isa<ConstantInt>(Call->getArgOperand(0)));
         ASSERT_EQ(dyn_cast<ConstantInt>(Call->getArgOperand(0))->getZExtValue(),
@@ -159,6 +163,7 @@ TEST(FunctionAbstractionsGeneratorTest, IndirectCall) {
             "test",
             Mod);
     BasicBlock *BB = BasicBlock::Create(Ctx, "", Fun);
+#if LLVM_VERSION_MAJOR <= 7
     CallInst::Create(
             FunPtr1, {ConstantInt::get(Type::getInt8Ty(Ctx), 0)}, "", BB);
     CallInst::Create(
@@ -167,6 +172,28 @@ TEST(FunctionAbstractionsGeneratorTest, IndirectCall) {
             FunPtr2, {ConstantInt::get(Type::getInt8Ty(Ctx), 1)}, "", BB);
     CallInst::Create(
             FunPtr4, {ConstantInt::get(Type::getInt16Ty(Ctx), 1)}, "", BB);
+#else
+    CallInst::Create(FunTy1,
+                     FunPtr1,
+                     {ConstantInt::get(Type::getInt8Ty(Ctx), 0)},
+                     "",
+                     BB);
+    CallInst::Create(FunTy2,
+                     FunPtr3,
+                     {ConstantInt::get(Type::getInt16Ty(Ctx), 0)},
+                     "",
+                     BB);
+    CallInst::Create(FunTy1,
+                     FunPtr2,
+                     {ConstantInt::get(Type::getInt8Ty(Ctx), 1)},
+                     "",
+                     BB);
+    CallInst::Create(FunTy2,
+                     FunPtr4,
+                     {ConstantInt::get(Type::getInt16Ty(Ctx), 1)},
+                     "",
+                     BB);
+#endif
     ReturnInst::Create(Ctx, BB);
 
     // Run the pass and check the result.
@@ -182,7 +209,7 @@ TEST(FunctionAbstractionsGeneratorTest, IndirectCall) {
     for (int i = 0; i < 4; i++) {
         ASSERT_TRUE(isa<CallInst>(FunBody[i]));
         auto Call = dyn_cast<CallInst>(FunBody[i]);
-        ASSERT_TRUE(isa<Function>(Call->getCalledValue()));
+        ASSERT_TRUE(isa<Function>(getCallee(Call)));
         auto CalledFun = Call->getCalledFunction();
         ASSERT_TRUE(isSimpllAbstractionDeclaration(CalledFun));
         Abstractions.push_back(CalledFun);

--- a/tests/unit_tests/simpll/passes/RemoveUnusedReturnValuesPassTest.cpp
+++ b/tests/unit_tests/simpll/passes/RemoveUnusedReturnValuesPassTest.cpp
@@ -16,6 +16,9 @@
 #include <llvm/IR/Instructions.h>
 #include <llvm/IR/Module.h>
 #include <llvm/IR/PassManager.h>
+#if LLVM_VERSION_MAJOR >= 11
+#include <llvm/IR/PassManagerImpl.h>
+#endif
 #include <llvm/Passes/PassBuilder.h>
 #include <passes/CalledFunctionsAnalysis.h>
 #include <passes/RemoveUnusedReturnValuesPass.h>

--- a/tests/unit_tests/simpll/passes/SimplifyKernelFunctionCallsPassTest.cpp
+++ b/tests/unit_tests/simpll/passes/SimplifyKernelFunctionCallsPassTest.cpp
@@ -11,6 +11,7 @@
 ///
 //===----------------------------------------------------------------------===//
 
+#include <Utils.h>
 #include <gtest/gtest.h>
 #include <llvm/IR/IRBuilder.h>
 #include <llvm/IR/InlineAsm.h>
@@ -80,7 +81,7 @@ TEST(SimplifyKernelFunctionCallsPassTest, InlineAsm) {
     ASSERT_NE(Iter, BB->end());
     auto Call1 = dyn_cast<CallInst>(&*Iter);
     ASSERT_TRUE(Call1);
-    ASSERT_EQ(Call1->getCalledValue(), Asm1);
+    ASSERT_EQ(getCallee(Call1), Asm1);
     ASSERT_EQ(Call1->getNumArgOperands(), 2);
     ASSERT_EQ(Call1->getOperand(0)->getType(),
               PointerType::get(Type::getInt8Ty(Ctx), 0));
@@ -94,7 +95,7 @@ TEST(SimplifyKernelFunctionCallsPassTest, InlineAsm) {
     ASSERT_NE(Iter, BB->end());
     auto Call2 = dyn_cast<CallInst>(&*Iter);
     ASSERT_TRUE(Call2);
-    ASSERT_EQ(Call2->getCalledValue(), Asm2);
+    ASSERT_EQ(getCallee(Call2), Asm2);
     ASSERT_EQ(Call2->getNumArgOperands(), 2);
     ASSERT_EQ(Call2->getOperand(0), AuxPtr);
     ASSERT_EQ(Call2->getOperand(1)->getType(), Type::getInt64Ty(Ctx));
@@ -169,7 +170,7 @@ TEST(SimplifyKernelFunctionCallsPassTest, PrintFun) {
         ASSERT_NE(Iter, BB->end());
         auto Call = dyn_cast<CallInst>(&*Iter);
         ASSERT_TRUE(Call);
-        ASSERT_EQ(Call->getCalledValue(), (i == 0) ? FunPrintk : FunDevWarn);
+        ASSERT_EQ(Call->getCalledFunction(), (i == 0) ? FunPrintk : FunDevWarn);
         ASSERT_EQ(Call->getNumArgOperands(), 2);
         ASSERT_TRUE(isa<ConstantPointerNull>(Call->getOperand(0)));
         ASSERT_TRUE(isa<ConstantPointerNull>(Call->getOperand(1)));
@@ -225,7 +226,7 @@ TEST(SimplifyKernelFunctionCallsPassTest, DebugFun) {
     ASSERT_NE(Iter, BB->end());
     auto Call = dyn_cast<CallInst>(&*Iter);
     ASSERT_TRUE(Call);
-    ASSERT_EQ(Call->getCalledValue(), FunMightSleep);
+    ASSERT_EQ(Call->getCalledFunction(), FunMightSleep);
     ASSERT_EQ(Call->getNumArgOperands(), 3);
     ASSERT_TRUE(isa<ConstantPointerNull>(Call->getOperand(0)));
     ASSERT_EQ(Call->getOperand(1)->getType(), Type::getInt32Ty(Ctx));

--- a/tests/unit_tests/simpll/passes/StructureSizeAnalysisTest.cpp
+++ b/tests/unit_tests/simpll/passes/StructureSizeAnalysisTest.cpp
@@ -15,6 +15,9 @@
 #include <llvm/IR/Instructions.h>
 #include <llvm/IR/Module.h>
 #include <llvm/IR/PassManager.h>
+#if LLVM_VERSION_MAJOR >= 11
+#include <llvm/IR/PassManagerImpl.h>
+#endif
 #include <llvm/Passes/PassBuilder.h>
 #include <passes/StructureSizeAnalysis.h>
 

--- a/tests/unit_tests/simpll/passes/UnifyMemcpyPassTest.cpp
+++ b/tests/unit_tests/simpll/passes/UnifyMemcpyPassTest.cpp
@@ -93,9 +93,12 @@ TEST(UnifyMemcpyPassTest, AlignmentUnification) {
     ASSERT_TRUE(isa<ConstantInt>(TestCall1->getOperand(3)));
     ASSERT_EQ(dyn_cast<ConstantInt>(TestCall1->getOperand(3))->getZExtValue(),
               1);
-#else
+#elif LLVM_VERSION_MAJOR < 10
     ASSERT_EQ(TestCall1->getParamAlignment(0), 1);
     ASSERT_EQ(TestCall1->getParamAlignment(1), 1);
+#else
+    ASSERT_EQ(TestCall1->getParamAlign(0), 1);
+    ASSERT_EQ(TestCall1->getParamAlign(1), 1);
 #endif
     ++Iter;
 
@@ -122,9 +125,12 @@ TEST(UnifyMemcpyPassTest, AlignmentUnification) {
     ASSERT_TRUE(isa<ConstantInt>(TestCall2->getOperand(3)));
     ASSERT_EQ(dyn_cast<ConstantInt>(TestCall2->getOperand(3))->getZExtValue(),
               2);
-#else
+#elif LLVM_VERSION_MAJOR < 10
     ASSERT_EQ(TestCall2->getParamAlignment(0), 2);
     ASSERT_EQ(TestCall2->getParamAlignment(1), 2);
+#else
+    ASSERT_EQ(TestCall2->getParamAlign(0), 2);
+    ASSERT_EQ(TestCall2->getParamAlign(1), 2);
 #endif
     ++Iter;
 


### PR DESCRIPTION
A number of changes was required:
- `StringRef` is not implicitly casted to `std::string` (needs `.str()` call)
- `CallInst::getCalledValue` was replaced by `CallInst::getCalledOperand`
- `SequentialType` was replaced by `ArrayType`
- custom `AnalysisManager` needs to include `<llvm/IR/PassManagerImpl.h>`
- some functions have changed headers (`CallInst::Create`, `InlineFunction`)
- `AttributeList` does not have context field
- `CallInst::getParamAlignment` was replaced by `CallInst::getParamAlign`

The container image is updated with LLVM 11 and Python 3.8 (as Ubuntu 16.04 contains Python 3.6 which has a bug in pip).
