### PR TITLE
Split generate into multiple sub-commands

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,7 +5,7 @@ __pycache__/
 
 # Build files
 .Python
-build/
+build*/
 tests/unit_tests/simpll/runTests
 diffkemp/simpll/_simpll.c
 

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ kernels are installed.
 
 First, generate snapshots for each kernel version that you need to compare:
 
-    bin/diffkemp generate KERNEL_DIR SNAPSHOT_DIR FUNCTION_LIST --kernel-with-builder
+    bin/diffkemp build-kernel KERNEL_DIR SNAPSHOT_DIR FUNCTION_LIST
 
 The command creates a DiffKemp snapshot for semantic diff of functions from
 `FUNCTION_LIST` for the kernel located in `KERNEL_DIR`. The snapshot is stored
@@ -72,9 +72,9 @@ variables), they will be ignored.
 
 Apart from comparing specific functions, DiffKemp supports comparison of
 semantics of sysctl options. List of the options to compare can be passed as the
-`FUNCTION_LIST` in the `generate` command. In such case, use `--sysctl` switch
-to generate snapshot for sysctl parameter comparison. The `compare` command is
-used in normal way.
+`FUNCTION_LIST` in the `build-kernel` command. In such case, use `--sysctl`
+switch to generate snapshot for sysctl parameter comparison. The `compare`
+command is used in normal way.
 
 Sysctl option comparison compares semantics of the proc handler function and
 semantics of all functions using the data variable that the sysctl option sets.
@@ -93,12 +93,18 @@ of a chosen kernel function or option (module parameter, sysctl) changed between
 two different kernel versions.
 
 The analysis is composed of multiple steps:
-* Generate:
+* Generate snapshot:
     * The source files containing definitions of the compared functions are
       compiled into the LLVM internal representation (LLVM IR).
     * The snapshot is created by copying the compiled LLVM IR files into the
       snapshot directory and by creating a YAML file with the list of functions
       to be compared.
+    * Currently, there are 2 ways for generating snapshots corresponding to the
+      2 supported types of projects:
+      * the Linux kernel (the snapshots are generated using the `build-kernel`
+        command) and
+      * projects that can be entirely built into a single LLVM IR file (the
+        snapshots are generated using the `llvm-to-snapshot` command).
 * Compare:
     * The **SimpLL** component is used to compare the programs for semantic
       equality. The list of functions that are compared as not equal are

--- a/diffkemp/cli.py
+++ b/diffkemp/cli.py
@@ -1,0 +1,98 @@
+from argparse import ArgumentParser, SUPPRESS
+import diffkemp.diffkemp
+
+
+def make_argument_parser():
+    """Parsing CLI arguments."""
+    ap = ArgumentParser(description="Checking equivalence of semantics of "
+                                    "functions in large C projects.")
+    ap.add_argument("-v", "--verbose",
+                    help="increase output verbosity",
+                    action="count", default=0)
+    sub_ap = ap.add_subparsers(dest="command", metavar="command")
+    sub_ap.required = True
+
+    # "generate" sub-command
+    generate_ap = sub_ap.add_parser(
+        "generate",
+        help="generate snapshot from Linux kernel")
+    generate_ap.add_argument("source_dir",
+                             help="kernel's root directory")
+    generate_ap.add_argument("output_dir",
+                             help="output directory of the snapshot")
+    generate_ap.add_argument("functions_list",
+                             help="list of functions to compare")
+
+    source_kind = generate_ap.add_mutually_exclusive_group(required=True)
+    source_kind.add_argument(
+        "--kernel-with-builder", action="store_true",
+        help="source is the Linux kernel not pre-built into LLVM IR")
+    source_kind.add_argument(
+        "--single-llvm-file", metavar="FILE",
+        help="source project is built into a single LLVM IR file")
+
+    generate_ap.add_argument(
+        "--sysctl",
+        action="store_true",
+        help="function list is a list of sysctl parameters")
+    generate_ap.add_argument(
+        "--no-source-dir",
+        action="store_true",
+        help="do not store path to the source kernel directory in snapshot")
+
+    generate_ap.set_defaults(func=diffkemp.diffkemp.generate)
+
+    # "compare" sub-command
+    compare_ap = sub_ap.add_parser("compare",
+                                   help="compare generated snapshots for "
+                                        "semantic equality")
+    compare_ap.add_argument("snapshot_dir_old",
+                            help="directory with the old snapshot")
+    compare_ap.add_argument("snapshot_dir_new",
+                            help="directory with the new snapshot")
+    compare_ap.add_argument("--show-diff",
+                            help="show diff for non-equal functions",
+                            action="store_true")
+    compare_ap.add_argument("--regex-filter",
+                            help="filter function diffs by given regex")
+    compare_ap.add_argument("--output-dir", "-o",
+                            help="name of the output directory")
+    compare_ap.add_argument("--stdout", help="print results to stdout",
+                            action="store_true")
+    compare_ap.add_argument("--report-stat",
+                            help="report statistics of the analysis",
+                            action="store_true")
+    compare_ap.add_argument("--source-dirs",
+                            nargs=2,
+                            help="specify root dirs for the compared projects")
+    compare_ap.add_argument("--function", "-f",
+                            help="compare only selected function")
+    compare_ap.add_argument("--patterns", "-p",
+                            help="difference pattern file or configuration")
+    compare_ap.add_argument("--output-llvm-ir",
+                            help="output each simplified module to a file",
+                            action="store_true")
+    compare_ap.add_argument("--control-flow-only",
+                            help=SUPPRESS,
+                            action="store_true")
+    compare_ap.add_argument("--print-asm-diffs",
+                            help="print raw inline assembly differences (does \
+                            not apply to macros)",
+                            action="store_true")
+    compare_ap.add_argument("--semdiff-tool",
+                            help=SUPPRESS,
+                            choices=["llreve"])
+    compare_ap.add_argument("--show-errors",
+                            help="show functions that are either unknown or \
+                            ended with an error in statistics",
+                            action="store_true")
+    compare_ap.add_argument("--enable-simpll-ffi",
+                            help="calls SimpLL through FFI",
+                            action="store_true")
+    compare_ap.add_argument("--enable-module-cache",
+                            help="loads frequently used modules to memory and \
+                            uses them in SimpLL (requires SimpLL FFI to be \
+                            enabled)",
+                            action="store_true")
+    compare_ap.set_defaults(func=diffkemp.diffkemp.compare)
+    return ap

--- a/diffkemp/cli.py
+++ b/diffkemp/cli.py
@@ -12,35 +12,38 @@ def make_argument_parser():
     sub_ap = ap.add_subparsers(dest="command", metavar="command")
     sub_ap.required = True
 
-    # "generate" sub-command
-    generate_ap = sub_ap.add_parser(
-        "generate",
+    # "build-kernel" sub-command
+    build_kernel_ap = sub_ap.add_parser(
+        "build-kernel",
         help="generate snapshot from Linux kernel")
-    generate_ap.add_argument("source_dir",
-                             help="kernel's root directory")
-    generate_ap.add_argument("output_dir",
-                             help="output directory of the snapshot")
-    generate_ap.add_argument("functions_list",
-                             help="list of functions to compare")
-
-    source_kind = generate_ap.add_mutually_exclusive_group(required=True)
-    source_kind.add_argument(
-        "--kernel-with-builder", action="store_true",
-        help="source is the Linux kernel not pre-built into LLVM IR")
-    source_kind.add_argument(
-        "--single-llvm-file", metavar="FILE",
-        help="source project is built into a single LLVM IR file")
-
-    generate_ap.add_argument(
+    build_kernel_ap.add_argument("source_dir",
+                                 help="kernel's root directory")
+    build_kernel_ap.add_argument("output_dir",
+                                 help="output directory of the snapshot")
+    build_kernel_ap.add_argument("symbol_list",
+                                 help="list of symbols (functions) to compare")
+    build_kernel_ap.add_argument(
         "--sysctl",
         action="store_true",
-        help="function list is a list of sysctl parameters")
-    generate_ap.add_argument(
+        help="interpret symbol list as a list of sysctl parameters")
+    build_kernel_ap.add_argument(
         "--no-source-dir",
         action="store_true",
         help="do not store path to the source kernel directory in snapshot")
+    build_kernel_ap.set_defaults(func=diffkemp.diffkemp.build_kernel)
 
-    generate_ap.set_defaults(func=diffkemp.diffkemp.generate)
+    # "llvm-to-snapshot" sub-command
+    llvm_snapshot_ap = sub_ap.add_parser(
+        "llvm-to-snapshot",
+        help="generate snapshot from a single LLVM IR file")
+    llvm_snapshot_ap.add_argument("source_dir",
+                                  help="project's root directory")
+    llvm_snapshot_ap.add_argument("llvm_file", help="name of the LLVM IR file")
+    llvm_snapshot_ap.add_argument("output_dir",
+                                  help="output directory of the snapshot")
+    llvm_snapshot_ap.add_argument("function_list",
+                                  help="list of functions to compare")
+    llvm_snapshot_ap.set_defaults(func=diffkemp.diffkemp.llvm_to_snapshot)
 
     # "compare" sub-command
     compare_ap = sub_ap.add_parser("compare",

--- a/diffkemp/diffkemp.py
+++ b/diffkemp/diffkemp.py
@@ -1,4 +1,4 @@
-from argparse import ArgumentParser, SUPPRESS
+from diffkemp.cli import make_argument_parser
 from diffkemp.config import Config
 from diffkemp.snapshot import Snapshot
 from diffkemp.llvm_ir.kernel_source_tree import KernelSourceTree
@@ -19,103 +19,9 @@ import sys
 import subprocess
 
 
-def __make_argument_parser():
-    """Parsing CLI arguments."""
-    ap = ArgumentParser(description="Checking equivalence of semantics of "
-                                    "functions in large C projects.")
-    ap.add_argument("-v", "--verbose",
-                    help="increase output verbosity",
-                    action="count", default=0)
-    sub_ap = ap.add_subparsers(dest="command", metavar="command")
-    sub_ap.required = True
-
-    # "generate" sub-command
-    generate_ap = sub_ap.add_parser("generate",
-                                    help="generate snapshot of compared "
-                                         "functions")
-    generate_ap.add_argument("source_dir",
-                             help="project's root directory")
-    generate_ap.add_argument("output_dir",
-                             help="output directory of the snapshot")
-    generate_ap.add_argument("functions_list",
-                             help="list of functions to compare")
-
-    source_kind = generate_ap.add_mutually_exclusive_group(required=True)
-    source_kind.add_argument(
-        "--kernel-with-builder", action="store_true",
-        help="source is the Linux kernel not pre-built into LLVM IR")
-    source_kind.add_argument(
-        "--single-llvm-file", metavar="FILE",
-        help="source project is built into a single LLVM IR file")
-
-    generate_ap.add_argument("--sysctl", action="store_true",
-                             help="function list is a list of function "
-                                  "parameters")
-    generate_ap.add_argument("--no-source-dir", action="store_true",
-                             help="do not store path to source directory in "
-                                  "snapshot")
-
-    generate_ap.set_defaults(func=generate)
-
-    # "compare" sub-command
-    compare_ap = sub_ap.add_parser("compare",
-                                   help="compare generated snapshots for "
-                                        "semantic equality")
-    compare_ap.add_argument("snapshot_dir_old",
-                            help="directory with the old snapshot")
-    compare_ap.add_argument("snapshot_dir_new",
-                            help="directory with the new snapshot")
-    compare_ap.add_argument("--show-diff",
-                            help="show diff for non-equal functions",
-                            action="store_true")
-    compare_ap.add_argument("--regex-filter",
-                            help="filter function diffs by given regex")
-    compare_ap.add_argument("--output-dir", "-o",
-                            help="name of the output directory")
-    compare_ap.add_argument("--stdout", help="print results to stdout",
-                            action="store_true")
-    compare_ap.add_argument("--report-stat",
-                            help="report statistics of the analysis",
-                            action="store_true")
-    compare_ap.add_argument("--source-dirs",
-                            nargs=2,
-                            help="specify root dirs for the compared projects")
-    compare_ap.add_argument("--function", "-f",
-                            help="compare only selected function")
-    compare_ap.add_argument("--patterns", "-p",
-                            help="difference pattern file or configuration")
-    compare_ap.add_argument("--output-llvm-ir",
-                            help="output each simplified module to a file",
-                            action="store_true")
-    compare_ap.add_argument("--control-flow-only",
-                            help=SUPPRESS,
-                            action="store_true")
-    compare_ap.add_argument("--print-asm-diffs",
-                            help="print raw inline assembly differences (does \
-                            not apply to macros)",
-                            action="store_true")
-    compare_ap.add_argument("--semdiff-tool",
-                            help=SUPPRESS,
-                            choices=["llreve"])
-    compare_ap.add_argument("--show-errors",
-                            help="show functions that are either unknown or \
-                            ended with an error in statistics",
-                            action="store_true")
-    compare_ap.add_argument("--enable-simpll-ffi",
-                            help="calls SimpLL through FFI",
-                            action="store_true")
-    compare_ap.add_argument("--enable-module-cache",
-                            help="loads frequently used modules to memory and \
-                            uses them in SimpLL (requires SimpLL FFI to be \
-                            enabled)",
-                            action="store_true")
-    compare_ap.set_defaults(func=compare)
-    return ap
-
-
 def run_from_cli():
     """Main method to run the tool."""
-    ap = __make_argument_parser()
+    ap = make_argument_parser()
     args = ap.parse_args()
     args.func(args)
 

--- a/diffkemp/diffkemp.py
+++ b/diffkemp/diffkemp.py
@@ -140,10 +140,15 @@ def generate(args):
                                          args.single_llvm_file)
         source = SourceTree(args.source_dir, source_finder)
 
+    if args.sysctl:
+        list_kind = "sysctl"
+    else:
+        list_kind = "function"
+
     # Create a new snapshot from the source directory.
     snapshot = Snapshot.create_from_source(source,
                                            args.output_dir,
-                                           "sysctl" if args.sysctl else None,
+                                           list_kind,
                                            not args.no_source_dir)
 
     # Build sources for symbols from the list into LLVM IR
@@ -174,8 +179,6 @@ def generate(args):
                     print("{}: no sysctl found".format(symbol))
                 for sysctl in sysctl_list:
                     print("{}:".format(sysctl))
-                    # New group in function list for the sysctl
-                    snapshot.add_fun_group(sysctl)
 
                     # Proc handler function for sysctl
                     proc_fun = sysctl_mod.get_proc_fun(sysctl)

--- a/diffkemp/llvm_ir/kernel_llvm_source_builder.py
+++ b/diffkemp/llvm_ir/kernel_llvm_source_builder.py
@@ -19,8 +19,8 @@ class KernelLlvmSourceBuilder(LlvmSourceFinder):
     it into LLVM IR.
     Extends the SourceFinder abstract class.
     """
-    def __init__(self, source_dir, path=None):
-        LlvmSourceFinder.__init__(self, source_dir, None)
+    def __init__(self, source_dir):
+        LlvmSourceFinder.__init__(self, source_dir)
         self.cscope_cache = dict()
         # Compiler headers (containing 'asm goto' constructions)
         self.compiler_headers = [os.path.join(self.source_dir, h) for h in
@@ -37,6 +37,9 @@ class KernelLlvmSourceBuilder(LlvmSourceFinder):
 
     def str(self):
         return "kernel_with_builder"
+
+    def clone_to_dir(self, new_source_dir):
+        return KernelLlvmSourceBuilder(new_source_dir)
 
     def initialize(self):
         """

--- a/diffkemp/llvm_ir/kernel_source_tree.py
+++ b/diffkemp/llvm_ir/kernel_source_tree.py
@@ -13,10 +13,8 @@ class KernelSourceTree(SourceTree):
     by implementing methods to get LLVM modules containing definitions of
     sysctl options or kernel modules.
     """
-    def __init__(self, source_dir, source_finder_cls=None,
-                 source_finder_path=None):
-        SourceTree.__init__(self, source_dir, source_finder_cls,
-                            source_finder_path)
+    def __init__(self, source_dir, source_finder):
+        SourceTree.__init__(self, source_dir, source_finder)
 
     def get_sysctl_module(self, sysctl):
         """

--- a/diffkemp/llvm_ir/llvm_source_finder.py
+++ b/diffkemp/llvm_ir/llvm_source_finder.py
@@ -18,12 +18,8 @@ class LlvmSourceFinder(ABC):
     Abstract class for finding LLVM files in a source tree.
     Defines methods that each LLVM source finder must implement.
     """
-    def __init__(self, source_dir, path):
+    def __init__(self, source_dir):
         self.source_dir = os.path.abspath(source_dir)
-        if path is not None:
-            self.path = os.path.relpath(path, source_dir)
-        else:
-            self.path = None
 
     @abstractmethod
     def str(self):
@@ -37,6 +33,11 @@ class LlvmSourceFinder(ABC):
     @abstractmethod
     def finalize(self):
         """Finalize the source finder."""
+        pass
+
+    @abstractmethod
+    def clone_to_dir(self, new_source_dir):
+        """Create a copy of this finder with a different source directory"""
         pass
 
     @abstractmethod

--- a/diffkemp/llvm_ir/single_llvm_finder.py
+++ b/diffkemp/llvm_ir/single_llvm_finder.py
@@ -3,6 +3,7 @@ LLVM source finder for projects that are entirely compiled into a single
 LLVM IR file.
 """
 from diffkemp.llvm_ir.llvm_source_finder import LlvmSourceFinder
+import os
 
 
 class SingleLlvmFinder(LlvmSourceFinder):
@@ -11,11 +12,15 @@ class SingleLlvmFinder(LlvmSourceFinder):
     LLVM IR file.
     Extends the LlvmSourceFinder class by always returning the single IR file.
     """
-    def __init__(self, source_dir, llvm_file):
-        LlvmSourceFinder.__init__(self, source_dir, llvm_file)
+    def __init__(self, source_dir, llvm_file_name):
+        LlvmSourceFinder.__init__(self, source_dir)
+        self.llvm_file_name = llvm_file_name
 
     def str(self):
         return "single_llvm_file"
+
+    def clone_to_dir(self, new_source_dir):
+        return SingleLlvmFinder(new_source_dir, self.llvm_file_name)
 
     def initialize(self):
         pass
@@ -24,7 +29,7 @@ class SingleLlvmFinder(LlvmSourceFinder):
         pass
 
     def find_llvm_with_symbol_def(self, symbol):
-        return self.path
+        return os.path.join(self.source_dir, self.llvm_file_name)
 
     def find_llvm_with_symbol_use(self, symbol):
-        return self.path
+        return os.path.join(self.source_dir, self.llvm_file_name)

--- a/diffkemp/llvm_ir/source_tree.py
+++ b/diffkemp/llvm_ir/source_tree.py
@@ -14,12 +14,9 @@ class SourceTree:
     Contains functions for getting LLVM modules from the project.
     Requires a source finder that extends the LlvmSourceFinder abstract class.
     """
-    def __init__(self, source_dir, source_finder_cls=None,
-                 source_finder_path=None):
+    def __init__(self, source_dir, source_finder=None):
         self.source_dir = os.path.abspath(source_dir)
-        self.source_finder = None
-        if source_finder_cls is not None:
-            self.create_source_finder(source_finder_cls, source_finder_path)
+        self.source_finder = source_finder
         self.modules = dict()
 
     def initialize(self):
@@ -30,8 +27,11 @@ class SourceTree:
         if self.source_finder is not None:
             self.source_finder.finalize()
 
-    def create_source_finder(self, finder_cls, path):
-        self.source_finder = finder_cls(self.source_dir, path)
+    def clone_to_dir(self, new_source_dir):
+        new_source_finder = None
+        if self.source_finder is not None:
+            new_source_finder = self.source_finder.clone_to_dir(new_source_dir)
+        return SourceTree(new_source_dir, new_source_finder)
 
     def _make_abs_path(self, file):
         if not os.path.isabs(file):

--- a/tests/regression/task_spec.py
+++ b/tests/regression/task_spec.py
@@ -56,10 +56,10 @@ class TaskSpec:
             self.control_flow_only = False
 
         # Create LLVM sources and configuration
-        self.old_kernel = KernelSourceTree(self.old_kernel_dir,
-                                           KernelLlvmSourceBuilder)
-        self.new_kernel = KernelSourceTree(self.new_kernel_dir,
-                                           KernelLlvmSourceBuilder)
+        self.old_kernel = KernelSourceTree(
+            self.old_kernel_dir, KernelLlvmSourceBuilder(self.old_kernel_dir))
+        self.new_kernel = KernelSourceTree(
+            self.new_kernel_dir, KernelLlvmSourceBuilder(self.new_kernel_dir))
         self.old_snapshot = Snapshot(self.old_kernel, self.old_kernel)
         self.new_snapshot = Snapshot(self.new_kernel, self.new_kernel)
         self.config = Config(self.old_snapshot, self.new_snapshot, False,

--- a/tests/unit_tests/function_syntax_diff_test.py
+++ b/tests/unit_tests/function_syntax_diff_test.py
@@ -17,10 +17,10 @@ def test_syntax_diff():
             '\tif (dio->end_io)\n! \t\tdio->end_io(dio->iocb, offset, ret, dio'
             '->private, 0, 0);\n  \n')
 
-    source_first = SourceTree("kernel/linux-3.10.0-862.el7",
-                              KernelLlvmSourceBuilder)
-    source_second = SourceTree("kernel/linux-3.10.0-957.el7",
-                               KernelLlvmSourceBuilder)
+    kernel_old = "kernel/linux-3.10.0-862.el7"
+    kernel_new = "kernel/linux-3.10.0-957.el7"
+    source_first = SourceTree(kernel_old, KernelLlvmSourceBuilder(kernel_old))
+    source_second = SourceTree(kernel_new, KernelLlvmSourceBuilder(kernel_new))
     config = Config(source_first, source_second, show_diff=True,
                     output_llvm_ir=False, pattern_config=None,
                     control_flow_only=True, print_asm_diffs=False,

--- a/tests/unit_tests/kernel_module_test.py
+++ b/tests/unit_tests/kernel_module_test.py
@@ -15,7 +15,8 @@ import tempfile
 @pytest.fixture
 def source():
     """Create KernelSource shared among multiple tests."""
-    s = SourceTree("kernel/linux-3.10.0-957.el7", KernelLlvmSourceBuilder)
+    kernel_dir = "kernel/linux-3.10.0-957.el7"
+    s = SourceTree(kernel_dir, KernelLlvmSourceBuilder(kernel_dir))
     yield s
     s.finalize()
 
@@ -68,7 +69,8 @@ def test_find_param_var():
     This is necessary since for parameters defined with module_param_named,
     names of the parameter and of the variable differ.
     """
-    source = SourceTree("kernel/linux-3.10", KernelLlvmSourceBuilder)
+    kernel_dir = "kernel/linux-3.10"
+    source = SourceTree(kernel_dir, KernelLlvmSourceBuilder(kernel_dir))
     mod = source.get_module_for_symbol("rfkill_init")
     assert mod.find_param_var("default_state").name == "rfkill_default_state"
 

--- a/tests/unit_tests/kernel_source_tree_test.py
+++ b/tests/unit_tests/kernel_source_tree_test.py
@@ -10,8 +10,8 @@ import pytest
 
 @pytest.fixture
 def source():
-    s = KernelSourceTree("kernel/linux-3.10.0-957.el7",
-                         KernelLlvmSourceBuilder)
+    kernel_dir = "kernel/linux-3.10.0-957.el7"
+    s = KernelSourceTree(kernel_dir, KernelLlvmSourceBuilder(kernel_dir))
     yield s
     s.finalize()
 

--- a/tests/unit_tests/llvm_sysctl_module_test.py
+++ b/tests/unit_tests/llvm_sysctl_module_test.py
@@ -11,8 +11,8 @@ def mod():
     """
     Build LlvmSysctlModule for net.core.* sysctl options shared among tests.
     """
-    source = KernelSourceTree("kernel/linux-3.10.0-957.el7",
-                              KernelLlvmSourceBuilder)
+    kernel_dir = "kernel/linux-3.10.0-957.el7"
+    source = KernelSourceTree(kernel_dir, KernelLlvmSourceBuilder(kernel_dir))
     kernel_module = source.get_module_for_symbol("net_core_table")
     yield LlvmSysctlModule(kernel_module, "net_core_table")
     source.finalize()
@@ -39,8 +39,8 @@ def test_get_data(mod):
 
 def test_get_child():
     """Test getting child of a sysctl definition."""
-    source = KernelSourceTree("kernel/linux-3.10.0-957.el7",
-                              KernelLlvmSourceBuilder)
+    kernel_dir = "kernel/linux-3.10.0-957.el7"
+    source = KernelSourceTree(kernel_dir, KernelLlvmSourceBuilder(kernel_dir))
     kernel_module = source.get_module_for_symbol("sysctl_base_table")
     sysctl_module = LlvmSysctlModule(kernel_module, "sysctl_base_table")
     assert sysctl_module.get_child("vm").name == "vm_table"

--- a/tests/unit_tests/snapshot_test.py
+++ b/tests/unit_tests/snapshot_test.py
@@ -15,9 +15,8 @@ def test_create_snapshot_from_source():
     """Create a new kernel directory snapshot."""
     kernel_dir = "kernel/linux-3.10.0-957.el7"
     output_dir = "snapshots/linux-3.10.0-957.el7"
-    snap = Snapshot.create_from_source(kernel_dir, output_dir,
-                                       KernelLlvmSourceBuilder, None,
-                                       None, True, False)
+    source = SourceTree(kernel_dir, KernelLlvmSourceBuilder(kernel_dir))
+    snap = Snapshot.create_from_source(source, output_dir, None, True, False)
 
     assert snap.source_tree is not None
     assert kernel_dir in snap.source_tree.source_dir
@@ -27,9 +26,8 @@ def test_create_snapshot_from_source():
     assert len(snap.fun_groups) == 1
     assert len(snap.fun_groups[None].functions) == 0
 
-    snap = Snapshot.create_from_source(kernel_dir, output_dir,
-                                       KernelLlvmSourceBuilder, None,
-                                       "sysctl", True, False)
+    snap = Snapshot.create_from_source(
+        source, output_dir, "sysctl", True, False)
 
     assert snap.fun_kind == "sysctl"
     assert len(snap.fun_groups) == 0
@@ -162,8 +160,8 @@ def test_add_sysctl_fun_group():
 
     kernel_dir = "kernel/linux-3.10.0-957.el7"
     output_dir = "snapshots/linux-3.10.0-957.el7"
-    snap = Snapshot.create_from_source(kernel_dir, output_dir,
-                                       KernelLlvmSourceBuilder, None,
+    source = SourceTree(kernel_dir, KernelLlvmSourceBuilder(kernel_dir))
+    snap = Snapshot.create_from_source(source, output_dir,
                                        "sysctl", True, False)
 
     snap.add_fun_group("kernel.sched_latency_ns")
@@ -176,8 +174,8 @@ def test_add_fun_none_group():
     """Create a snapshot and try to add functions into a None group."""
     kernel_dir = "kernel/linux-3.10.0-957.el7"
     output_dir = "snapshots/linux-3.10.0-957.el7"
-    snap = Snapshot.create_from_source(kernel_dir, output_dir,
-                                       KernelLlvmSourceBuilder, None,
+    source = SourceTree(kernel_dir, KernelLlvmSourceBuilder(kernel_dir))
+    snap = Snapshot.create_from_source(source, output_dir,
                                        None, True, False)
 
     mod = LlvmModule("net/core/skbuff.ll")
@@ -194,8 +192,8 @@ def test_add_fun_sysctl_group():
     """Create a snapshot and try to add functions into sysctl groups."""
     kernel_dir = "kernel/linux-3.10.0-957.el7"
     output_dir = "snapshots/linux-3.10.0-957.el7"
-    snap = Snapshot.create_from_source(kernel_dir, output_dir,
-                                       KernelLlvmSourceBuilder, None,
+    source = SourceTree(kernel_dir, KernelLlvmSourceBuilder(kernel_dir))
+    snap = Snapshot.create_from_source(source, output_dir,
                                        "sysctl", True, False)
 
     snap.add_fun_group("kernel.sched_latency_ns")
@@ -223,8 +221,8 @@ def test_get_modules():
     """
     kernel_dir = "kernel/linux-3.10.0-957.el7"
     output_dir = "snapshots/linux-3.10.0-957.el7"
-    snap = Snapshot.create_from_source(kernel_dir, output_dir,
-                                       KernelLlvmSourceBuilder, None,
+    source = SourceTree(kernel_dir, KernelLlvmSourceBuilder(kernel_dir))
+    snap = Snapshot.create_from_source(source, output_dir,
                                        "sysctl", True, False)
 
     snap.add_fun_group("kernel.sched_latency_ns")
@@ -246,8 +244,8 @@ def test_get_by_name_functions():
     """Get the module of inserted function by its name."""
     kernel_dir = "kernel/linux-3.10.0-957.el7"
     output_dir = "snapshots/linux-3.10.0-957.el7"
-    snap = Snapshot.create_from_source(kernel_dir, output_dir,
-                                       KernelLlvmSourceBuilder, None,
+    source = SourceTree(kernel_dir, KernelLlvmSourceBuilder(kernel_dir))
+    snap = Snapshot.create_from_source(source, output_dir,
                                        None, True, False)
 
     mod_buff = LlvmModule("net/core/skbuff.ll")
@@ -265,8 +263,8 @@ def test_get_by_name_sysctls():
     """Get the module of inserted function by its name and sysctl group."""
     kernel_dir = "kernel/linux-3.10.0-957.el7"
     output_dir = "snapshots/linux-3.10.0-957.el7"
-    snap = Snapshot.create_from_source(kernel_dir, output_dir,
-                                       KernelLlvmSourceBuilder, None,
+    source = SourceTree(kernel_dir, KernelLlvmSourceBuilder(kernel_dir))
+    snap = Snapshot.create_from_source(source, output_dir,
                                        "sysctl", True, False)
 
     snap.add_fun_group("kernel.sched_latency_ns")
@@ -291,8 +289,8 @@ def test_filter():
     """Filter snapshot functions."""
     kernel_dir = "kernel/linux-3.10.0-957.el7"
     output_dir = "snapshots/linux-3.10.0-957.el7"
-    snap = Snapshot.create_from_source(kernel_dir, output_dir,
-                                       KernelLlvmSourceBuilder, None,
+    source = SourceTree(kernel_dir, KernelLlvmSourceBuilder(kernel_dir))
+    snap = Snapshot.create_from_source(source, output_dir,
                                        None, True, False)
 
     snap.add_fun("___pskb_trim", LlvmModule("net/core/skbuff.ll"))
@@ -316,8 +314,8 @@ def test_to_yaml_functions():
     """
     kernel_dir = "kernel/linux-3.10.0-957.el7"
     output_dir = "snapshots/linux-3.10.0-957.el7"
-    snap = Snapshot.create_from_source(kernel_dir, output_dir,
-                                       KernelLlvmSourceBuilder, None,
+    source = SourceTree(kernel_dir, KernelLlvmSourceBuilder(kernel_dir))
+    snap = Snapshot.create_from_source(source, output_dir,
                                        None, True, False)
 
     snap.add_fun("___pskb_trim", LlvmModule(
@@ -356,8 +354,8 @@ def test_to_yaml_sysctls():
     """
     kernel_dir = "kernel/linux-3.10.0-957.el7"
     output_dir = "snapshots-sysctl/linux-3.10.0-957.el7"
-    snap = Snapshot.create_from_source(kernel_dir, output_dir,
-                                       KernelLlvmSourceBuilder, None,
+    source = SourceTree(kernel_dir, KernelLlvmSourceBuilder(kernel_dir))
+    snap = Snapshot.create_from_source(source, output_dir,
                                        "sysctl", True, False)
 
     snap.add_fun_group("kernel.sched_latency_ns")

--- a/tests/unit_tests/source_tree_test.py
+++ b/tests/unit_tests/source_tree_test.py
@@ -18,7 +18,8 @@ import tempfile
 def source():
     # If a new class extending LlvmSourceFinder is implemented, it should be
     # added here for testing that it provides correct LLVM IR files.
-    s = SourceTree("kernel/linux-3.10.0-957.el7", KernelLlvmSourceBuilder)
+    kernel_dir = "kernel/linux-3.10.0-957.el7"
+    s = SourceTree(kernel_dir, KernelLlvmSourceBuilder(kernel_dir))
     yield s
     s.finalize()
 


### PR DESCRIPTION
The `generate` command covers too much functionality and is not easily extensible. Therefore, in this PR, it is split into (currently) 2 sub-commands:
- `build-kernel` - covering the current `--kernel-with-builder` option (creates snapshot from a Linux kernel source by building source files into LLVM IR on-the-fly)    
- `llvm-to-snapshot` - covering the current `--single-llvm-file` option, creates snapshot from a project pre-built into a single LLVM IR file
    
This way, new snapshot generation options (such as `build` added by #228) can be easily added with new sub-commands that may have their own options.

As a preparation step for this PR, I refactored a good portion of snapshot generation parts. In particular, I moved instantiation of `SourceTree` and `SourceFinder` objects out of the `Snapshot` constructor into the snapshot generation functions in `diffkemp.py`. Also, I reworked snapshot groups a bit, which means that snapshot YAML files are now **not compatible** with the old ones.

Since there are major CLI and snapshot format changes, we should do a new release ASAP after merging this.

Resolves #235.