### PR TITLE
Fix color output

### DIFF
--- a/diffkemp/semdiff/function_diff.py
+++ b/diffkemp/semdiff/function_diff.py
@@ -297,8 +297,6 @@ def functions_diff(mod_first, mod_second,
                                 fun_result.first.diff_kind))
                         fun_result.diff = "unknown\n"
                 result.add_inner(fun_result)
-        if config.verbosity > 0:
-            print("  {}".format(result))
     except ValueError:
         result.kind = Result.Kind.ERROR
     except SimpLLException as e:

--- a/diffkemp/semdiff/function_diff.py
+++ b/diffkemp/semdiff/function_diff.py
@@ -190,8 +190,8 @@ def functions_diff(mod_first, mod_second,
                 fun_str = fun_first
             else:
                 fun_str = "{} and {}".format(fun_first, fun_second)
-            print("Syntactic diff of {} (in {})".format(fun_str,
-                                                        mod_first.llvm))
+            print("Semantic diff of {} (in {})".format(fun_str,
+                                                       mod_first.llvm))
 
         simplify = True
         while simplify:

--- a/diffkemp/simpll/ModuleAnalysis.cpp
+++ b/diffkemp/simpll/ModuleAnalysis.cpp
@@ -188,9 +188,11 @@ void simplifyModulesDiff(Config &config, OverallResult &Result) {
             }
             if (funPairResult.second.kind == Result::Kind::NOT_EQUAL) {
                 allEqual = false;
-                DEBUG_WITH_TYPE(DEBUG_SIMPLL,
-                                dbgs() << funPairResult.first.first->getName()
-                                       << " are semantically different\n");
+                DEBUG_WITH_TYPE(
+                        DEBUG_SIMPLL,
+                        dbgs() << funPairResult.first.first->getName()
+                               << " are "
+                               << Color::makeRed("semantically different\n"));
             }
         }
         if (allEqual) {

--- a/diffkemp/simpll/ModuleAnalysis.cpp
+++ b/diffkemp/simpll/ModuleAnalysis.cpp
@@ -178,7 +178,7 @@ void simplifyModulesDiff(Config &config, OverallResult &Result) {
         modComp.compareFunctions(config.FirstFun, config.SecondFun);
 
         DEBUG_WITH_TYPE(DEBUG_SIMPLL,
-                        dbgs() << "Syntactic comparison results:\n");
+                        dbgs() << "Semantic comparison results:\n");
         bool allEqual = true;
         for (auto &funPairResult : modComp.ComparedFuns) {
             if (!funPairResult.first.first->isIntrinsic()
@@ -190,7 +190,7 @@ void simplifyModulesDiff(Config &config, OverallResult &Result) {
                 allEqual = false;
                 DEBUG_WITH_TYPE(DEBUG_SIMPLL,
                                 dbgs() << funPairResult.first.first->getName()
-                                       << " are syntactically different\n");
+                                       << " are semantically different\n");
             }
         }
         if (allEqual) {
@@ -199,7 +199,7 @@ void simplifyModulesDiff(Config &config, OverallResult &Result) {
             // main functions) are equal.
             DEBUG_WITH_TYPE(DEBUG_SIMPLL,
                             dbgs() << Color::makeGreen(
-                                    "All functions are syntactically equal\n"));
+                                    "All functions are semantically equal\n"));
             config.FirstFun->deleteBody();
             config.SecondFun->deleteBody();
             deleteAliasToFun(*config.First, config.FirstFun);

--- a/diffkemp/simpll/ModuleComparator.cpp
+++ b/diffkemp/simpll/ModuleComparator.cpp
@@ -8,7 +8,7 @@
 ///
 /// \file
 /// This file contains definitions of methods of the ModuleComparator class that
-/// can be used for syntactical comparison of two LLVM modules.
+/// can be used for semantic comparison of two LLVM modules.
 ///
 //===----------------------------------------------------------------------===//
 
@@ -20,7 +20,7 @@
 #include <llvm/Support/raw_ostream.h>
 #include <llvm/Transforms/Utils/Cloning.h>
 
-/// Syntactical comparison of functions.
+/// Semantic comparison of functions.
 /// Function declarations are equal if they have the same name.
 /// Functions with body are compared using custom FunctionComparator that
 /// is designed for comparing functions between different modules.

--- a/diffkemp/simpll/ModuleComparator.h
+++ b/diffkemp/simpll/ModuleComparator.h
@@ -70,7 +70,7 @@ class ModuleComparator {
               StructSizeMapL(StructSizeMapL), StructSizeMapR(StructSizeMapR),
               StructDIMapL(StructDIMapL), StructDIMapR(StructDIMapR) {}
 
-    /// Syntactically compare two functions.
+    /// Semantically compare two functions.
     /// The result of the comparison is stored into the ComparedFuns map.
     void compareFunctions(Function *FirstFun, Function *SecondFun);
 

--- a/diffkemp/simpll/Utils.cpp
+++ b/diffkemp/simpll/Utils.cpp
@@ -749,7 +749,13 @@ const std::string GREEN = "\e[1;32m";
 const std::string YELLOW = "\e[0;93m";
 const std::string WHITE = "\e[0m";
 
-std::string makeRed(std::string text) { return RED + text + WHITE; }
-std::string makeGreen(std::string text) { return GREEN + text + WHITE; }
-std::string makeYellow(std::string text) { return YELLOW + text + WHITE; }
+std::string makeRed(std::string text) {
+    return dbgs().has_colors() ? (RED + text + WHITE) : text;
+}
+std::string makeGreen(std::string text) {
+    return dbgs().has_colors() ? (GREEN + text + WHITE) : text;
+}
+std::string makeYellow(std::string text) {
+    return dbgs().has_colors() ? (YELLOW + text + WHITE) : text;
+}
 } // namespace Color


### PR DESCRIPTION
Fixes #197
I'm not quite sure which `"syntactic"` strings should've been changed to `"semantic"` so I might've changed some that should've stayed and didn't change some that should be changed. Could you have a look at that? Particularly in `semdiff/function_diff.py`.