### PR TITLE
Add missing nullptr check to `extractAlignmentFromInstructions`

### DIFF
--- a/diffkemp/simpll/DebugInfo.cpp
+++ b/diffkemp/simpll/DebugInfo.cpp
@@ -91,15 +91,14 @@ void DebugInfo::extractAlignmentFromInstructions(GetElementPtrInst *GEP,
              ++idx, indices.push_back(*idx)) {
             auto indexedType = GEP->getIndexedType(GEP->getSourceElementType(),
                                                    ArrayRef<Value *>(indices));
+            if (!indexedType || !indexedType->isStructTy())
+                continue;
 
             Type *indexedTypeOther = nullptr;
             if (OtherGEP)
                 indexedTypeOther = OtherGEP->getIndexedType(
                         OtherGEP->getSourceElementType(),
                         ArrayRef<Value *>(indicesOther));
-
-            if (!indexedType->isStructTy())
-                continue;
 
             if (indexedTypeOther && !indexedTypeOther->isStructTy()) {
                 // The type in the corresponding GEP instruction is different,


### PR DESCRIPTION
The missing check caused a null dereference error when the function `GetElementPtrInst::getIndexedType` returns null. This apparently happens when the array of indices passed to the function is not valid for the passed source element type.