### PR TITLE
Fix memory issues and set up a CI run with Address sanitizer

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,12 +24,23 @@ jobs:
         env:
           - CC: gcc-9
             CXX: g++-9
+        asan: [OFF]
+        regression-tests: [true]
 
         include:
           - llvm: 14
             env:
               CC: clang
               CXX: clang++
+            asan: OFF
+            regression-tests: true
+
+          - llvm: 14
+            env:
+              CC: gcc-9
+              CXX: g++-9
+            asan: ON
+            regression-tests: false
 
     steps:
       - uses: actions/checkout@v2
@@ -56,10 +67,12 @@ jobs:
           echo "/usr/lib/llvm-${{ matrix.llvm }}/bin" >> $GITHUB_PATH
 
       - name: Set GCC Version for Kernel Builds
+        if: matrix.regression-tests
         run: |
           sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-7 100
 
       - name: Cache Linux Kernels
+        if: matrix.regression-tests
         id: kernel-cache
         uses: actions/cache@v2
         with:
@@ -67,7 +80,7 @@ jobs:
           key: kernels-${{ env.KERNELS }}
 
       - name: Obtain Linux Kernels
-        if: steps.kernel-cache.outputs.cache-hit != 'true'
+        if: steps.kernel-cache.outputs.cache-hit != 'true' && matrix.regression-tests
         working-directory: ${{ github.workspace }}
         run: |
           mkdir -p ${{ github.workspace }}/kernel
@@ -78,7 +91,7 @@ jobs:
           done
       
       - name: Clean Linux Kernels
-        if: steps.kernel-cache.outputs.cache-hit == 'true'
+        if: steps.kernel-cache.outputs.cache-hit == 'true' && matrix.regression-tests
         working-directory: ${{ github.workspace }}/kernel
         run: find -name *.ll -delete
 
@@ -90,7 +103,7 @@ jobs:
         env: ${{ matrix.env }}
         working-directory: ${{ github.workspace }}/build
         shell: bash
-        run: cmake $GITHUB_WORKSPACE -GNinja
+        run: cmake $GITHUB_WORKSPACE -GNinja -DSANITIZE_ADDRESS=${{ matrix.asan }}
 
       - name: Build
         env: ${{ matrix.env }}
@@ -102,10 +115,15 @@ jobs:
         working-directory: ${{ github.workspace }}
         run: pip3 install -e .
 
-      - name: Run Tests
+      - name: Run Unit Tests
         working-directory: ${{ github.workspace }}
         run: |
           tests/unit_tests/simpll/runTests
+
+      - name: Run Regression Tests
+        if: matrix.regression-tests
+        working-directory: ${{ github.workspace }}
+        run: |
           pytest tests
 
   code-style:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,6 +12,8 @@ set(CMAKE_CXX_STANDARD 14)
 
 include(GNUInstallDirs)
 
+option(SANITIZE_ADDRESS "Enable address sanitizer" OFF)
+
 add_subdirectory(diffkemp/simpll)
 
 option(BUILD_LLREVE "Build the LLReve tool for semantic comparison" OFF)

--- a/diffkemp/simpll/CMakeLists.txt
+++ b/diffkemp/simpll/CMakeLists.txt
@@ -22,6 +22,11 @@ file(GLOB library library/*.cpp)
 set(CMAKE_INCLUDE_CURRENT_DIR ON)
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fno-rtti -fpic -Wall -Wextra")
 
+if (${SANITIZE_ADDRESS})
+  add_compile_options(-fsanitize=address -fno-omit-frame-pointer)
+  add_link_options(-fsanitize=address -fno-omit-frame-pointer)
+endif()
+
 exec_program(llvm-config ARGS --libs irreader passes support OUTPUT_VARIABLE llvm_libs)
 exec_program(llvm-config ARGS --system-libs OUTPUT_VARIABLE system_libs)
 string(STRIP ${system_libs} system_libs)

--- a/diffkemp/simpll/passes/VarDependencySlicer.cpp
+++ b/diffkemp/simpll/passes/VarDependencySlicer.cpp
@@ -767,7 +767,7 @@ void VarDependencySlicer::changeToVoid(Function &Fun) {
 
     // Rename functions
     // New function gets original name. Old functions gets ".old" suffix.
-    auto Name = Fun.getName();
+    std::string Name = Fun.getName().str();
     Fun.setName(Name + ".old");
     NewFun->setName(Name);
 }

--- a/tests/unit_tests/simpll/CMakeLists.txt
+++ b/tests/unit_tests/simpll/CMakeLists.txt
@@ -14,6 +14,11 @@ add_subdirectory("${CMAKE_CURRENT_BINARY_DIR}/googletest-src"
 # Disable RTTI to link with SimpLL correctly.
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fno-rtti -fvisibility=hidden")
 
+if (${SANITIZE_ADDRESS})
+  add_compile_options(-fsanitize=address -fno-omit-frame-pointer)
+  add_link_options(-fsanitize=address -fno-omit-frame-pointer)
+endif()
+
 enable_testing()
 
 include_directories(${CMAKE_SOURCE_DIR}/diffkemp/simpll)


### PR DESCRIPTION
This PR adds:
- fixes of all memory issues in Diffkemp (as reported by Valgrind and Address Sanitizer)
- the ability to compile Diffkemp with ASan using the `-DSANITIZE_ADDRESS=ON` option
- a CI run which compiles Diffkemp with ASan and runs unit tests

Resolves #218.