### PR TITLE
Improve handling inverse condition branches

### DIFF
--- a/diffkemp/simpll/Utils.h
+++ b/diffkemp/simpll/Utils.h
@@ -89,6 +89,9 @@ bool isCast(const Value *Val);
 /// Returns true if the given instruction is a GEP with all indices equal to 0
 bool isZeroGEP(const Value *Val);
 
+/// Returns true if the given instruction is a boolean negation operation
+bool isLogicalNot(const Instruction *Inst);
+
 /// Run simplification passes on the function
 ///  - simplify CFG
 ///  - dead code elimination


### PR DESCRIPTION
Until now, the only supported situation related to inverse condition branches was when conditions had inverse operations
(e.g. `eq` and `ne`).

This PR covers a situation when one condition is a negation (using `xor`) of the other. Also handles a combination of the two approaches - conditions have inverse operations, then one of them is negated, and the final `br` instructions have the same successors order (i.e. not swapped).

Also adds unit tests for both supported cases.