### PR TITLE
WIP: Allow multiple builds using an environment variable

### DIFF
--- a/diffkemp/simpll/simpll.py
+++ b/diffkemp/simpll/simpll.py
@@ -113,10 +113,16 @@ def run_simpll(first, second, fun_first, fun_second, var, suffix=None,
         try:
             # Determine the SimpLL binary to use.
             # The manually built one has priority over the installed one.
-            if os.path.isfile("build/diffkemp/simpll/diffkemp-simpll"):
-                simpll_bin = "build/diffkemp/simpll/diffkemp-simpll"
+            # A custom build directory has priority over the default one.
+            build_dir_var = "SIMPLL_BUILD_DIR"
+            if build_dir_var in os.environ:
+                build_dir = os.environ[build_dir_var]
             else:
+                build_dir = "build"
+            simpll_bin = "{}/diffkemp/simpll/diffkemp-simpll".format(build_dir)
+            if not os.path.isfile(simpll_bin):
                 simpll_bin = "diffkemp-simpll"
+
             # SimpLL command
             simpll_command = list([simpll_bin, first, second,
                                    "--print-callstacks"])

--- a/diffkemp/simpll/simpll.py
+++ b/diffkemp/simpll/simpll.py
@@ -5,6 +5,7 @@ from diffkemp.llvm_ir.llvm_module import LlvmModule
 from diffkemp.semdiff.caching import ComparisonGraph
 from diffkemp.simpll._simpll import ffi, lib
 from diffkemp.simpll.library import SimpLLModule
+from diffkemp.simpll.simpll_build import get_simpll_build_dir
 import os
 from subprocess import check_call, check_output, CalledProcessError
 import yaml
@@ -113,13 +114,8 @@ def run_simpll(first, second, fun_first, fun_second, var, suffix=None,
         try:
             # Determine the SimpLL binary to use.
             # The manually built one has priority over the installed one.
-            # A custom build directory has priority over the default one.
-            build_dir_var = "SIMPLL_BUILD_DIR"
-            if build_dir_var in os.environ:
-                build_dir = os.environ[build_dir_var]
-            else:
-                build_dir = "build"
-            simpll_bin = "{}/diffkemp/simpll/diffkemp-simpll".format(build_dir)
+            simpll_bin = "{}/diffkemp/simpll/diffkemp-simpll".format(
+                get_simpll_build_dir())
             if not os.path.isfile(simpll_bin):
                 simpll_bin = "diffkemp-simpll"
 

--- a/diffkemp/simpll/simpll_build.py
+++ b/diffkemp/simpll/simpll_build.py
@@ -4,6 +4,13 @@ from cffi import FFI
 from subprocess import check_output
 
 
+def get_simpll_build_dir():
+    build_dir_var = "SIMPLL_BUILD_DIR"
+    if build_dir_var in os.environ:
+        return os.environ[build_dir_var]
+    return "build"
+
+
 def get_c_declarations(header_filename):
     """
     Extracts C declarations important for the cFFI module from the SimpLL FFI
@@ -37,12 +44,7 @@ llvm_ldflags = list(filter(lambda x: x != "",
 llvm_libs = list(filter(lambda x: x != "",
                         llvm_libs.decode("ascii").strip().split()))
 
-build_dir_var = "SIMPLL_BUILD_DIR"
-if build_dir_var in os.environ:
-    simpll_build_dir = os.environ[build_dir_var]
-else:
-    simpll_build_dir = "build"
-simpll_link_arg = "-L{}/diffkemp/simpll".format(simpll_build_dir)
+simpll_link_arg = "-L{}/diffkemp/simpll".format(get_simpll_build_dir())
 
 ffibuilder.set_source(
     "diffkemp.simpll._simpll", '#include <library/FFI.h>',

--- a/diffkemp/simpll/simpll_build.py
+++ b/diffkemp/simpll/simpll_build.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python3
+import os
 from cffi import FFI
 from subprocess import check_output
 
@@ -36,12 +37,19 @@ llvm_ldflags = list(filter(lambda x: x != "",
 llvm_libs = list(filter(lambda x: x != "",
                         llvm_libs.decode("ascii").strip().split()))
 
+build_dir_var = "SIMPLL_BUILD_DIR"
+if build_dir_var in os.environ:
+    simpll_build_dir = os.environ[build_dir_var]
+else:
+    simpll_build_dir = "build"
+simpll_link_arg = "-L{}/diffkemp/simpll".format(simpll_build_dir)
+
 ffibuilder.set_source(
     "diffkemp.simpll._simpll", '#include <library/FFI.h>',
     language="c++",
     libraries=['simpll-lib'],
     extra_compile_args=["-Idiffkemp/simpll"] + llvm_cflags,
-    extra_link_args=["-Lbuild/diffkemp/simpll", "-lstdc++"] + llvm_ldflags +
+    extra_link_args=[simpll_link_arg, "-lstdc++"] + llvm_ldflags +
     llvm_libs)
 
 if __name__ == "__main__":


### PR DESCRIPTION
We could support multiple builds using an environment variable similarly to e.g., [Flask](https://flask.palletsprojects.com/en/2.0.x/config/). The usage of a default build directory would remain the same, usage of a custom one would be as follows:
```bash
mkdir custom_build                       # assume that the custom build is in this directory
export SIMPLL_BUILD_DIR=custom_build     # set the environment variable
pip install -e .                         # install normally (but within the same environment)
bin/diffkemp                             # use diffkemp normally (still in the same environment)
```

After researching the possible options, this seems like the only viable way of allowing multiple builds.
Let me know if this is acceptable.

If accepted, this PR resolves #211.