### PR TITLE
Add --full-diff and --no-show-diff command-line options

### DIFF
--- a/diffkemp/cli.py
+++ b/diffkemp/cli.py
@@ -91,6 +91,9 @@ def make_argument_parser():
     compare_ap.add_argument("--show-diff",
                             help="show diff for non-equal functions",
                             action="store_true")
+    compare_ap.add_argument("--no-show-diff",
+                            help="do not show diff for non-equal functions",
+                            action="store_true")
     compare_ap.add_argument("--regex-filter",
                             help="filter function diffs by given regex")
     compare_ap.add_argument("--output-dir", "-o",
@@ -130,6 +133,10 @@ def make_argument_parser():
     compare_ap.add_argument("--enable-module-cache",
                             help="loads frequently used modules to memory and \
                             uses them in SimpLL",
+                            action="store_true")
+    compare_ap.add_argument("--full-diff",
+                            help="show diff for all functions \
+                            (even semantically equivalent ones)",
                             action="store_true")
     compare_ap.set_defaults(func=diffkemp.diffkemp.compare)
     return ap

--- a/diffkemp/config.py
+++ b/diffkemp/config.py
@@ -9,7 +9,7 @@ class ConfigException(Exception):
 class Config:
     def __init__(self, snapshot_first, snapshot_second, show_diff,
                  output_llvm_ir, pattern_config, control_flow_only,
-                 print_asm_diffs, verbosity, use_ffi, semdiff_tool):
+                 print_asm_diffs, verbosity, use_ffi, full_diff, semdiff_tool):
         """
         Store configuration of DiffKemp
         :param snapshot_first: First snapshot representation.
@@ -31,6 +31,7 @@ class Config:
         self.print_asm_diffs = print_asm_diffs
         self.verbosity = verbosity
         self.use_ffi = use_ffi
+        self.full_diff = full_diff
 
         # Semantic diff tool configuration
         self.semdiff_tool = semdiff_tool

--- a/diffkemp/config.py
+++ b/diffkemp/config.py
@@ -1,10 +1,7 @@
 """Configuration of the tool."""
 from diffkemp.semdiff.pattern_config import PatternConfig
 from diffkemp.snapshot import Snapshot
-from diffkemp.utils import get_llvm_version
 import os
-import sys
-import errno
 
 
 class ConfigException(Exception):
@@ -71,28 +68,6 @@ class Config:
         # Parse both the new and the old snapshot.
         snapshot_first = Snapshot.load_from_dir(args.snapshot_dir_old)
         snapshot_second = Snapshot.load_from_dir(args.snapshot_dir_new)
-
-        # Check if snapshot LLVM versions are compatible with
-        # the current version.
-        llvm_version = get_llvm_version()
-
-        if llvm_version != snapshot_first.llvm_version:
-            sys.stderr.write(
-                "Error: old snapshot was built with LLVM {}, "
-                "current version is LLVM {}.\n".format(
-                    snapshot_first.llvm_version, llvm_version
-                )
-            )
-            sys.exit(errno.EINVAL)
-
-        if llvm_version != snapshot_second.llvm_version:
-            sys.stderr.write(
-                "Error: new snapshot was built with LLVM {}, "
-                "current version is LLVM {}.\n".format(
-                    snapshot_second.llvm_version, llvm_version
-                )
-            )
-            sys.exit(errno.EINVAL)
 
         if args.function:
             snapshot_first.filter([args.function])

--- a/diffkemp/config.py
+++ b/diffkemp/config.py
@@ -30,8 +30,8 @@ class Config:
         Store configuration of DiffKemp
         :param snapshot_first: First snapshot representation.
         :param snapshot_second: Second snapshot representation.
-        :param show_diff: Only perform the syntax diff.
-        :param full_diff: Evaluate all syntactic differences.
+        :param show_diff: Evaluate syntax differences.
+        :param full_diff: Evaluate semantics-preserving syntax differences too.
         :param output_llvm_ir: Output each simplified module into a file.
         :param pattern_config: Valid difference patterns configuration.
         :param print_asm_diffs: Print assembly differences.

--- a/diffkemp/config.py
+++ b/diffkemp/config.py
@@ -114,7 +114,7 @@ class Config:
             control_flow_only=args.control_flow_only,
             output_llvm_ir=args.output_llvm_ir,
             print_asm_diffs=args.print_asm_diffs,
-            verbosity=args.verbosity,
-            use_ffi=args.use_ffi,
+            verbosity=args.verbose,
+            use_ffi=not args.disable_simpll_ffi,
             semdiff_tool=args.semdiff_tool,
         )

--- a/diffkemp/config.py
+++ b/diffkemp/config.py
@@ -1,5 +1,10 @@
 """Configuration of the tool."""
+from diffkemp.semdiff.pattern_config import PatternConfig
+from diffkemp.snapshot import Snapshot
+from diffkemp.utils import get_llvm_version
 import os
+import sys
+import errno
 
 
 class ConfigException(Exception):
@@ -7,31 +12,45 @@ class ConfigException(Exception):
 
 
 class Config:
-    def __init__(self, snapshot_first, snapshot_second, show_diff,
-                 output_llvm_ir, pattern_config, control_flow_only,
-                 print_asm_diffs, verbosity, use_ffi, full_diff, semdiff_tool):
+    def __init__(
+        self,
+        snapshot_first=None,
+        snapshot_second=None,
+        show_diff=True,
+        full_diff=False,
+        output_llvm_ir=False,
+        pattern_config=None,
+        control_flow_only=False,
+        print_asm_diffs=False,
+        verbosity=0,
+        use_ffi=False,
+        semdiff_tool=None,
+    ):
         """
         Store configuration of DiffKemp
         :param snapshot_first: First snapshot representation.
         :param snapshot_second: Second snapshot representation.
         :param show_diff: Only perform the syntax diff.
+        :param full_diff: Evaluate all syntactic differences.
         :param output_llvm_ir: Output each simplified module into a file.
         :param pattern_config: Valid difference patterns configuration.
+        :param print_asm_diffs: Print assembly differences.
         :param control_flow_only: Check only for control-flow differences.
         :param verbosity: Verbosity level (currently boolean).
         :param use_ffi: Use Python FFI to call SimpLL.
-        :param semdiff_tool: Tool to use for semantic diff
+        :param semdiff_tool: Tool to use for semantic diff.
         """
+
         self.snapshot_first = snapshot_first
         self.snapshot_second = snapshot_second
         self.show_diff = show_diff
+        self.full_diff = full_diff
         self.output_llvm_ir = output_llvm_ir
         self.pattern_config = pattern_config
         self.control_flow_only = control_flow_only
         self.print_asm_diffs = print_asm_diffs
         self.verbosity = verbosity
         self.use_ffi = use_ffi
-        self.full_diff = full_diff
 
         # Semantic diff tool configuration
         self.semdiff_tool = semdiff_tool
@@ -42,3 +61,60 @@ class Config:
                                        with -DBUILD_LLREVE=ON")
         elif semdiff_tool is not None:
             raise ConfigException("Unsupported semantic diff tool")
+
+    @classmethod
+    def from_args(cls, args):
+        """
+        Create the configuration from command line arguments.
+        :param args: Command line arguments
+        """
+        # Parse both the new and the old snapshot.
+        snapshot_first = Snapshot.load_from_dir(args.snapshot_dir_old)
+        snapshot_second = Snapshot.load_from_dir(args.snapshot_dir_new)
+
+        # Check if snapshot LLVM versions are compatible with
+        # the current version.
+        llvm_version = get_llvm_version()
+
+        if llvm_version != snapshot_first.llvm_version:
+            sys.stderr.write(
+                "Error: old snapshot was built with LLVM {}, "
+                "current version is LLVM {}.\n".format(
+                    snapshot_first.llvm_version, llvm_version
+                )
+            )
+            sys.exit(errno.EINVAL)
+
+        if llvm_version != snapshot_second.llvm_version:
+            sys.stderr.write(
+                "Error: new snapshot was built with LLVM {}, "
+                "current version is LLVM {}.\n".format(
+                    snapshot_second.llvm_version, llvm_version
+                )
+            )
+            sys.exit(errno.EINVAL)
+
+        if args.function:
+            snapshot_first.filter([args.function])
+            snapshot_second.filter([args.function])
+
+        # Transform difference pattern files into an LLVM IR
+        # based configuration.
+        if args.patterns:
+            pattern_config = PatternConfig.create_from_file(args.patterns)
+        else:
+            pattern_config = None
+
+        return cls(
+            snapshot_first=snapshot_first,
+            snapshot_second=snapshot_second,
+            show_diff=not args.no_show_diff or args.show_diff,
+            full_diff=args.full_diff,
+            pattern_config=pattern_config,
+            control_flow_only=args.control_flow_only,
+            output_llvm_ir=args.output_llvm_ir,
+            print_asm_diffs=args.print_asm_diffs,
+            verbosity=args.verbosity,
+            use_ffi=args.use_ffi,
+            semdiff_tool=args.semdiff_tool,
+        )

--- a/diffkemp/diffkemp.py
+++ b/diffkemp/diffkemp.py
@@ -534,12 +534,8 @@ def print_syntax_diff(snapshot_dir_old, snapshot_dir_new, fun, fun_result,
     old_dir_abs_path = os.path.join(os.path.abspath(snapshot_dir_old), "")
     new_dir_abs_path = os.path.join(os.path.abspath(snapshot_dir_new), "")
 
-    # Do not print anything if there is neither semantic nor syntax difference
-    empty_diff = not "".join(map(lambda x: x.diff, fun_result.inner.values()))
-    if fun_result.kind == Result.Kind.EQUAL and empty_diff:
-        return
-
-    if fun_result.kind == Result.Kind.NOT_EQUAL or full_diff:
+    any_diff = any([x.diff for x in fun_result.inner.values()])
+    if fun_result.kind == Result.Kind.NOT_EQUAL or (full_diff and any_diff):
         if output_dir:
             output = open(os.path.join(output_dir, "{}.diff".format(fun)), "w")
             output.write(

--- a/diffkemp/diffkemp.py
+++ b/diffkemp/diffkemp.py
@@ -423,9 +423,9 @@ def compare(args):
                             fun_tag=old_fun_desc.tag,
                             output_dir=group_dir if group_dir else output_dir,
                             show_diff=config.show_diff,
+                            full_diff=config.full_diff,
                             initial_indent=2 if (group_name is not None and
-                                                 group_dir is None) else 0,
-                            full_diff=config.full_diff)
+                                                 group_dir is None) else 0)
                     else:
                         # Print the group name if needed
                         if group_name is not None and not group_printed:
@@ -475,8 +475,8 @@ def default_output_dir(src_snapshot, dest_snapshot):
 
 
 def print_syntax_diff(snapshot_dir_old, snapshot_dir_new, fun, fun_result,
-                      fun_tag, output_dir, show_diff, initial_indent,
-                      full_diff):
+                      fun_tag, output_dir, show_diff, full_diff,
+                      initial_indent):
     """
     Log syntax diff of 2 functions. If log_files is set, the output is printed
     into a separate file, otherwise it goes to stdout.
@@ -487,6 +487,7 @@ def print_syntax_diff(snapshot_dir_old, snapshot_dir_new, fun, fun_result,
     :param fun_result: Result of the analysis
     :param output_dir: True if the output is to be written into a file
     :param show_diff: Print syntax diffs.
+    :param full_diff: Print semantics-preserving syntax diffs too.
     :param initial_indent: Initial indentation of printed messages
     """
     def text_indent(text, width):

--- a/diffkemp/diffkemp.py
+++ b/diffkemp/diffkemp.py
@@ -497,8 +497,8 @@ def print_syntax_diff(snapshot_dir_old, snapshot_dir_new, fun, fun_result,
     old_dir_abs_path = os.path.join(os.path.abspath(snapshot_dir_old), "")
     new_dir_abs_path = os.path.join(os.path.abspath(snapshot_dir_new), "")
 
-    any_diff = any([x.diff for x in fun_result.inner.values()])
-    if fun_result.kind == Result.Kind.NOT_EQUAL or (full_diff and any_diff):
+    if fun_result.kind == Result.Kind.NOT_EQUAL or (
+            full_diff and any([x.diff for x in fun_result.inner.values()])):
         if output_dir:
             output = open(os.path.join(output_dir, "{}.diff".format(fun)), "w")
             output.write(

--- a/diffkemp/semdiff/caching.py
+++ b/diffkemp/semdiff/caching.py
@@ -440,7 +440,7 @@ class ComparisonGraph:
                     predecessor.cachable = False
                     vertex.prevents_caching_of.append(predecessor)
 
-    def graph_to_fun_pair_list(self, fun_first, fun_second):
+    def graph_to_fun_pair_list(self, fun_first, fun_second, full_diff):
         # Extract the functions that should be compared from the graph in
         # the form of Vertex objects.
         called_funs_left, backtracking_map_left = self.reachable_from(
@@ -458,8 +458,8 @@ class ComparisonGraph:
         syndiff_bodies_left = dict()
         syndiff_bodies_right = dict()
         for vertex in vertices_to_compare:
-            if vertex.result in [Result.Kind.EQUAL,
-                                 Result.Kind.ASSUMED_EQUAL]:
+            if (vertex.result == Result.Kind.EQUAL and not full_diff) or \
+               vertex.result == Result.Kind.ASSUMED_EQUAL:
                 # Do not include equal functions into the result.
                 continue
             # Generate and add the function difference.

--- a/diffkemp/semdiff/function_diff.py
+++ b/diffkemp/semdiff/function_diff.py
@@ -259,7 +259,9 @@ def functions_diff(mod_first, mod_second,
                                                  Result.Kind.ASSUMED_EQUAL]])
 
         objects_to_compare, syndiff_bodies_left, syndiff_bodies_right = \
-            curr_result_graph.graph_to_fun_pair_list(fun_first, fun_second)
+            curr_result_graph.graph_to_fun_pair_list(fun_first,
+                                                     fun_second,
+                                                     config.full_diff)
 
         mod_first.restore_unlinked_llvm()
         mod_second.restore_unlinked_llvm()
@@ -282,8 +284,10 @@ def functions_diff(mod_first, mod_second,
                     fun_result = Result(fun_pair[2], fun_first, fun_second)
                 fun_result.first = fun_pair[0]
                 fun_result.second = fun_pair[1]
-                if fun_result.kind == Result.Kind.NOT_EQUAL:
-                    if fun_result.first.diff_kind in ["function", "type"]:
+                if fun_result.kind == Result.Kind.NOT_EQUAL or \
+                   config.full_diff:
+                    if fun_result.first.diff_kind in ["function", "type"] or \
+                       config.full_diff:
                         # Get the syntactic diff of functions or types
                         fun_result.diff = syntax_diff(
                             fun_result.first.filename,

--- a/diffkemp/semdiff/function_diff.py
+++ b/diffkemp/semdiff/function_diff.py
@@ -286,8 +286,10 @@ def functions_diff(mod_first, mod_second,
                 fun_result.second = fun_pair[1]
                 if fun_result.kind == Result.Kind.NOT_EQUAL or \
                    config.full_diff:
-                    if fun_result.first.diff_kind in ["function", "type"] or \
-                       config.full_diff:
+                    if fun_result.first.diff_kind in ["function", "type"] or (
+                            config.full_diff and
+                            fun_result.first.filename is not None and
+                            fun_result.second.filename is not None):
                         # Get the syntactic diff of functions or types
                         fun_result.diff = syntax_diff(
                             fun_result.first.filename,

--- a/diffkemp/semdiff/function_diff.py
+++ b/diffkemp/semdiff/function_diff.py
@@ -309,6 +309,11 @@ def functions_diff(mod_first, mod_second,
                             "warning: unknown diff kind: {}\n".format(
                                 fun_result.first.diff_kind))
                         fun_result.diff = "unknown\n"
+                # Do not save the result if there is neither syntactic nor
+                # semantic difference.
+                if (fun_result.kind != Result.Kind.NOT_EQUAL and
+                        fun_result.diff == ""):
+                    continue
                 result.add_inner(fun_result)
     except ValueError:
         result.kind = Result.Kind.ERROR

--- a/diffkemp/semdiff/function_diff.py
+++ b/diffkemp/semdiff/function_diff.py
@@ -286,10 +286,7 @@ def functions_diff(mod_first, mod_second,
                 fun_result.second = fun_pair[1]
                 if fun_result.kind == Result.Kind.NOT_EQUAL or \
                    config.full_diff:
-                    if fun_result.first.diff_kind in ["function", "type"] or (
-                            config.full_diff and
-                            fun_result.first.filename is not None and
-                            fun_result.second.filename is not None):
+                    if fun_result.first.diff_kind in ["function", "type"]:
                         # Get the syntactic diff of functions or types
                         fun_result.diff = syntax_diff(
                             fun_result.first.filename,

--- a/diffkemp/snapshot.py
+++ b/diffkemp/snapshot.py
@@ -15,6 +15,7 @@ import pkg_resources
 import shutil
 import sys
 import yaml
+import errno
 
 
 class Snapshot:
@@ -96,6 +97,17 @@ class Snapshot:
         with open(os.path.join(snapshot_dir, config_file), "r") as \
                 snapshot_yaml:
             loaded_snapshot._from_yaml(snapshot_yaml.read())
+
+        # Check if the snapshot LLVM version is compatible with
+        # the current version.
+        llvm_version = get_llvm_version()
+        if llvm_version != loaded_snapshot.llvm_version:
+            sys.stderr.write(
+                f"Error: The snapshot {snapshot_dir} was built with LLVM"
+                f"{loaded_snapshot.llvm_version}, "
+                f"the current version is {llvm_version}.\n"
+            )
+            sys.exit(errno.EINVAL)
 
         return loaded_snapshot
 

--- a/diffkemp/syndiff/function_syntax_diff.py
+++ b/diffkemp/syndiff/function_syntax_diff.py
@@ -22,8 +22,8 @@ def syntax_diff(first_file, second_file, name, kind, first_line, second_line):
     # the lines on which the function starts in each file to extract both
     # functions into temporary files
     for filename in [first_file, second_file]:
-        tmp_file = "1" if filename == first_file else "2"
-        start = first_line if filename == first_file else second_line
+        tmp_file = "1" if filename is first_file else "2"
+        start = first_line if filename is first_file else second_line
 
         try:
             end = get_end_line(filename, start, kind)

--- a/tests/regression/task_spec.py
+++ b/tests/regression/task_spec.py
@@ -69,7 +69,8 @@ class TaskSpec:
         self.new_snapshot = Snapshot(self.new_kernel, self.new_kernel)
         self.config = Config(self.old_snapshot, self.new_snapshot, False,
                              False, self.pattern_config,
-                             self.control_flow_only, False, False, False, None)
+                             self.control_flow_only, False, False, False,
+                             False, None)
 
         self.functions = dict()
 

--- a/tests/regression/task_spec.py
+++ b/tests/regression/task_spec.py
@@ -49,16 +49,16 @@ class TaskSpec:
                 config_filename = spec["pattern_config"]["opaque"]
             else:
                 config_filename = spec["pattern_config"]["explicit"]
-            self.pattern_config = PatternConfig.create_from_file(
+            pattern_config = PatternConfig.create_from_file(
                 path=os.path.join(patterns_path, config_filename),
                 patterns_path=base_path
             )
         else:
-            self.pattern_config = None
+            pattern_config = None
         if "control_flow_only" in spec:
-            self.control_flow_only = spec["control_flow_only"]
+            control_flow_only = spec["control_flow_only"]
         else:
-            self.control_flow_only = False
+            control_flow_only = False
 
         # Create LLVM sources and configuration
         self.old_kernel = KernelSourceTree(
@@ -67,11 +67,10 @@ class TaskSpec:
             self.new_kernel_dir, KernelLlvmSourceBuilder(self.new_kernel_dir))
         self.old_snapshot = Snapshot(self.old_kernel, self.old_kernel)
         self.new_snapshot = Snapshot(self.new_kernel, self.new_kernel)
-        self.config = Config(self.old_snapshot, self.new_snapshot, False,
-                             False, self.pattern_config,
-                             self.control_flow_only, False, False, False,
-                             False, None)
-
+        self.config = Config(snapshot_first=self.old_snapshot,
+                             snapshot_second=self.new_snapshot,
+                             pattern_config=pattern_config,
+                             control_flow_only=control_flow_only)
         self.functions = dict()
 
     def finalize(self):

--- a/tests/unit_tests/caching_test.py
+++ b/tests/unit_tests/caching_test.py
@@ -166,7 +166,7 @@ def test_graph_to_fun_pair_list(graph):
     """Tests the conversion of a graph to a structure representing the output
     of DiffKemp."""
     objects_to_compare, syndiff_bodies_left, syndiff_bodies_right = \
-        graph.graph_to_fun_pair_list("main_function", "main_function")
+        graph.graph_to_fun_pair_list("main_function", "main_function", False)
     for side in [0, 1]:
         assert {obj[side].name for obj in objects_to_compare} == {
             "do_check", "MACRO", "struct_file"}

--- a/tests/unit_tests/function_syntax_diff_test.py
+++ b/tests/unit_tests/function_syntax_diff_test.py
@@ -24,7 +24,8 @@ def test_syntax_diff():
     config = Config(source_first, source_second, show_diff=True,
                     output_llvm_ir=False, pattern_config=None,
                     control_flow_only=True, print_asm_diffs=False,
-                    verbosity=False, use_ffi=False, semdiff_tool=None)
+                    verbosity=False, use_ffi=False, full_diff=False,
+                    semdiff_tool=None)
     first = source_first.get_module_for_symbol(f)
     second = source_second.get_module_for_symbol(f)
     fun_result = functions_diff(mod_first=first, mod_second=second,

--- a/tests/unit_tests/function_syntax_diff_test.py
+++ b/tests/unit_tests/function_syntax_diff_test.py
@@ -21,11 +21,7 @@ def test_syntax_diff():
     kernel_new = "kernel/linux-3.10.0-957.el7"
     source_first = SourceTree(kernel_old, KernelLlvmSourceBuilder(kernel_old))
     source_second = SourceTree(kernel_new, KernelLlvmSourceBuilder(kernel_new))
-    config = Config(source_first, source_second, show_diff=True,
-                    output_llvm_ir=False, pattern_config=None,
-                    control_flow_only=True, print_asm_diffs=False,
-                    verbosity=False, use_ffi=False, full_diff=False,
-                    semdiff_tool=None)
+    config = Config(control_flow_only=True)
     first = source_first.get_module_for_symbol(f)
     second = source_second.get_module_for_symbol(f)
     fun_result = functions_diff(mod_first=first, mod_second=second,

--- a/tests/unit_tests/result_test.py
+++ b/tests/unit_tests/result_test.py
@@ -112,7 +112,7 @@ def result(graph):
 
     comp1_result = Result(Result.Kind.NONE, "main_function", "main_function")
     objects_to_compare, *_ = \
-        graph.graph_to_fun_pair_list("main_function", "main_function")
+        graph.graph_to_fun_pair_list("main_function", "main_function", False)
     for fun_pair in objects_to_compare:
         fun_result = Result(fun_pair[2], "main_function", "main_function")
         fun_result.first = fun_pair[0]

--- a/tests/unit_tests/snapshot_test.py
+++ b/tests/unit_tests/snapshot_test.py
@@ -4,6 +4,7 @@ from diffkemp.snapshot import Snapshot
 from diffkemp.llvm_ir.llvm_module import LlvmModule
 from diffkemp.llvm_ir.source_tree import SourceTree
 from diffkemp.llvm_ir.kernel_llvm_source_builder import KernelLlvmSourceBuilder
+from diffkemp.utils import get_llvm_version
 from tempfile import NamedTemporaryFile
 from tempfile import TemporaryDirectory
 import datetime
@@ -61,8 +62,8 @@ def test_load_snapshot_from_dir_functions():
             kind: kernel_with_builder
             path: null
           source_dir: /diffkemp/kernel/linux-3.10.0-957.el7
-          llvm_version: 13
-        """)
+          llvm_version: {}
+        """.format(get_llvm_version()))
 
         # Load the temporary snapshot configuration file.
         config_file.seek(0)
@@ -124,8 +125,8 @@ def test_load_snapshot_from_dir_sysctls():
             kind: kernel_with_builder
             path: null
           source_dir: /diffkemp/kernel/linux-3.10.0-957.el7
-          llvm_version: 13
-        """)
+          llvm_version: {}
+        """.format(get_llvm_version()))
 
         # Load the temporary sysctl snapshot configuration file.
         config_file.seek(0)


### PR DESCRIPTION
This PR adds two new command-line options to Diffkemp:
- `--no-show-diff`: The current default option is to **not** print syntactic differences. I propose that the default behaviour is that we **do** print them, and this option disables it.
- `--full-diff`:  This option causes Diffkemp to show syntactic differences even for functions that are semantically equal. This is useful when analyzing which functions with syntactic differences were successfully evaluated as semantically equal.