### PR TITLE
Viewer: Add code style checks to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -183,5 +183,7 @@ jobs:
       run: npm ci --prefix view
     - name: Run tests
       run: npm test --prefix view
-    - name: Create build with ESLint checks
+    - name: Check coding style with ESLint
+      run: npm run lint --prefix view
+    - name: Create build
       run: CI=false npm run build --prefix view


### PR DESCRIPTION
I found out that `npm run build` (which is part of CI) does not fail if there is a coding style error in test source files, it only fails when there is a coding style error in the "app" sources.
This commit adds to CI an independent "test" of coding style using ESLint.