### PR TITLE
Handle comparison of relocated code

### DIFF
--- a/diffkemp/simpll/DifferentialFunctionComparator.h
+++ b/diffkemp/simpll/DifferentialFunctionComparator.h
@@ -245,6 +245,13 @@ class DifferentialFunctionComparator : public FunctionComparator {
     /// 3. Look a macro-function difference.
     void processCallInstDifference(const CallInst *CL,
                                    const CallInst *CR) const;
+
+    /// Check if there is a dependency between the given instruction and the
+    /// currently stored relocation.
+    /// There is a dependency if both the instruction and the relocated code
+    /// (any instruction within it) access the same pointer and one of the
+    /// accesses is a store and the other one is a load.
+    bool isDependingOnReloc(const Instruction &Inst) const;
 };
 
 #endif // DIFFKEMP_SIMPLL_DIFFERENTIALFUNCTIONCOMPARATOR_H

--- a/diffkemp/simpll/ModuleComparator.h
+++ b/diffkemp/simpll/ModuleComparator.h
@@ -81,8 +81,7 @@ class ModuleComparator {
 
     /// Pointer to a function that is called just by one of the compared
     /// functions and needs to be inlined.
-    std::pair<const CallInst *, const CallInst *> tryInline = {nullptr,
-                                                               nullptr};
+    CallPair tryInline = {nullptr, nullptr};
 
   protected:
     enum InliningResult {

--- a/diffkemp/simpll/Utils.h
+++ b/diffkemp/simpll/Utils.h
@@ -29,6 +29,7 @@ enum Program { First, Second };
 typedef std::pair<Function *, Function *> FunPair;
 typedef std::pair<const Function *, const Function *> ConstFunPair;
 typedef std::pair<const GlobalValue *, const GlobalValue *> GlobalValuePair;
+typedef std::pair<const CallInst *, const CallInst *> CallPair;
 
 /// Instructions pointer set.
 typedef SmallPtrSet<const Instruction *, 32> InstructionSet;

--- a/diffkemp/simpll/llvm-lib/10/FunctionComparator.h
+++ b/diffkemp/simpll/llvm-lib/10/FunctionComparator.h
@@ -106,7 +106,7 @@ public:
 
 protected:
   /// Start the comparison.
-  void beginCompare() {
+  virtual void beginCompare() {
     sn_mapL.clear();
     sn_mapR.clear();
   }

--- a/diffkemp/simpll/llvm-lib/11/FunctionComparator.h
+++ b/diffkemp/simpll/llvm-lib/11/FunctionComparator.h
@@ -105,7 +105,7 @@ public:
 
 protected:
   /// Start the comparison.
-  void beginCompare() {
+  virtual void beginCompare() {
     sn_mapL.clear();
     sn_mapR.clear();
   }

--- a/diffkemp/simpll/llvm-lib/12/FunctionComparator.h
+++ b/diffkemp/simpll/llvm-lib/12/FunctionComparator.h
@@ -106,7 +106,7 @@ class FunctionComparator {
 
   protected:
   /// Start the comparison.
-  void beginCompare() {
+  virtual void beginCompare() {
     sn_mapL.clear();
     sn_mapR.clear();
   }

--- a/diffkemp/simpll/llvm-lib/13/FunctionComparator.h
+++ b/diffkemp/simpll/llvm-lib/13/FunctionComparator.h
@@ -106,7 +106,7 @@ class FunctionComparator {
 
   protected:
   /// Start the comparison.
-  void beginCompare() {
+  virtual void beginCompare() {
     sn_mapL.clear();
     sn_mapR.clear();
   }

--- a/diffkemp/simpll/llvm-lib/14/FunctionComparator.h
+++ b/diffkemp/simpll/llvm-lib/14/FunctionComparator.h
@@ -106,7 +106,7 @@ class FunctionComparator {
 
   protected:
   /// Start the comparison.
-  void beginCompare() {
+  virtual void beginCompare() {
     sn_mapL.clear();
     sn_mapR.clear();
   }

--- a/diffkemp/simpll/llvm-lib/5/FunctionComparator.h
+++ b/diffkemp/simpll/llvm-lib/5/FunctionComparator.h
@@ -90,7 +90,7 @@ public:
 
 protected:
   /// Start the comparison.
-  void beginCompare() {
+  virtual void beginCompare() {
     sn_mapL.clear();
     sn_mapR.clear();
   }

--- a/diffkemp/simpll/llvm-lib/6/FunctionComparator.h
+++ b/diffkemp/simpll/llvm-lib/6/FunctionComparator.h
@@ -107,7 +107,7 @@ public:
 
 protected:
   /// Start the comparison.
-  void beginCompare() {
+  virtual void beginCompare() {
     sn_mapL.clear();
     sn_mapR.clear();
   }

--- a/diffkemp/simpll/llvm-lib/7/FunctionComparator.h
+++ b/diffkemp/simpll/llvm-lib/7/FunctionComparator.h
@@ -107,7 +107,7 @@ public:
 
 protected:
   /// Start the comparison.
-  void beginCompare() {
+  virtual void beginCompare() {
     sn_mapL.clear();
     sn_mapR.clear();
   }

--- a/diffkemp/simpll/llvm-lib/8/FunctionComparator.h
+++ b/diffkemp/simpll/llvm-lib/8/FunctionComparator.h
@@ -107,7 +107,7 @@ public:
 
 protected:
   /// Start the comparison.
-  void beginCompare() {
+  virtual void beginCompare() {
     sn_mapL.clear();
     sn_mapR.clear();
   }

--- a/diffkemp/simpll/llvm-lib/9/FunctionComparator.h
+++ b/diffkemp/simpll/llvm-lib/9/FunctionComparator.h
@@ -106,7 +106,7 @@ public:
 
 protected:
   /// Start the comparison.
-  void beginCompare() {
+  virtual void beginCompare() {
     sn_mapL.clear();
     sn_mapR.clear();
   }


### PR DESCRIPTION
A common refactoring is when a piece of code is moved into another part of the function (e.g. from inside the loop before the loop head). This helps to compare such a change as semantically equal.

Handling code relocations is done in 3 phases, they roughly correspond to states of the new enum `RelocationInfo::Status`.
- Relocation detection is run when a difference is found and no relocation has been found so far (status is `None`). Detection is done by trying to "skip" a block of code in one of the basic blocks and match the remaining parts of the blocks. If it succeeds, the relocation is stored.
- Relocation matching is run when a difference is found and there is a previously found potential relocation (state is `Stored`). In such a case, we reset the current instruction iterator to the head of the stored relocation (in the appropriate program) and continue the comparison (state is changed to `Matching`). Once all relocation instructions were successfully compared, the state is reset to `None` and the last phase is run.
- Relocation checking checks if the relocated code has no dependency on the skipped code. Direct data dependencies are resolved by the SSA property of LLVM IR, so this only checks indirect dependencies through load/store instructions. This is simply done by checking if both the relocated and the skipped code access the same pointer and one of the accesses is a write. In such a case, the relocation is evaluated as not equal.

See commit messages for more implementation details.

Note that relocation detection must be run after all other approaches to show equality (including custom pattern matching) are tried.
