### PR TITLE
Add elapsed time to the reported statistics

### DIFF
--- a/diffkemp/diffkemp.py
+++ b/diffkemp/diffkemp.py
@@ -8,6 +8,7 @@ from diffkemp.semdiff.function_diff import functions_diff
 from diffkemp.semdiff.result import Result
 from diffkemp.simpll.library import SimpLLModule
 from tempfile import mkdtemp
+from timeit import default_timer
 import errno
 import os
 import re
@@ -272,7 +273,7 @@ def compare(args):
                     args.print_asm_diffs, args.verbose, args.enable_simpll_ffi,
                     args.semdiff_tool)
     result = Result(Result.Kind.NONE, args.snapshot_dir_old,
-                    args.snapshot_dir_old)
+                    args.snapshot_dir_old, start_time=default_timer())
 
     for group_name, group in sorted(old_snapshot.fun_groups.items()):
         group_printed = False
@@ -382,6 +383,7 @@ def compare(args):
         print("")
         print("Statistics")
         print("----------")
+        result.stop_time = default_timer()
         result.report_stat(args.show_errors)
     return 0
 

--- a/diffkemp/semdiff/result.py
+++ b/diffkemp/semdiff/result.py
@@ -55,7 +55,8 @@ class Result:
             self.diff_kind = diff_kind
             self.covered = covered
 
-    def __init__(self, kind, first_name, second_name):
+    def __init__(self, kind, first_name, second_name, start_time=None,
+                 stop_time=None):
         self.kind = kind
         self.first = Result.Entity(first_name)
         self.second = Result.Entity(second_name)
@@ -63,6 +64,8 @@ class Result:
         self.macro_diff = None
         self.graph = None
         self.inner = dict()
+        self.start_time = start_time
+        self.stop_time = stop_time
 
     def __str__(self):
         return str(self.kind)
@@ -168,6 +171,9 @@ class Result:
         empty = len([r for r in unique_diffs if r.res.diff == ""])
 
         # Print statistics
+        if self.start_time and self.stop_time:
+            print("Elapsed time:            {:.2f} s".format(
+                self.stop_time - self.start_time))
         print("Functions compared:      {}".format(compared))
         print("Total differences:       {}".format(total))
         if total == 0:


### PR DESCRIPTION
Adds the total elapsed time in seconds to the reported statistics. The timer starts when the primary instance of `Result` gets created and ends just before the statistics get reported.

Example `--report-stat` output:
```
Statistics
----------
Total symbols: 471
Equal:         356 (76%)
Not equal:     85 (18%)
(empty diff):  1 (0%)
Unknown:       25 (5%)
Errors:        5 (1%)

Elapsed time:            233.42 s
Functions compared:      3411
Total differences:       93
In functions:            81 (87%)
In types:                5 (5%)
In macros:               7 (8%)
In inline assembly code: 0 (0%)
Empty diffs:             4 (4%)
```