### PR TITLE
Add verbose levels

### DIFF
--- a/diffkemp/config.py
+++ b/diffkemp/config.py
@@ -16,7 +16,7 @@ class Config:
         :param snapshot_second: Second snapshot representation.
         :param show_diff: Only perform the syntax diff.
         :param control_flow_only: Check only for control-flow differences.
-        :param verbosity: Verbosity level (currently boolean).
+        :param verbosity: Verbosity level.
         :param semdiff_tool: Tool to use for semantic diff
         """
         self.snapshot_first = snapshot_first

--- a/diffkemp/diffkemp.py
+++ b/diffkemp/diffkemp.py
@@ -21,7 +21,7 @@ def __make_argument_parser():
                                     "kernel functions.")
     ap.add_argument("-v", "--verbose",
                     help="increase output verbosity",
-                    action="store_true")
+                    action="count", default=0)
     sub_ap = ap.add_subparsers(dest="command", metavar="command")
     sub_ap.required = True
 

--- a/diffkemp/semdiff/function_diff.py
+++ b/diffkemp/semdiff/function_diff.py
@@ -48,7 +48,7 @@ def _link_symbol_def(snapshot, module, symbol):
 
 
 def _run_llreve_z3(first, second, funFirst, funSecond, coupled, timeout,
-                   verbose):
+                   verbosity):
     """
     Run the comparison of semantics of two functions using the llreve tool and
     the Z3 SMT solver. The llreve tool takes compared functions in LLVM IR and
@@ -66,11 +66,11 @@ def _run_llreve_z3(first, second, funFirst, funSecond, coupled, timeout,
                     correspond to each other in both modules). These are needed
                     for functions not having definintions.
     :param timeout: Timeout for the analysis in seconds
-    :param verbose: Verbosity option
+    :param verbosity: Verbosity level
     """
 
     stderr = None
-    if not verbose:
+    if verbosity == 0:
         stderr = open('/dev/null', 'w')
 
     # Commands for running llreve and Z3 (output of llreve is piped into Z3)
@@ -82,7 +82,7 @@ def _run_llreve_z3(first, second, funFirst, funSecond, coupled, timeout,
     for c in coupled:
         command.append("--couple-functions={},{}".format(c[0], c[1]))
 
-    if verbose:
+    if verbosity > 0:
         sys.stderr.write(" ".join(command) + "\n")
 
     llreve_process = Popen(command, stdout=PIPE, stderr=stderr)
@@ -185,7 +185,7 @@ def functions_diff(mod_first, mod_second,
     result = Result(Result.Kind.NONE, fun_first, fun_second)
     curr_result_graph = None
     try:
-        if config.verbosity:
+        if config.verbosity > 0:
             if fun_first == fun_second:
                 fun_str = fun_first
             else:
@@ -215,7 +215,7 @@ def functions_diff(mod_first, mod_second,
                                control_flow_only=config.control_flow_only,
                                output_llvm_ir=config.output_llvm_ir,
                                print_asm_diffs=config.print_asm_diffs,
-                               verbose=config.verbosity,
+                               verbosity=config.verbosity,
                                use_ffi=config.use_ffi,
                                module_cache=module_cache)
                 if missing_defs:
@@ -297,12 +297,12 @@ def functions_diff(mod_first, mod_second,
                                 fun_result.first.diff_kind))
                         fun_result.diff = "unknown\n"
                 result.add_inner(fun_result)
-        if config.verbosity:
+        if config.verbosity > 0:
             print("  {}".format(result))
     except ValueError:
         result.kind = Result.Kind.ERROR
     except SimpLLException as e:
-        if config.verbosity:
+        if config.verbosity > 0:
             print(e)
         result.kind = Result.Kind.ERROR
     result.graph = (curr_result_graph if curr_result_graph

--- a/diffkemp/simpll/Config.cpp
+++ b/diffkemp/simpll/Config.cpp
@@ -46,9 +46,9 @@ cl::opt<bool> ControlFlowOpt(
 cl::opt<bool> PrintCallstacksOpt(
         "print-callstacks",
         cl::desc("Print call stacks for non-equal functions."));
-cl::opt<bool>
-        VerboseOpt("verbose",
-                   cl::desc("Show verbose output (debugging information)."));
+cl::opt<int> VerbosityOpt(
+        "verbosity",
+        cl::desc("Level of verbose output (debugging information)."));
 cl::opt<bool> VerboseMacrosOpt("verbose-macros",
                                cl::desc("Show debugging information for "
                                         "discovering macro differences"));
@@ -107,9 +107,14 @@ Config::Config()
     }
 
     std::vector<std::string> debugTypes;
-    if (VerboseOpt) {
-        // Enable debugging output in passes
-        debugTypes.emplace_back(DEBUG_SIMPLL);
+    if (VerbosityOpt > 0) {
+        // Enable debugging output in passes. Intended fallthrough
+        switch (VerbosityOpt) {
+        default:
+        case 1:
+            debugTypes.emplace_back(DEBUG_SIMPLL);
+            break;
+        }
     }
     if (VerboseMacrosOpt) {
         // Enable debugging output when finding macro differences
@@ -145,7 +150,7 @@ Config::Config(std::string FirstFunName,
                bool ControlFlowOnly,
                bool PrintAsmDiffs,
                bool PrintCallStacks,
-               bool Verbose,
+               int Verbosity,
                bool VerboseMacros)
         : First(std::move(FirstModule)), Second(std::move(SecondModule)),
           FirstFunName(FirstFunName), SecondFunName(SecondFunName),
@@ -161,9 +166,14 @@ Config::Config(std::string FirstFunName,
     }
 
     std::vector<std::string> debugTypes;
-    if (Verbose) {
-        // Enable debugging output in passes
-        debugTypes.emplace_back(DEBUG_SIMPLL);
+    if (Verbosity > 0) {
+        // Enable debugging output in passes. Intended fallthrough
+        switch (Verbosity) {
+        default:
+        case 1:
+            debugTypes.emplace_back(DEBUG_SIMPLL);
+            break;
+        }
     }
     if (VerboseMacros) {
         // Enable debugging output when finding macro differences

--- a/diffkemp/simpll/Config.cpp
+++ b/diffkemp/simpll/Config.cpp
@@ -111,6 +111,9 @@ Config::Config()
         // Enable debugging output in passes. Intended fallthrough
         switch (VerbosityOpt) {
         default:
+        case 2:
+            debugTypes.emplace_back(DEBUG_SIMPLL_VERBOSE);
+            [[fallthrough]];
         case 1:
             debugTypes.emplace_back(DEBUG_SIMPLL);
             break;
@@ -170,6 +173,9 @@ Config::Config(std::string FirstFunName,
         // Enable debugging output in passes. Intended fallthrough
         switch (Verbosity) {
         default:
+        case 2:
+            debugTypes.emplace_back(DEBUG_SIMPLL_VERBOSE);
+            [[fallthrough]];
         case 1:
             debugTypes.emplace_back(DEBUG_SIMPLL);
             break;

--- a/diffkemp/simpll/Config.cpp
+++ b/diffkemp/simpll/Config.cpp
@@ -49,9 +49,6 @@ cl::opt<bool> PrintCallstacksOpt(
 cl::opt<int> VerbosityOpt(
         "verbosity",
         cl::desc("Level of verbose output (debugging information)."));
-cl::opt<bool> VerboseMacrosOpt("verbose-macros",
-                               cl::desc("Show debugging information for "
-                                        "discovering macro differences"));
 cl::opt<bool> PrintAsmDiffsOpt(
         "print-asm-diffs",
         cl::desc("Print raw differences in inline assembly code "
@@ -111,6 +108,9 @@ Config::Config()
         // Enable debugging output in passes. Intended fallthrough
         switch (VerbosityOpt) {
         default:
+        case 3:
+            debugTypes.emplace_back(DEBUG_SIMPLL_VERBOSE_EXTRA);
+            [[fallthrough]];
         case 2:
             debugTypes.emplace_back(DEBUG_SIMPLL_VERBOSE);
             [[fallthrough]];
@@ -118,10 +118,6 @@ Config::Config()
             debugTypes.emplace_back(DEBUG_SIMPLL);
             break;
         }
-    }
-    if (VerboseMacrosOpt) {
-        // Enable debugging output when finding macro differences
-        debugTypes.emplace_back(DEBUG_SIMPLL_MACROS);
     }
     setDebugTypes(debugTypes);
 }
@@ -153,8 +149,7 @@ Config::Config(std::string FirstFunName,
                bool ControlFlowOnly,
                bool PrintAsmDiffs,
                bool PrintCallStacks,
-               int Verbosity,
-               bool VerboseMacros)
+               int Verbosity)
         : First(std::move(FirstModule)), Second(std::move(SecondModule)),
           FirstFunName(FirstFunName), SecondFunName(SecondFunName),
           FirstOutFile(FirstOutFile), SecondOutFile(SecondOutFile),
@@ -173,6 +168,9 @@ Config::Config(std::string FirstFunName,
         // Enable debugging output in passes. Intended fallthrough
         switch (Verbosity) {
         default:
+        case 3:
+            debugTypes.emplace_back(DEBUG_SIMPLL_VERBOSE_EXTRA);
+            [[fallthrough]];
         case 2:
             debugTypes.emplace_back(DEBUG_SIMPLL_VERBOSE);
             [[fallthrough]];
@@ -180,10 +178,6 @@ Config::Config(std::string FirstFunName,
             debugTypes.emplace_back(DEBUG_SIMPLL);
             break;
         }
-    }
-    if (VerboseMacros) {
-        // Enable debugging output when finding macro differences
-        debugTypes.emplace_back(DEBUG_SIMPLL_MACROS);
     }
     setDebugTypes(debugTypes);
 }

--- a/diffkemp/simpll/Config.h
+++ b/diffkemp/simpll/Config.h
@@ -22,7 +22,7 @@
 
 #define DEBUG_SIMPLL "debug-simpll"
 #define DEBUG_SIMPLL_VERBOSE "debug-simpll-verbose"
-#define DEBUG_SIMPLL_MACROS "debug-simpll-macros"
+#define DEBUG_SIMPLL_VERBOSE_EXTRA "debug-simpll-verbose-extra"
 
 using namespace llvm;
 
@@ -35,7 +35,6 @@ extern cl::opt<std::string> SuffixOpt;
 extern cl::opt<bool> ControlFlowOpt;
 extern cl::opt<bool> PrintCallstacksOpt;
 extern cl::opt<int> VerbosityOpt;
-extern cl::opt<bool> VerboseMacrosOpt;
 
 /// Tool configuration parsed from CLI options.
 class Config {
@@ -87,8 +86,7 @@ class Config {
            bool ControlFlowOnly = false,
            bool PrintAsmDiffs = true,
            bool PrintCallStacks = true,
-           int Verbosity = 0,
-           bool VerboseMacros = false);
+           int Verbosity = 0);
     // Constructor without module loading (for tests).
     Config(std::string FirstFunName,
            std::string SecondFunName,

--- a/diffkemp/simpll/Config.h
+++ b/diffkemp/simpll/Config.h
@@ -33,7 +33,7 @@ extern cl::opt<std::string> VariableOpt;
 extern cl::opt<std::string> SuffixOpt;
 extern cl::opt<bool> ControlFlowOpt;
 extern cl::opt<bool> PrintCallstacksOpt;
-extern cl::opt<bool> VerboseOpt;
+extern cl::opt<int> VerbosityOpt;
 extern cl::opt<bool> VerboseMacrosOpt;
 
 /// Tool configuration parsed from CLI options.
@@ -86,7 +86,7 @@ class Config {
            bool ControlFlowOnly = false,
            bool PrintAsmDiffs = true,
            bool PrintCallStacks = true,
-           bool Verbose = false,
+           int Verbosity = 0,
            bool VerboseMacros = false);
     // Constructor without module loading (for tests).
     Config(std::string FirstFunName,

--- a/diffkemp/simpll/Config.h
+++ b/diffkemp/simpll/Config.h
@@ -21,6 +21,7 @@
 #include <llvm/Support/SourceMgr.h>
 
 #define DEBUG_SIMPLL "debug-simpll"
+#define DEBUG_SIMPLL_VERBOSE "debug-simpll-verbose"
 #define DEBUG_SIMPLL_MACROS "debug-simpll-macros"
 
 using namespace llvm;

--- a/diffkemp/simpll/DebugInfo.cpp
+++ b/diffkemp/simpll/DebugInfo.cpp
@@ -162,7 +162,7 @@ void DebugInfo::extractAlignmentFromInstructions(GetElementPtrInst *GEP,
                                                IndexConstant->getBitWidth(),
                                                ModFirst.getContext());
                         DEBUG_WITH_TYPE(
-                                DEBUG_SIMPLL,
+                                DEBUG_SIMPLL_VERBOSE,
                                 dbgs() << "Index alignment in:" << *GEP << "\n"
                                        << "                     " << indexFirst
                                        << " -> " << indexSecond << "\n");

--- a/diffkemp/simpll/SourceCodeUtils.cpp
+++ b/diffkemp/simpll/SourceCodeUtils.cpp
@@ -32,13 +32,13 @@ void MacroDiffAnalysis::collectMacroUsesAtLocation(
     std::string line = extractLineFromLocation(Loc, lineOffset);
     if (line.empty()) {
         // Source line was not found
-        DEBUG_WITH_TYPE(DEBUG_SIMPLL_MACROS,
+        DEBUG_WITH_TYPE(DEBUG_SIMPLL_VERBOSE_EXTRA,
                         dbgs() << getDebugIndent()
                                << "Source for macro not found\n");
         return;
     }
 
-    DEBUG_WITH_TYPE(DEBUG_SIMPLL_MACROS,
+    DEBUG_WITH_TYPE(DEBUG_SIMPLL_VERBOSE_EXTRA,
                     dbgs() << getDebugIndent()
                            << "Looking for all macros on line:" << line
                            << "\n");
@@ -117,7 +117,7 @@ void MacroDiffAnalysis::collectMacroUsesAtLocation(
                         // If the macro use is new (it was not in the result
                         // map, yet), add its body into the toExpand queue.
                         DEBUG_WITH_TYPE(
-                                DEBUG_SIMPLL_MACROS,
+                                DEBUG_SIMPLL_VERBOSE_EXTRA,
                                 dbgs() << getDebugIndent() << "Adding macro "
                                        << newMacroUse.def->name << " : "
                                        << newMacroUse.def->body
@@ -227,7 +227,7 @@ const StringMap<MacroUse> &
                                                      int lineOffset) {
     if (!Loc || Loc->getNumOperands() == 0) {
         // DILocation has no scope or is not present - cannot get macro stack
-        DEBUG_WITH_TYPE(DEBUG_SIMPLL_MACROS,
+        DEBUG_WITH_TYPE(DEBUG_SIMPLL_VERBOSE_EXTRA,
                         dbgs() << getDebugIndent()
                                << "Scope for macro not found\n");
         MacroUsesAtLocation.emplace(Loc, StringMap<MacroUse>());
@@ -294,7 +294,7 @@ std::vector<std::unique_ptr<SyntaxDifference>>
             std::reverse(StackR.begin(), StackR.end());
 
             DEBUG_WITH_TYPE(
-                    DEBUG_SIMPLL_MACROS,
+                    DEBUG_SIMPLL_VERBOSE_EXTRA,
                     dbgs() << getDebugIndent() << "Left stack:\n\t";
                     dbgs() << getDebugIndent() << MacroUseL.second.def->body
                            << "\n";
@@ -305,7 +305,7 @@ std::vector<std::unique_ptr<SyntaxDifference>>
                                << elem.line << "\n";
                     });
             DEBUG_WITH_TYPE(
-                    DEBUG_SIMPLL_MACROS,
+                    DEBUG_SIMPLL_VERBOSE_EXTRA,
                     dbgs() << getDebugIndent() << "Right stack:\n\t";
                     dbgs() << getDebugIndent() << MacroUseR->second.def->body
                            << "\n";

--- a/diffkemp/simpll/library/FFI.cpp
+++ b/diffkemp/simpll/library/FFI.cpp
@@ -51,7 +51,7 @@ void runSimpLL(std::unique_ptr<Module> ModL,
                   Conf.ControlFlowOnly,
                   Conf.PrintAsmDiffs,
                   Conf.PrintCallStacks,
-                  Conf.Verbose,
+                  Conf.Verbosity,
                   Conf.VerboseMacros);
 
     OverallResult Result;

--- a/diffkemp/simpll/library/FFI.cpp
+++ b/diffkemp/simpll/library/FFI.cpp
@@ -51,8 +51,7 @@ void runSimpLL(std::unique_ptr<Module> ModL,
                   Conf.ControlFlowOnly,
                   Conf.PrintAsmDiffs,
                   Conf.PrintCallStacks,
-                  Conf.Verbosity,
-                  Conf.VerboseMacros);
+                  Conf.Verbosity);
 
     OverallResult Result;
     processAndCompare(config, Result);

--- a/diffkemp/simpll/library/FFI.h
+++ b/diffkemp/simpll/library/FFI.h
@@ -27,7 +27,7 @@ struct config {
     int ControlFlowOnly;
     int PrintAsmDiffs;
     int PrintCallStacks;
-    int Verbose;
+    int Verbosity;
     int VerboseMacros;
 };
 

--- a/diffkemp/simpll/library/FFI.h
+++ b/diffkemp/simpll/library/FFI.h
@@ -28,7 +28,6 @@ struct config {
     int PrintAsmDiffs;
     int PrintCallStacks;
     int Verbosity;
-    int VerboseMacros;
 };
 
 struct ptr_array {

--- a/diffkemp/simpll/passes/ControlFlowSlicer.cpp
+++ b/diffkemp/simpll/passes/ControlFlowSlicer.cpp
@@ -138,7 +138,7 @@ PreservedAnalyses ControlFlowSlicer::run(Function &Fun,
     }
 
     if (!ToRemove.empty()) {
-        DEBUG_WITH_TYPE(DEBUG_SIMPLL,
+        DEBUG_WITH_TYPE(DEBUG_SIMPLL_VERBOSE,
                         dbgs() << "Removed instructions from " << Fun.getName()
                                << ": \n");
     }

--- a/diffkemp/simpll/passes/FunctionAbstractionsGenerator.cpp
+++ b/diffkemp/simpll/passes/FunctionAbstractionsGenerator.cpp
@@ -102,7 +102,7 @@ FunctionAbstractionsGenerator::Result FunctionAbstractionsGenerator::run(
                     auto newCall =
                             CallInst::Create(newFun, args, "", CallInstr);
                     newCall->setDebugLoc(CallInstr->getDebugLoc());
-                    DEBUG_WITH_TYPE(DEBUG_SIMPLL,
+                    DEBUG_WITH_TYPE(DEBUG_SIMPLL_VERBOSE,
                                     dbgs() << "Replacing :" << *CallInstr
                                            << "\n     with :" << *newCall
                                            << "\n");

--- a/diffkemp/simpll/passes/RemoveUnusedReturnValuesPass.cpp
+++ b/diffkemp/simpll/passes/RemoveUnusedReturnValuesPass.cpp
@@ -70,7 +70,7 @@ PreservedAnalyses RemoveUnusedReturnValuesPass::run(
             // Nothing to replace.
             continue;
 
-        DEBUG_WITH_TYPE(DEBUG_SIMPLL,
+        DEBUG_WITH_TYPE(DEBUG_SIMPLL_VERBOSE,
                         dbgs() << getDebugIndent(' ')
                                << "Creating void-returning variant of "
                                << Fun->getName() << "\n");
@@ -162,12 +162,12 @@ PreservedAnalyses RemoveUnusedReturnValuesPass::run(
                 CallInst *CI_New = CallInst::Create(Fun_New, Args_AR, "", CI);
                 copyCallInstProperties(CI, CI_New);
 
-                DEBUG_WITH_TYPE(DEBUG_SIMPLL, increaseDebugIndentLevel();
-                                dbgs() << getDebugIndent()
-                                       << "Replacing :" << *CI << "\n"
-                                       << getDebugIndent()
-                                       << "     with :" << *CI_New << "\n";
-                                decreaseDebugIndentLevel());
+                DEBUG_WITH_TYPE(
+                        DEBUG_SIMPLL_VERBOSE, increaseDebugIndentLevel();
+                        dbgs()
+                        << getDebugIndent() << "Replacing :" << *CI << "\n"
+                        << getDebugIndent() << "     with :" << *CI_New << "\n";
+                        decreaseDebugIndentLevel());
                 // Erase the old instruction
                 CI->eraseFromParent();
             }

--- a/diffkemp/simpll/passes/SeparateCallsToBitcastPass.cpp
+++ b/diffkemp/simpll/passes/SeparateCallsToBitcastPass.cpp
@@ -109,7 +109,7 @@ PreservedAnalyses
 
                     // Replace the old call instruction with the last generated
                     // instruction.
-                    DEBUG_WITH_TYPE(DEBUG_SIMPLL,
+                    DEBUG_WITH_TYPE(DEBUG_SIMPLL_VERBOSE,
                                     dbgs() << "Replacing :" << *Call
                                            << "\n   with :" << *replacementValue
                                            << "\n");

--- a/diffkemp/simpll/passes/VarDependencySlicer.cpp
+++ b/diffkemp/simpll/passes/VarDependencySlicer.cpp
@@ -37,7 +37,7 @@ PreservedAnalyses VarDependencySlicer::run(Function &Fun,
     IncludedBasicBlocks.clear();
     IncludedParams.clear();
 
-    DEBUG_WITH_TYPE(DEBUG_SIMPLL,
+    DEBUG_WITH_TYPE(DEBUG_SIMPLL_VERBOSE,
                     dbgs() << "Function: " << Fun.getName().str() << "\n");
 
     // First phase - determine which instructions are dependent on the parameter
@@ -65,7 +65,7 @@ PreservedAnalyses VarDependencySlicer::run(Function &Fun,
 
             if (dependent) {
                 addToDependent(&Instr);
-                DEBUG_WITH_TYPE(DEBUG_SIMPLL, {
+                DEBUG_WITH_TYPE(DEBUG_SIMPLL_VERBOSE, {
                     dbgs() << "Dependent: ";
                     Instr.print(dbgs());
                 });
@@ -85,7 +85,7 @@ PreservedAnalyses VarDependencySlicer::run(Function &Fun,
 
     // Second phase - determine which additional instructions we need to
     // produce a valid CFG
-    DEBUG_WITH_TYPE(DEBUG_SIMPLL, dbgs() << "Second phase\n");
+    DEBUG_WITH_TYPE(DEBUG_SIMPLL_VERBOSE, dbgs() << "Second phase\n");
     // Recursively add all instruction operands to included
     for (auto &Inst : DependentInstrs) {
         if (isa<PHINode>(Inst))
@@ -161,7 +161,7 @@ PreservedAnalyses VarDependencySlicer::run(Function &Fun,
         // Collect and clear all instruction that can be removed
         for (auto &Inst : BB) {
             if (!isIncluded(&Inst) && !Inst.isTerminator()) {
-                DEBUG_WITH_TYPE(DEBUG_SIMPLL,
+                DEBUG_WITH_TYPE(DEBUG_SIMPLL_VERBOSE,
                                 { dbgs() << "Clearing " << Inst << "\n"; });
                 Inst.replaceAllUsesWith(UndefValue::get(Inst.getType()));
                 toRemove.push_back(&Inst);
@@ -178,7 +178,7 @@ PreservedAnalyses VarDependencySlicer::run(Function &Fun,
     // to return void
     if (RetBB && !RetBB->empty() && !isIncluded(RetBB->getTerminator())
         && !Fun.getReturnType()->isVoidTy()) {
-        DEBUG_WITH_TYPE(DEBUG_SIMPLL,
+        DEBUG_WITH_TYPE(DEBUG_SIMPLL_VERBOSE,
                         dbgs() << "Changing return type of " << Fun.getName()
                                << " to void.\n");
         changeToVoid(Fun);
@@ -217,7 +217,7 @@ PreservedAnalyses VarDependencySlicer::run(Function &Fun,
     //       in a newer version of LLVM.
     deleteUnreachableBlocks(Fun);
 
-    DEBUG_WITH_TYPE(DEBUG_SIMPLL, {
+    DEBUG_WITH_TYPE(DEBUG_SIMPLL_VERBOSE, {
         dbgs() << "Function " << Fun.getName().str() << " after cleanup:\n";
         Fun.print(dbgs());
         dbgs() << "\n";
@@ -267,7 +267,7 @@ void VarDependencySlicer::addAllInstrs(
         IncludedBasicBlocks.insert(BB);
         for (auto &Instr : *BB) {
             DependentInstrs.insert(&Instr);
-            DEBUG_WITH_TYPE(DEBUG_SIMPLL, {
+            DEBUG_WITH_TYPE(DEBUG_SIMPLL_VERBOSE, {
                 dbgs() << "Dependent: ";
                 Instr.print(dbgs());
             });
@@ -328,7 +328,7 @@ bool VarDependencySlicer::addAllOpsToIncluded(const Instruction *Inst) {
     for (auto &Op : Inst->operands()) {
         if (auto OpInst = dyn_cast<Instruction>(&Op)) {
             if (addToIncluded(OpInst)) {
-                DEBUG_WITH_TYPE(DEBUG_SIMPLL, {
+                DEBUG_WITH_TYPE(DEBUG_SIMPLL_VERBOSE, {
                     dbgs() << "Included: ";
                     OpInst->print(dbgs());
                 });

--- a/diffkemp/simpll/simpll.py
+++ b/diffkemp/simpll/simpll.py
@@ -21,7 +21,7 @@ def add_suffix(file, suffix):
 
 def run_simpll(first, second, fun_first, fun_second, var, suffix=None,
                cache_dir=None, control_flow_only=False, output_llvm_ir=False,
-               print_asm_diffs=False, verbose=False, use_ffi=False,
+               print_asm_diffs=False, verbosity=0, use_ffi=False,
                module_cache=None):
     """
     Simplify modules to ease their semantic difference. Uses the SimpLL tool.
@@ -30,7 +30,7 @@ def run_simpll(first, second, fun_first, fun_second, var, suffix=None,
             a list of missing function definitions.
     """
     stderr = None
-    if not verbose:
+    if verbosity == 0:
         stderr = open(os.devnull, "w")
 
     first_out_name = add_suffix(first, suffix) if suffix else first
@@ -53,7 +53,7 @@ def run_simpll(first, second, fun_first, fun_second, var, suffix=None,
         conf_struct.PrintAsmDiffs = print_asm_diffs
         conf_struct.PrintCallStacks = True
         conf_struct.Variable = variable
-        conf_struct.Verbose = verbose
+        conf_struct.Verbosity = verbosity
         conf_struct.VerboseMacros = False
 
         if use_cached_modules:
@@ -116,8 +116,8 @@ def run_simpll(first, second, fun_first, fun_second, var, suffix=None,
             if print_asm_diffs:
                 simpll_command.append("--print-asm-diffs")
 
-            if verbose:
-                simpll_command.append("--verbose")
+            if verbosity > 0:
+                simpll_command.extend(["--verbosity", str(verbosity)])
                 print(" ".join(simpll_command))
 
             simpll_out = check_output(simpll_command)

--- a/diffkemp/simpll/simpll.py
+++ b/diffkemp/simpll/simpll.py
@@ -54,7 +54,6 @@ def run_simpll(first, second, fun_first, fun_second, var, suffix=None,
         conf_struct.PrintCallStacks = True
         conf_struct.Variable = variable
         conf_struct.Verbosity = verbosity
-        conf_struct.VerboseMacros = False
 
         if use_cached_modules:
             module_left = module_cache[first].pointer


### PR DESCRIPTION
Added a new, more verbose verbosity level.

This new verbosity level can be selected by using a `-vv` parameter.
So far I've only moved each passes' debug output to this new level. Other debug messages stay on the same level as before.

Resolves #36 