### PR TITLE
SimpLL: Print info about analysis phases

### DIFF
--- a/diffkemp/simpll/DebugInfo.cpp
+++ b/diffkemp/simpll/DebugInfo.cpp
@@ -12,7 +12,6 @@
 //===----------------------------------------------------------------------===//
 
 #include "DebugInfo.h"
-#include "Config.h"
 #include <llvm/IR/Constants.h>
 #include <llvm/Passes/PassBuilder.h>
 

--- a/diffkemp/simpll/DebugInfo.h
+++ b/diffkemp/simpll/DebugInfo.h
@@ -15,6 +15,7 @@
 #ifndef DIFFKEMP_SIMPLL_DEBUGINFO_H
 #define DIFFKEMP_SIMPLL_DEBUGINFO_H
 
+#include "Config.h"
 #include "Utils.h"
 #include <llvm/IR/DebugInfo.h>
 #include <llvm/IR/Instructions.h>
@@ -46,6 +47,9 @@ class DebugInfo {
             : FunFirst(funFirst), FunSecond(funSecond), ModFirst(modFirst),
               ModSecond(modSecond), CalledFirst(CalledFirst),
               CalledSecond(CalledSecond) {
+        DEBUG_WITH_TYPE(DEBUG_SIMPLL,
+                        dbgs() << "Analysing debugging information...\n";
+                        increaseDebugIndentLevel());
         DebugInfoFirst.processModule(ModFirst);
         DebugInfoSecond.processModule(ModSecond);
         // Use debug info to gather useful information
@@ -53,6 +57,7 @@ class DebugInfo {
         calculateMacroAlignments();
         collectLocalVariables(CalledFirst, LocalVariableMapL);
         collectLocalVariables(CalledSecond, LocalVariableMapR);
+        DEBUG_WITH_TYPE(DEBUG_SIMPLL, decreaseDebugIndentLevel());
     };
 
     /// Maps structure type and index to struct member names

--- a/diffkemp/simpll/ModuleAnalysis.cpp
+++ b/diffkemp/simpll/ModuleAnalysis.cpp
@@ -60,6 +60,9 @@ void preprocessModule(Module &Mod,
                       Function *Main,
                       GlobalVariable *Var,
                       bool ControlFlowOnly) {
+    DEBUG_WITH_TYPE(DEBUG_SIMPLL,
+                    dbgs() << "Preprocessing " << Mod.getName() << "...\n";
+                    increaseDebugIndentLevel());
     if (Var) {
         // Slicing of the program w.r.t. the value of a global variable
         PassManager<Function, FunctionAnalysisManager, GlobalVariable *> fpm;
@@ -100,6 +103,8 @@ void preprocessModule(Module &Mod,
     mpm.addPass(StructHashGeneratorPass{});
 
     mpm.run(Mod, mam);
+
+    DEBUG_WITH_TYPE(DEBUG_SIMPLL, decreaseDebugIndentLevel());
 }
 
 /// Simplification of modules to ease the semantic diff.

--- a/diffkemp/simpll/passes/ControlFlowSlicer.cpp
+++ b/diffkemp/simpll/passes/ControlFlowSlicer.cpp
@@ -85,6 +85,9 @@ bool isResultOnlyStored(const Instruction *Inst) {
 /// parameters, and all instructions depending on these.
 PreservedAnalyses ControlFlowSlicer::run(Function &Fun,
                                          FunctionAnalysisManager & /*fam*/) {
+    DEBUG_WITH_TYPE(DEBUG_SIMPLL,
+                    dbgs() << "Slicing control-flow-only statements...\n";
+                    increaseDebugIndentLevel());
     std::set<const Instruction *> Dependent;
     for (const auto &BB : Fun) {
         for (const auto &Instr : BB) {
@@ -147,5 +150,6 @@ PreservedAnalyses ControlFlowSlicer::run(Function &Fun,
         DEBUG_WITH_TYPE(DEBUG_SIMPLL, dbgs() << *Instr << "\n";);
         Instr->eraseFromParent();
     }
+    DEBUG_WITH_TYPE(DEBUG_SIMPLL, decreaseDebugIndentLevel());
     return PreservedAnalyses::none();
 }

--- a/diffkemp/simpll/passes/FunctionAbstractionsGenerator.cpp
+++ b/diffkemp/simpll/passes/FunctionAbstractionsGenerator.cpp
@@ -26,6 +26,10 @@ AnalysisKey FunctionAbstractionsGenerator::Key;
 /// and for each pair of assembly code and constraint.
 FunctionAbstractionsGenerator::Result FunctionAbstractionsGenerator::run(
         Module &Mod, AnalysisManager<Module, Function *> &mam, Function *Main) {
+    DEBUG_WITH_TYPE(DEBUG_SIMPLL,
+                    dbgs() << "Generating function abstractions in "
+                           << Mod.getName() << "...\n";
+                    increaseDebugIndentLevel());
     FunMap funAbstractions;
     int i = 0;
     std::vector<Instruction *> toErase;
@@ -115,6 +119,7 @@ FunctionAbstractionsGenerator::Result FunctionAbstractionsGenerator::run(
             toErase.clear();
         }
     }
+    DEBUG_WITH_TYPE(DEBUG_SIMPLL, decreaseDebugIndentLevel());
     return FunctionAbstractionsGenerator::Result{funAbstractions};
 }
 

--- a/diffkemp/simpll/passes/RemoveUnusedReturnValuesPass.cpp
+++ b/diffkemp/simpll/passes/RemoveUnusedReturnValuesPass.cpp
@@ -25,6 +25,10 @@ PreservedAnalyses RemoveUnusedReturnValuesPass::run(
         AnalysisManager<Module, Function *> &mam,
         Function *Main,
         Module *ModOther) {
+    DEBUG_WITH_TYPE(DEBUG_SIMPLL,
+                    dbgs() << "Removing unused return values in "
+                           << Mod.getName() << "...\n";
+                    increaseDebugIndentLevel());
 
     auto &CalledFuns = mam.getResult<CalledFunctionsAnalysis>(Mod, Main);
 
@@ -180,5 +184,6 @@ PreservedAnalyses RemoveUnusedReturnValuesPass::run(
         Fun->eraseFromParent();
     }
 
+    DEBUG_WITH_TYPE(DEBUG_SIMPLL, decreaseDebugIndentLevel());
     return PreservedAnalyses();
 }

--- a/diffkemp/simpll/passes/VarDependencySlicer.cpp
+++ b/diffkemp/simpll/passes/VarDependencySlicer.cpp
@@ -26,6 +26,10 @@
 PreservedAnalyses VarDependencySlicer::run(Function &Fun,
                                            FunctionAnalysisManager &fam,
                                            GlobalVariable *Var) {
+    DEBUG_WITH_TYPE(DEBUG_SIMPLL,
+                    dbgs() << "Slicing " << Fun.getName() << " w.r.t. value of "
+                           << Var->getName() << "...\n";
+                    increaseDebugIndentLevel());
     if (Fun.isDeclaration())
         return PreservedAnalyses::all();
 
@@ -226,6 +230,7 @@ PreservedAnalyses VarDependencySlicer::run(Function &Fun,
         dbgs() << "Function " << Fun.getName().str() << " after cleanup:\n";
         Fun.print(dbgs());
         dbgs() << "\n";
+        decreaseDebugIndentLevel();
     });
     return PreservedAnalyses::none();
 }


### PR DESCRIPTION
Resolves #67 
Adds these messages:
```
Analysing debugging information...
Preprocessing {mod_name}...
Slicing control-flow-only statements...
Generating function abstractions in module {mod_name}...
Removing unused return values in module {mod_name}...
Slicing {fun_name} w.r.t. value of {var_name}...
```