### PR TITLE
Fix instruction ignoring bug

### DIFF
--- a/diffkemp/simpll/DifferentialFunctionComparator.h
+++ b/diffkemp/simpll/DifferentialFunctionComparator.h
@@ -172,7 +172,9 @@ class DifferentialFunctionComparator : public FunctionComparator {
 
     /// Retrive the replacement for the given value from the ignored
     /// instructions map. Try to generate the replacement if a bitcast is given.
-    const Value *getReplacementValue(const Value *Replaced) const;
+    const Value *
+            getReplacementValue(const Value *Replaced,
+                                DenseMap<const Value *, int> &sn_map) const;
 
     /// Does additional operations in cases when a difference between two
     /// CallInsts or their arguments is detected.


### PR DESCRIPTION
When getting a replacement value for an ignored instruction in `cmpValues`, besides querying the `ignoredInstructions` map, we allow to skip bitcast and zero GEP operators. The problem is that the replacing value may not be already synchronized and hence an incorrect synchronisation may be created by `cmpValues`.

This fixes the above problem by checking that if the replacing value is an instruction, it is already synchronised.

See the added unit test for an example.