### PR TITLE
Save LLVM version when running diffkemp generate

### DIFF
--- a/diffkemp/snapshot.py
+++ b/diffkemp/snapshot.py
@@ -14,6 +14,7 @@ import pkg_resources
 import shutil
 import sys
 import yaml
+import subprocess
 
 
 class Snapshot:
@@ -51,6 +52,7 @@ class Snapshot:
         self.fun_kind = fun_kind
         self.fun_groups = dict()
         self.created_time = None
+        self.llvm_version = None
 
     @classmethod
     def create_from_source(cls, source_dir, output_dir,
@@ -200,6 +202,8 @@ class Snapshot:
         self.created_time = self.created_time.replace(
             tzinfo=datetime.timezone.utc)
 
+        self.llvm_version = yaml_dict["llvm_version"]
+
         llvm_finder_cls = None
         llvm_finder_path = None
         if yaml_dict["llvm_source_finder"]["kind"] == "kernel_with_builder":
@@ -265,6 +269,8 @@ class Snapshot:
         # Create the top level YAML structure.
         yaml_dict = [{
             "diffkemp_version": pkg_resources.require("diffkemp")[0].version,
+            "llvm_version": subprocess.check_output(
+                ["llvm-config", "--version"]).decode().rstrip().split(".")[0],
             "created_time": datetime.datetime.now(datetime.timezone.utc),
             "kind": "function_list" if self.fun_kind is None else
             "systcl_group_list",

--- a/tests/unit_tests/snapshot_test.py
+++ b/tests/unit_tests/snapshot_test.py
@@ -64,6 +64,7 @@ def test_load_snapshot_from_dir_functions():
             kind: kernel_with_builder
             path: null
           source_dir: /diffkemp/kernel/linux-3.10.0-957.el7
+          llvm_version: 13
         """)
 
         # Load the temporary snapshot configuration file.
@@ -126,6 +127,7 @@ def test_load_snapshot_from_dir_sysctls():
             kind: kernel_with_builder
             path: null
           source_dir: /diffkemp/kernel/linux-3.10.0-957.el7
+          llvm_version: 13
         """)
 
         # Load the temporary sysctl snapshot configuration file.
@@ -328,7 +330,7 @@ def test_to_yaml_functions():
 
     assert len(yaml_snap) == 1
     yaml_dict = yaml_snap[0]
-    assert len(yaml_dict) == 6
+    assert len(yaml_dict) == 7
     assert isinstance(yaml_dict["created_time"], datetime.datetime)
     assert yaml_dict["llvm_source_finder"]["kind"] == "kernel_with_builder"
     assert len(yaml_dict["list"]) == 2
@@ -374,7 +376,7 @@ def test_to_yaml_sysctls():
     yaml_snap = yaml.safe_load(yaml_str)
     assert len(yaml_snap) == 1
     yaml_dict = yaml_snap[0]
-    assert len(yaml_dict) == 6
+    assert len(yaml_dict) == 7
     assert yaml_dict["llvm_source_finder"]["kind"] == "kernel_with_builder"
     assert isinstance(yaml_dict["created_time"], datetime.datetime)
     assert len(yaml_dict["list"]) == 2


### PR DESCRIPTION
This PR resolves #199.

When running `diffkemp generate`, saves the current LLVM **major** version into the snapshot YAML file.
When running `diffkemp compare`, checks whether the major version in use now is the same as in both snapshots. If not, fails.

There is no need to check for minor version differences, as [minor versions are never released](http://blog.llvm.org/2016/12/llvms-new-versioning-scheme.html). Furthermore, different patch versions should be compatible, so they are not checked either.