### PR TITLE
Kernel builds: suppress all warnings

### DIFF
--- a/diffkemp/llvm_ir/kernel_llvm_source_builder.py
+++ b/diffkemp/llvm_ir/kernel_llvm_source_builder.py
@@ -490,8 +490,7 @@ class KernelLlvmSourceBuilder(LlvmSourceFinder):
             try:
                 output = check_output(
                     ["make", "V=1",
-                     "CFLAGS=-Wno-error=restrict -Wno-error=attributes",
-                     "EXTRA_CFLAGS=-Wno-error=restrict -Wno-error=attributes",
+                     "CFLAGS=-w", "EXTRA_CFLAGS=-w",
                      object_file,
                      "--just-print"], stderr=stderr).decode("utf-8")
             except CalledProcessError:


### PR DESCRIPTION
Kernel has `-Werror` on by default, which causes LLVM IR build to fail when, e.g., building older kernels with newer GCC. Using `-w` suppresses all warnings and eliminates this issue.