### PR TITLE
Add a script that cleans up the environment after upgrading LLVM

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,4 +29,8 @@ if (${BUILD_LLREVE})
   add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/llreve/reve)
 endif ()
 
+execute_process(COMMAND
+  ${CMAKE_CURRENT_SOURCE_DIR}/tools/simpll_clean.sh
+  ${CMAKE_CURRENT_SOURCE_DIR})
+
 add_subdirectory(tests/unit_tests/simpll)

--- a/tools/simpll_clean.sh
+++ b/tools/simpll_clean.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+# A script which deletes the SimpLL shared library if it's linked against
+# a different LLVM version than the one currently installed.
+#
+# Usage:
+# ./simpll_clean.sh [DIFFKEMP_ROOT]
+#
+# When DIFFKEMP_ROOT is not provided, the script assumes that
+# the current working directory is the DiffKemp root directory.
+
+if [[ -z $1 ]]
+    then
+        DIFFKEMP_ROOT=$PWD
+    else
+        DIFFKEMP_ROOT=$1
+fi
+
+if [[ ! -d ${DIFFKEMP_ROOT}/diffkemp/simpll ]]
+    then
+        echo "Error: ${DIFFKEMP_ROOT} is not a DiffKemp root directory." >&2
+        exit 1
+fi
+
+if [[ ! -f ${DIFFKEMP_ROOT}/diffkemp/simpll/_simpll.abi3.so ]]
+    then
+        exit 0
+fi
+
+LLVM_SYSTEM_VERSION=`llvm-config --version | sed -n 's/\([0-9]*\)\..*/\1/p'`
+LLVM_SIMPLL_VERSION=`ldd ${DIFFKEMP_ROOT}/diffkemp/simpll/_simpll.abi3.so | sed -n 's/^.*LLVM-\([0-9]*\)\.so.*$/\\1/p'`
+
+if [[ $LLVM_SIMPLL_VERSION -ne $LLVM_SYSTEM_VERSION ]]
+    then
+        echo "Deleting SimpLL shared library linked to LLVM ${LLVM_SIMPLL_VERSION}."
+        rm -f ${DIFFKEMP_ROOT}/diffkemp/simpll/_simpll.abi3.so
+        rm -rf ${DIFFKEMP_ROOT}/build/lib.linux* ${DIFFKEMP_ROOT}/build/temp.linux*
+fi
+
+exit 0


### PR DESCRIPTION
When upgrading LLVM,  the `.ll` files in `kernel/` and `tests/regression/kernel_modules/` become deprecated. Similarly, `diffkemp/simpll/_simpll.abi3.so` has to be replaced. Up to now, we were not able to detect the upgrade and rebuild them automatically.

I propose to execute a simple script during CMake configuration. The script reads the LLVM version from `diffkemp/simpll/_simpll.abi3.so` (i.e. the version of LLVM against which `simpll` is linked) and the current system LLVM version. If they differ, all of the mentioned files are deleted.

