### PR TITLE
Allow not saving path to source to the snapshot

### DIFF
--- a/diffkemp/diffkemp.py
+++ b/diffkemp/diffkemp.py
@@ -50,6 +50,10 @@ def __make_argument_parser():
     generate_ap.add_argument("--sysctl", action="store_true",
                              help="function list is a list of function "
                                   "parameters")
+    generate_ap.add_argument("--no-source-dir", action="store_true",
+                             help="do not store path to source directory in "
+                                  "snapshot")
+
     generate_ap.set_defaults(func=generate)
 
     # "compare" sub-command
@@ -138,7 +142,8 @@ def generate(args):
     snapshot = Snapshot.create_from_source(
         args.source_dir, args.output_dir,
         source_finder_cls, source_finder_path,
-        "sysctl" if args.sysctl else None)
+        "sysctl" if args.sysctl else None,
+        not args.no_source_dir)
     source = snapshot.source_tree
 
     # Build sources for symbols from the list into LLVM IR

--- a/tests/unit_tests/snapshot_test.py
+++ b/tests/unit_tests/snapshot_test.py
@@ -17,7 +17,7 @@ def test_create_snapshot_from_source():
     output_dir = "snapshots/linux-3.10.0-957.el7"
     snap = Snapshot.create_from_source(kernel_dir, output_dir,
                                        KernelLlvmSourceBuilder, None,
-                                       None, False)
+                                       None, True, False)
 
     assert snap.source_tree is not None
     assert kernel_dir in snap.source_tree.source_dir
@@ -29,7 +29,7 @@ def test_create_snapshot_from_source():
 
     snap = Snapshot.create_from_source(kernel_dir, output_dir,
                                        KernelLlvmSourceBuilder, None,
-                                       "sysctl", False)
+                                       "sysctl", True, False)
 
     assert snap.fun_kind == "sysctl"
     assert len(snap.fun_groups) == 0
@@ -164,7 +164,7 @@ def test_add_sysctl_fun_group():
     output_dir = "snapshots/linux-3.10.0-957.el7"
     snap = Snapshot.create_from_source(kernel_dir, output_dir,
                                        KernelLlvmSourceBuilder, None,
-                                       "sysctl", False)
+                                       "sysctl", True, False)
 
     snap.add_fun_group("kernel.sched_latency_ns")
 
@@ -178,7 +178,7 @@ def test_add_fun_none_group():
     output_dir = "snapshots/linux-3.10.0-957.el7"
     snap = Snapshot.create_from_source(kernel_dir, output_dir,
                                        KernelLlvmSourceBuilder, None,
-                                       None, False)
+                                       None, True, False)
 
     mod = LlvmModule("net/core/skbuff.ll")
     snap.add_fun("___pskb_trim", mod)
@@ -196,7 +196,7 @@ def test_add_fun_sysctl_group():
     output_dir = "snapshots/linux-3.10.0-957.el7"
     snap = Snapshot.create_from_source(kernel_dir, output_dir,
                                        KernelLlvmSourceBuilder, None,
-                                       "sysctl", False)
+                                       "sysctl", True, False)
 
     snap.add_fun_group("kernel.sched_latency_ns")
     mod = LlvmModule("kernel/sched/debug.ll")
@@ -225,7 +225,7 @@ def test_get_modules():
     output_dir = "snapshots/linux-3.10.0-957.el7"
     snap = Snapshot.create_from_source(kernel_dir, output_dir,
                                        KernelLlvmSourceBuilder, None,
-                                       "sysctl", False)
+                                       "sysctl", True, False)
 
     snap.add_fun_group("kernel.sched_latency_ns")
     snap.add_fun_group("kernel.timer_migration")
@@ -248,7 +248,7 @@ def test_get_by_name_functions():
     output_dir = "snapshots/linux-3.10.0-957.el7"
     snap = Snapshot.create_from_source(kernel_dir, output_dir,
                                        KernelLlvmSourceBuilder, None,
-                                       None, False)
+                                       None, True, False)
 
     mod_buff = LlvmModule("net/core/skbuff.ll")
     mod_alloc = LlvmModule("mm/page_alloc.ll")
@@ -267,7 +267,7 @@ def test_get_by_name_sysctls():
     output_dir = "snapshots/linux-3.10.0-957.el7"
     snap = Snapshot.create_from_source(kernel_dir, output_dir,
                                        KernelLlvmSourceBuilder, None,
-                                       "sysctl", False)
+                                       "sysctl", True, False)
 
     snap.add_fun_group("kernel.sched_latency_ns")
     snap.add_fun_group("kernel.timer_migration")
@@ -293,7 +293,7 @@ def test_filter():
     output_dir = "snapshots/linux-3.10.0-957.el7"
     snap = Snapshot.create_from_source(kernel_dir, output_dir,
                                        KernelLlvmSourceBuilder, None,
-                                       None, False)
+                                       None, True, False)
 
     snap.add_fun("___pskb_trim", LlvmModule("net/core/skbuff.ll"))
     snap.add_fun("__alloc_pages_nodemask",
@@ -318,7 +318,7 @@ def test_to_yaml_functions():
     output_dir = "snapshots/linux-3.10.0-957.el7"
     snap = Snapshot.create_from_source(kernel_dir, output_dir,
                                        KernelLlvmSourceBuilder, None,
-                                       None, False)
+                                       None, True, False)
 
     snap.add_fun("___pskb_trim", LlvmModule(
         "snapshots/linux-3.10.0-957.el7/net/core/skbuff.ll"))
@@ -358,7 +358,7 @@ def test_to_yaml_sysctls():
     output_dir = "snapshots-sysctl/linux-3.10.0-957.el7"
     snap = Snapshot.create_from_source(kernel_dir, output_dir,
                                        KernelLlvmSourceBuilder, None,
-                                       "sysctl", False)
+                                       "sysctl", True, False)
 
     snap.add_fun_group("kernel.sched_latency_ns")
     snap.add_fun_group("kernel.timer_migration")


### PR DESCRIPTION
In some cases, it makes sense to deliberately omit storing the path to source dir in snapshot. An example is when the path would be the same for both compared snapshots (e.g. when comparing different Git refs) where storing the path could lead to false negative errors. This also facilitates moving snapshots independently from sources.