### PR TITLE
Release 0.4.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_policy(SET CMP0048 NEW)
 cmake_minimum_required(VERSION 3.5)
 project(diffkemp
-    VERSION 0.3.0)
+    VERSION 0.4.0)
 
 find_package(LLVM REQUIRED CONFIG)
 message(STATUS "Found LLVM ${LLVM_PACKAGE_VERSION}")

--- a/diffkemp/building/CMakeLists.txt
+++ b/diffkemp/building/CMakeLists.txt
@@ -1,4 +1,15 @@
+# Try to find RPython as:
+# - standalone executable (rpython)
+# - Python2 module (python2 -m rpython)
 find_program(RPYTHON rpython)
+if (NOT RPYTHON)
+  execute_process(COMMAND python2 -m rpython --help
+                  RESULT_VARIABLE HAVE_RPYTHON_MODULE
+                  OUTPUT_QUIET ERROR_QUIET)
+  if (${HAVE_RPYTHON_MODULE} EQUAL 0)
+    set(RPYTHON python2 -m rpython)
+  endif ()
+endif ()
 set(CC_WRAPPER_SOURCE "${CMAKE_SOURCE_DIR}/diffkemp/building/cc_wrapper.py")
 add_custom_target(cc-wrapper-source ALL DEPENDS ${CC_WRAPPER_SOURCE})
 install(PROGRAMS ${CC_WRAPPER_SOURCE} RENAME diffkemp-cc-wrapper.py DESTINATION ${CMAKE_INSTALL_BINDIR})

--- a/diffkemp/simpll/simpll_lib.py
+++ b/diffkemp/simpll/simpll_lib.py
@@ -2,9 +2,14 @@ import sys
 from diffkemp.utils import get_simpll_build_dir
 
 # Dynamically import the SimpLL C extension module.
-# This way, we can prettily import the module objects into other files.
-sys.path.append(get_simpll_build_dir())
-import _simpll  # noqa E402
+# First try to import from the current build directory (to allow multiple
+# parallel local builds).
+# If that fails, import from the default location.
+try:
+    sys.path.append(get_simpll_build_dir())
+    _simpll = __import__("_simpll")
+except ImportError:
+    _simpll = __import__("diffkemp.simpll._simpll", fromlist=[None])
 
 lib = _simpll.lib
 ffi = _simpll.ffi

--- a/rpm/diffkemp.spec
+++ b/rpm/diffkemp.spec
@@ -1,7 +1,7 @@
 Name:           diffkemp
-Version:        0.3.0
+Version:        0.4.0
 Release:        1%{?dist}
-Summary:        A tool for analyzing differences in kernel functions
+Summary:        A tool for analyzing semantic differences in C projects
 
 License:        ASL 2.0
 URL:            https://github.com/viktormalik/diffkemp
@@ -23,11 +23,11 @@ Requires:       python3-setuptools
 %{?python_enable_dependency_generator}
 
 %description
-DiffKemp is a tool for finding changes in semantics of various parts of the
-Linux kernel between different kernel versions. It allows to compare semantics
-of functions and of sysctl kernel parameters. The comparison is based on static
-analysis of the source code that is translated into the LLVM intermediate
-representation.
+DiffKemp is a tool for finding changes in semantics between versions of C
+projects, with the main focus on the Linux kernel. It allows to compare
+semantics of functions and of sysctl kernel parameters. The comparison is based
+on static analysis of the source code that is translated into the LLVM
+intermediate representation.
 
 
 %prep
@@ -69,11 +69,20 @@ tests/unit_tests/simpll/runTests
 %{_bindir}/%{name}-cc-wrapper.py
 # SimpLL (C++ part)
 %{_bindir}/%{name}
-%{_bindir}/%{name}-simpll
 %{_libdir}/libsimpll-lib.so
 
 
 %changelog
+* Wed Nov 23 2022 Viktor Malik <vmalik@redhat.com> - 0.4.0-1
+- Reworked CLI interface (generate split into multiple commands)
+- New command for analysing any Makefile-based projects
+- Support for LLVM 14 and 15
+- SimpLL used as a library by default
+- Support for custom patterns
+- Handling code relocations
+- Improved handling of inverse branching conditions
+- Prevent analysing snapshots with other LLVM version
+
 * Mon Feb 28 2022 Viktor Malik <vmalik@redhat.com> - 0.3.0-1
 - Improved CLI interface
 - Support analysis of projects built into a single LLVM IR file

--- a/rpm/diffkemp.spec
+++ b/rpm/diffkemp.spec
@@ -6,11 +6,14 @@ Summary:        A tool for analyzing differences in kernel functions
 License:        ASL 2.0
 URL:            https://github.com/viktormalik/diffkemp
 Source0:        https://github.com/viktormalik/diffkemp/archive/v%{version}.tar.gz#/%{name}-%{version}.tar.gz
+Source1:        https://files.pythonhosted.org/packages/f9/71/4931d0c9b9be01a401f89ced4afb41aa46064f08b2659c31ccdaa5a8b679/rpython-0.2.1.tar.gz
+Source2:        https://files.pythonhosted.org/packages/98/ff/fec109ceb715d2a6b4c4a85a61af3b40c723a961e8828319fbcb15b868dc/py-1.11.0.tar.gz
 
 BuildRequires:  gcc gcc-c++ cmake ninja-build
 BuildRequires:  llvm-devel
-BuildRequires:  python3-devel python3-pip python3-setuptools
+BuildRequires:  python3-devel python3-pip python3-setuptools python2
 BuildRequires:  git
+BuildRequires:  /usr/bin/pathfix.py
 Requires:       cscope
 Requires:       clang llvm-devel
 Requires:       make
@@ -28,10 +31,11 @@ representation.
 
 
 %prep
-%setup -q
-
+%setup -q -a 1 -a 2
 
 %build
+PYTHONPATH=$PWD/rpython-0.2.1:$PWD/py-1.11.0:$PYTHONPATH
+export PYTHONPATH
 mkdir build
 # SimpLL (C++ part)
 %cmake -S . -B build -GNinja
@@ -47,6 +51,7 @@ mkdir -p %{buildroot}/%{_bindir}
 install -m 0755 bin/%{name} %{buildroot}/%{_bindir}/%{name}
 # Python part
 %py3_install
+pathfix.py -pni "%{__python3} %{py3_shbang_opts}" %{buildroot}%{_bindir}/diffkemp-cc-wrapper.py
 
 
 %check
@@ -60,6 +65,8 @@ tests/unit_tests/simpll/runTests
 # Python part
 %{python3_sitearch}/%{name}-*.egg-info/
 %{python3_sitearch}/%{name}
+%{_bindir}/%{name}-cc-wrapper
+%{_bindir}/%{name}-cc-wrapper.py
 # SimpLL (C++ part)
 %{_bindir}/%{name}
 %{_bindir}/%{name}-simpll

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ import os
 import subprocess
 
 setup(name="diffkemp",
-      version="0.3.0",
+      version="0.4.0",
       description="A tool for semantic difference analysis of kernel functions",
       author="Viktor Malik",
       author_email="vmalik@redhat.com",

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,6 @@
 from setuptools import setup, find_packages
 from diffkemp.utils import get_simpll_build_dir
+import os
 import subprocess
 
 setup(name="diffkemp",
@@ -13,5 +14,6 @@ setup(name="diffkemp",
       install_requires=["pyyaml", "cffi"],
       cffi_modules=["./diffkemp/simpll/simpll_build.py:ffibuilder"])
 
-build_dir = get_simpll_build_dir()
-subprocess.run(["mv", "diffkemp/simpll/_simpll.abi3.so", build_dir])
+if os.path.isfile("diffkemp/simpll/_simpll.abi3.so"):
+    build_dir = get_simpll_build_dir()
+    subprocess.run(["cp", "diffkemp/simpll/_simpll.abi3.so", build_dir])


### PR DESCRIPTION
Changelog:
- Reworked CLI interface (generate split into multiple commands)
- New command for analysing any Makefile-based projects
- Support for LLVM 14 and 15
- SimpLL used as a library by default
- Support for custom patterns
- Handling code relocations
- Improved handling of inverse branching conditions
- Prevent analysing snapshots with other LLVM version

Several changes were needed for this build:
- Allow using RPython as a Python2 module (`python2 -m rpython`) from CMake, since the `rpython` binary cannot be easily installed in Fedora for the RPM build.
- Update specfile to compile the CC wrapper with RPython. Since RPython is based on Python2 (which is not supported anymore), the RPython package and its dependent packages (Py) are downloaded manually during RPM build.
- Improve SimpLL library imports. Since we need to allow imports from local (possibly multiple) builds, local installations, and system installations, the importing must be done in a better way.

See individual commit messages for more details.