### PR TITLE
Small improvement and refactoring of inlining

### DIFF
--- a/diffkemp/simpll/ModuleComparator.cpp
+++ b/diffkemp/simpll/ModuleComparator.cpp
@@ -126,6 +126,7 @@ void ModuleComparator::compareFunctions(Function *FirstFun,
                                << Color::makeRed(" ==========\n"););
         ComparedFuns.at({FirstFun, SecondFun}).kind = Result::NOT_EQUAL;
 
+        std::set<ConstFunPair> inlinedPairs;
         while (tryInline.first || tryInline.second) {
             DEBUG_WITH_TYPE(DEBUG_SIMPLL, increaseDebugIndentLevel());
 
@@ -149,6 +150,7 @@ void ModuleComparator::compareFunctions(Function *FirstFun,
                 DEBUG_WITH_TYPE(DEBUG_SIMPLL, decreaseDebugIndentLevel());
                 break;
             }
+            inlinedPairs.emplace(calledFirst, calledSecond);
 
             // Always simplify both functions even if inlining was done in one
             // of them only - this is to keep them synchronized.
@@ -181,6 +183,12 @@ void ModuleComparator::compareFunctions(Function *FirstFun,
 
             DEBUG_WITH_TYPE(DEBUG_SIMPLL, decreaseDebugIndentLevel());
             if (result == 0) {
+                // If the functions are equal after inlining, results for all
+                // inlined functions must be reset as they may pollute
+                // the overall output otherwise
+                for (auto &inlinedPair : inlinedPairs)
+                    ComparedFuns.erase(inlinedPair);
+
                 DEBUG_WITH_TYPE(DEBUG_SIMPLL,
                                 dbgs() << getDebugIndent() << "\""
                                        << FirstFun->getName() << "\" and \""

--- a/diffkemp/simpll/ModuleComparator.h
+++ b/diffkemp/simpll/ModuleComparator.h
@@ -83,6 +83,15 @@ class ModuleComparator {
     /// functions and needs to be inlined.
     std::pair<const CallInst *, const CallInst *> tryInline = {nullptr,
                                                                nullptr};
+
+  protected:
+    enum InliningResult {
+        NotInlined,
+        Inlined,
+        MissingDef,
+    };
+
+    InliningResult tryToInline(CallInst *InlinedCall, Program program) const;
 };
 
 #endif // DIFFKEMP_SIMPLL_MODULECOMPARATOR_H

--- a/diffkemp/simpll/Utils.cpp
+++ b/diffkemp/simpll/Utils.cpp
@@ -52,6 +52,10 @@ static std::vector<Attribute::AttrKind> badVoidAttributes = {
         Attribute::AttrKind::Dereferenceable,
         Attribute::AttrKind::DereferenceableOrNull};
 
+std::string programName(Program p) {
+    return p == Program::First ? "first" : "second";
+}
+
 /// Convert a value to a function.
 /// Handles situation when the actual function is inside a bitcast or alias.
 const Function *valueToFunction(const Value *Value) {
@@ -69,6 +73,8 @@ const Function *valueToFunction(const Value *Value) {
 /// Extract called function from a called value.
 /// Handles situation when the called value is a bitcast.
 const Function *getCalledFunction(const CallInst *Call) {
+    if (!Call)
+        return nullptr;
 #if LLVM_VERSION_MAJOR <= 7
     return valueToFunction(Call->getCalledValue());
 #else

--- a/diffkemp/simpll/Utils.h
+++ b/diffkemp/simpll/Utils.h
@@ -35,6 +35,9 @@ typedef SmallPtrSet<const Instruction *, 32> InstructionSet;
 /// Instruction to instruction mapping.
 typedef DenseMap<const Instruction *, const Instruction *> InstructionMap;
 
+/// Program to string
+std::string programName(Program p);
+
 /// Convert a value to a function.
 /// Handles situation then the actual function is inside a bitcast or alias.
 const Function *valueToFunction(const Value *Value);


### PR DESCRIPTION
There is a problem that if a pair of called functions is compared as non equal, but then they are inlined which makes the caller functions to be compared as equal, the non-equal result may pollute the overall output. This is solved by removing the inlined functions comparison verdict.

Also, there was a lot of repetition in the code handling function inlining, so it made sense to refactor it a bit.