### PR TITLE
CI: install GCC7 manually

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,7 +39,7 @@ jobs:
         working-directory: ${{ github.workspace }}
         shell: bash
         run: |
-          sudo apt-get install bc cscope libelf-dev ninja-build
+          sudo apt-get install bc cscope gcc-7 libelf-dev ninja-build
           pip install -r requirements.txt
 
       - name: Install LLVM

--- a/diffkemp/simpll/simpll_build.py
+++ b/diffkemp/simpll/simpll_build.py
@@ -38,6 +38,7 @@ llvm_libs = list(filter(lambda x: x != "",
 
 ffibuilder.set_source(
     "diffkemp.simpll._simpll", '#include <library/FFI.h>',
+    language="c++",
     libraries=['simpll-lib'],
     extra_compile_args=["-Idiffkemp/simpll"] + llvm_cflags,
     extra_link_args=["-Lbuild/diffkemp/simpll", "-lstdc++"] + llvm_ldflags +


### PR DESCRIPTION
This is now required since GCC7 is not installed by default in the CI environment.
The change also required to explicitly set CFFI language to C++.