### PR TITLE
Update CI workflow to save space

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,38 @@ env:
     4.11
 
 jobs:
+  cache-kernels:
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Cache Linux Kernels
+        id: kernel-cache
+        uses: actions/cache@v3
+        with:
+          path: ${{ github.workspace }}/kernel
+          key: kernels-${{ env.KERNELS }}
+          lookup-only: true
+
+      - name: Install Dependencies
+        if: steps.kernel-cache.outputs.cache-hit != 'true'
+        run: sudo apt-get install gcc-7 libelf-dev
+
+      - name: Set GCC Version for Kernel Builds
+        if: steps.kernel-cache.outputs.cache-hit != 'true'
+        run: sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-7 100
+
+      - name: Obtain Linux Kernels
+        if: steps.kernel-cache.outputs.cache-hit != 'true'
+        working-directory: ${{ github.workspace }}
+        run: |
+          mkdir -p ${{ github.workspace }}/kernel
+          git clone https://github.com/viktormalik/rhel-kernel-get.git
+          pip3 install -r rhel-kernel-get/requirements.txt
+          for k in $KERNELS; do
+            rhel-kernel-get/rhel-kernel-get.py $k --output-dir kernel
+          done
+
   build-and-test:
+    needs: cache-kernels
     runs-on: ubuntu-20.04
     strategy:
       matrix:
@@ -43,10 +74,17 @@ jobs:
             regression-tests: false
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
+
+      - name: Delete unused software
+        run: |
+          sudo rm -rf /usr/local/lib/android
+          sudo rm -rf /usr/share/dotnet
+          sudo rm -rf /opt/ghc
+          sudo rm -rf /opt/hostedtoolcache/CodeQL
 
       - name: Setup Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: 3.9
 
@@ -54,7 +92,7 @@ jobs:
         working-directory: ${{ github.workspace }}
         shell: bash
         run: |
-          sudo apt-get install bc cscope gcc-7 libelf-dev ninja-build
+          sudo apt-get install bc cscope libelf-dev ninja-build
           pip install -r requirements.txt
 
       - name: Install LLVM
@@ -66,34 +104,13 @@ jobs:
           sudo ln -s /usr/lib/llvm-${{ matrix.llvm }} /usr/local/lib/llvm
           echo "/usr/lib/llvm-${{ matrix.llvm }}/bin" >> $GITHUB_PATH
 
-      - name: Set GCC Version for Kernel Builds
+      - name: Restore Kernels
+        uses: actions/cache/restore@v3
         if: matrix.regression-tests
-        run: |
-          sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-7 100
-
-      - name: Cache Linux Kernels
-        if: matrix.regression-tests
-        id: kernel-cache
-        uses: actions/cache@v2
         with:
           path: ${{ github.workspace }}/kernel
           key: kernels-${{ env.KERNELS }}
-
-      - name: Obtain Linux Kernels
-        if: steps.kernel-cache.outputs.cache-hit != 'true' && matrix.regression-tests
-        working-directory: ${{ github.workspace }}
-        run: |
-          mkdir -p ${{ github.workspace }}/kernel
-          git clone https://github.com/viktormalik/rhel-kernel-get.git
-          pip3 install -r rhel-kernel-get/requirements.txt
-          for k in $KERNELS; do
-            rhel-kernel-get/rhel-kernel-get.py $k --output-dir kernel
-          done
-      
-      - name: Clean Linux Kernels
-        if: steps.kernel-cache.outputs.cache-hit == 'true' && matrix.regression-tests
-        working-directory: ${{ github.workspace }}/kernel
-        run: find -name *.ll -delete
+          fail-on-cache-miss: true
 
       - name: Prepare Build Environment
         run: |
@@ -129,10 +146,10 @@ jobs:
   code-style:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Setup Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: 3.9
 


### PR DESCRIPTION
Apparently, issue #263 (which has been recently occurring non-deterministically in multiple branches) is caused by the lack of space in GitHub runners.

Github only [guarantees 14 GB of disk space ](https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners#supported-runners-and-hardware-resources) in the runners. In practice, the available space is usually higher, but it does not suffice in some runs (just the `kernel` directory has 21 GB after all tests are run).

This PR attempts to solve the issue using the following workarounds and upgrades of the CI workflow:
-  At the beginning of `build-and-test` jobs, some unused software is deleted, namely .NET, Haskell, CodeQL, and Android SDK. This frees up to 20 GB of disk space. The solution is taken from [this action](https://github.com/marketplace/actions/maximize-build-disk-space).
- Kernel caching is moved to a separate job, which is a prerequisite of each `build-and-test` job. Using a new feature of the cache action, `build-and-test` only restores the cache, without attempting to submit it. This way, the jobs in the `build-and-test` matrix save the space necessary to create the compressed archive. Arguably, the solution is also prettier, because it is clear which job creates the cache (previously, it was the job which got to the post step first).