### PR TITLE
Adjusting compilation for macOS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,6 +5,7 @@ message(STATUS "Found LLVM ${LLVM_PACKAGE_VERSION}")
 add_definitions(${LLVM_DEFINITIONS})
 include_directories(${LLVM_INCLUDE_DIRS})
 link_directories(${LLVM_LIBRARY_DIRS})
+set(CMAKE_CXX_STANDARD 14)
 
 include(GNUInstallDirs)
 

--- a/diffkemp/simpll/CMakeLists.txt
+++ b/diffkemp/simpll/CMakeLists.txt
@@ -19,13 +19,19 @@ file(GLOB passes passes/*.cpp)
 file(GLOB library library/*.cpp)
 
 set(CMAKE_INCLUDE_CURRENT_DIR ON)
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fno-rtti -fpic")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fno-rtti -fpic -fvisibility=hidden")
 
 exec_program(llvm-config ARGS --libs irreader passes support OUTPUT_VARIABLE llvm_libs)
+exec_program(llvm-config ARGS --system-libs OUTPUT_VARIABLE system_libs)
+string(STRIP ${system_libs} system_libs)
+
 add_library(simpll-lib ${srcs} ${passes} ${library})
 add_executable(simpll SimpLL.cpp)
 set_target_properties(simpll PROPERTIES PREFIX "diffkemp-")
 target_link_libraries(simpll simpll-lib ${llvm_libs})
+if (NOT ${system_libs} STREQUAL "")
+    target_link_libraries(simpll ${system_libs})
+endif()
 
 if(SIMPLL_REBUILD_BINDINGS)
 add_custom_target(python-ffi ALL DEPENDS _simpll.c)

--- a/diffkemp/simpll/simpll_build.py
+++ b/diffkemp/simpll/simpll_build.py
@@ -23,20 +23,25 @@ ffibuilder = FFI()
 
 ffibuilder.cdef(get_c_declarations("diffkemp/simpll/library/FFI.h"))
 
-llvm_libs = ["irreader", "passes", "support"]
+llvm_components = ["irreader", "passes", "support"]
 llvm_cflags = check_output(["llvm-config", "--cflags"])
-llvm_ldflags = check_output(["llvm-config", "--libs"] + llvm_libs)
+llvm_ldflags = check_output(["llvm-config", "--ldflags"])
+llvm_libs = check_output(["llvm-config", "--libs"] + llvm_components +
+                         ["--system-libs"])
 
 llvm_cflags = list(filter(lambda x: x != "",
-                          llvm_cflags.decode("ascii").strip().split(" ")))
+                          llvm_cflags.decode("ascii").strip().split()))
 llvm_ldflags = list(filter(lambda x: x != "",
-                           llvm_ldflags.decode("ascii").strip().split(" ")))
+                           llvm_ldflags.decode("ascii").strip().split()))
+llvm_libs = list(filter(lambda x: x != "",
+                        llvm_libs.decode("ascii").strip().split()))
 
 ffibuilder.set_source(
     "diffkemp.simpll._simpll", '#include <library/FFI.h>',
     libraries=['simpll-lib'],
     extra_compile_args=["-Idiffkemp/simpll"] + llvm_cflags,
-    extra_link_args=["-Lbuild/diffkemp/simpll", "-lstdc++"] + llvm_ldflags)
+    extra_link_args=["-Lbuild/diffkemp/simpll", "-lstdc++"] + llvm_ldflags +
+    llvm_libs)
 
 if __name__ == "__main__":
     ffibuilder.compile()

--- a/tests/unit_tests/simpll/CMakeLists.txt
+++ b/tests/unit_tests/simpll/CMakeLists.txt
@@ -12,7 +12,7 @@ add_subdirectory("${CMAKE_CURRENT_BINARY_DIR}/googletest-src"
                  EXCLUDE_FROM_ALL)
 
 # Disable RTTI to link with SimpLL correctly.
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fno-rtti")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fno-rtti -fvisibility=hidden")
 
 enable_testing()
 
@@ -26,4 +26,10 @@ set_target_properties(runTests
   PROPERTIES
   RUNTIME_OUTPUT_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
 exec_program(llvm-config ARGS --libs irreader passes support OUTPUT_VARIABLE llvm_libs)
+exec_program(llvm-config ARGS --system-libs OUTPUT_VARIABLE system_libs)
+string(STRIP ${system_libs} system_libs)
+
 target_link_libraries(runTests gtest simpll-lib ${llvm_libs})
+if (NOT ${system_libs} STREQUAL "")
+	target_link_libraries(runTests gtest ${system_libs})
+endif()

--- a/tests/unit_tests/simpll/DifferentialFunctionComparatorTest.cpp
+++ b/tests/unit_tests/simpll/DifferentialFunctionComparatorTest.cpp
@@ -201,7 +201,7 @@ class DifferentialFunctionComparatorTest : public ::testing::Test {
         // Note: even though ModuleComparator is not tested here,
         // DifferentialFunctionComparator expects the presence of the key in
         // the map, therefore it is necessary to do this here.
-        ModComp->ComparedFuns.insert({{FL, FR}, Result{}});
+        ModComp->ComparedFuns.emplace(std::make_pair(FL, FR), Result{});
 
         // Generate debug metadata.
         generateDebugMetadata();


### PR DESCRIPTION
To compile Diffkemp in macOS, we need explicitly add system libraries for linking. 
Also, it is needed to explicitly define C++14 standard.
By default, insertion to map makes copy in macOS. `Class Result` do not
have copy constructor, so it caused errors. Therefore, we use `emplace` to
fix it.