### PR TITLE
Replace uses of a global before erasing it (fix memory error)

### DIFF
--- a/diffkemp/simpll/passes/SimplifyKernelGlobalsPass.cpp
+++ b/diffkemp/simpll/passes/SimplifyKernelGlobalsPass.cpp
@@ -86,6 +86,7 @@ PreservedAnalyses
         bool isStruct = isa<ConstantStruct>(Initializer);
 
         // Remove the global variable itself.
+        V->replaceAllUsesWith(Constant::getNullValue(V->getType()));
         V->eraseFromParent();
 
         // Remove its initializer if it was a struct.


### PR DESCRIPTION
`SimplifyKernelGlobalsPass` removes global variables having the `__ksym` prefix. Before erasing such a global, we need to replace all its uses by `nullptr` so that there are no memory leaks.

This should also fix a bug that non-determinisically appears for the regression test `rhel-73-74_debugfs_create_u32` with LLVM 13.