### PR TITLE
Viewer: Install build to system

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -52,11 +52,11 @@ if (${BUILD_VIEWER})
     FILE_PERMISSIONS OWNER_READ OWNER_WRITE
                      GROUP_READ
                      WORLD_READ
-    # Setting 777 for directories to make it possible to create
-    # `src` and `diffs` folder by user (`diffkemp view`).
+    # Setting 711 for directories to make it possible 
+    # to access files/folders in the directory. 
     DIRECTORY_PERMISSIONS OWNER_READ OWNER_WRITE OWNER_EXECUTE
-                     GROUP_READ GROUP_WRITE GROUP_EXECUTE
-                     WORLD_READ WORLD_WRITE WORLD_EXECUTE
+                          GROUP_EXECUTE
+                          WORLD_EXECUTE
     # Do not install files describing results of comparison.
     PATTERN "diffkemp-out.yaml" EXCLUDE
     PATTERN "src" EXCLUDE

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -61,7 +61,27 @@ if (${BUILD_VIEWER})
     PATTERN "diffkemp-out.yaml" EXCLUDE
     PATTERN "src" EXCLUDE
     PATTERN "diffs" EXCLUDE
-  ) # install
-endif ()
+  ) # install - copy `build` dir
+  # Creating `src`, `diffs` directories
+  # and setting the permissions to 777 to make able to copy there files and remove them.
+  install(DIRECTORY DESTINATION /var/lib/diffkemp/view/src
+    DIRECTORY_PERMISSIONS OWNER_READ OWNER_WRITE OWNER_EXECUTE
+                          GROUP_READ GROUP_WRITE GROUP_EXECUTE
+                          WORLD_READ WORLD_WRITE WORLD_EXECUTE
+  ) # install src dir
+  install(DIRECTORY DESTINATION /var/lib/diffkemp/view/diffs
+    DIRECTORY_PERMISSIONS OWNER_READ OWNER_WRITE OWNER_EXECUTE
+                          GROUP_READ GROUP_WRITE GROUP_EXECUTE
+                          WORLD_READ WORLD_WRITE WORLD_EXECUTE
+  ) # install diffs dir
+  # Creating diffkemp-out.yaml
+  # and setting its permission to 666 to make able edit its content by `diffkemp view`.
+  install(CODE "file(TOUCH /var/lib/diffkemp/view/diffkemp-out.yaml)")
+  install(CODE "file(CHMOD /var/lib/diffkemp/view/diffkemp-out.yaml
+                           PERMISSIONS OWNER_READ OWNER_WRITE
+                                       GROUP_READ GROUP_WRITE
+                                       WORLD_READ WORLD_WRITE
+  )") # install - file chmod
+endif () # ${BUILD_VIEWER}
 
 add_subdirectory(tests/unit_tests/simpll)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -47,6 +47,22 @@ if (${BUILD_VIEWER})
     COMMAND ${NPM} run build
     WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/view
   )
+  install(DIRECTORY view/build DESTINATION /var/lib/diffkemp/view
+    # Setting 755 for files.
+    FILE_PERMISSIONS OWNER_READ OWNER_WRITE OWNER_EXECUTE
+                     GROUP_READ GROUP_EXECUTE
+                     WORLD_READ WORLD_EXECUTE
+    # Setting 777 for directories to make it possible to create
+    # `src` and `diffs` folder by user (`diffkemp view`).
+    DIRECTORY_PERMISSIONS OWNER_READ OWNER_WRITE OWNER_EXECUTE
+                     GROUP_READ GROUP_WRITE GROUP_EXECUTE
+                     WORLD_READ WORLD_WRITE WORLD_EXECUTE
+    # Making it possible to remove `diffkemp-out.yaml`
+    # by a user (`diffkemp view`) if it existed during installation.
+    PATTERN "diffkemp-out.yaml"
+         PERMISSIONS OWNER_READ OWNER_WRITE OWNER_EXECUTE
+                     GROUP_READ GROUP_WRITE GROUP_EXECUTE
+                     WORLD_READ WORLD_WRITE WORLD_EXECUTE
+  ) # install
 endif ()
-
 add_subdirectory(tests/unit_tests/simpll)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -47,7 +47,9 @@ if (${BUILD_VIEWER})
     COMMAND ${NPM} run build
     WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/view
   )
-  install(DIRECTORY view/build/ DESTINATION /var/lib/diffkemp/view
+
+  set(VIEW_INSTALL_DIR /var/lib/diffkemp/view)
+  install(DIRECTORY view/build/ DESTINATION ${VIEW_INSTALL_DIR}
     # Setting 644 for files.
     FILE_PERMISSIONS OWNER_READ OWNER_WRITE
                      GROUP_READ
@@ -62,7 +64,7 @@ if (${BUILD_VIEWER})
   ) # install - copy `build` dir
   # Creating `data` directory
   # and setting the permissions to 777 to make able to create there files and remove them.
-  install(DIRECTORY DESTINATION /var/lib/diffkemp/view/data
+  install(DIRECTORY DESTINATION ${VIEW_INSTALL_DIR}/data
     DIRECTORY_PERMISSIONS OWNER_READ OWNER_WRITE OWNER_EXECUTE
                           GROUP_READ GROUP_WRITE GROUP_EXECUTE
                           WORLD_READ WORLD_WRITE WORLD_EXECUTE

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -57,31 +57,16 @@ if (${BUILD_VIEWER})
     DIRECTORY_PERMISSIONS OWNER_READ OWNER_WRITE OWNER_EXECUTE
                           GROUP_READ GROUP_EXECUTE
                           WORLD_READ WORLD_EXECUTE
-    # Do not install files describing results of comparison.
-    PATTERN "diffkemp-out.yaml" EXCLUDE
-    PATTERN "src" EXCLUDE
-    PATTERN "diffs" EXCLUDE
+    # Do not install directory describing results of comparison.
+    PATTERN "data/" EXCLUDE
   ) # install - copy `build` dir
-  # Creating `src`, `diffs` directories
-  # and setting the permissions to 777 to make able to copy there files and remove them.
-  install(DIRECTORY DESTINATION /var/lib/diffkemp/view/src
+  # Creating `data` directory
+  # and setting the permissions to 777 to make able to create there files and remove them.
+  install(DIRECTORY DESTINATION /var/lib/diffkemp/view/data
     DIRECTORY_PERMISSIONS OWNER_READ OWNER_WRITE OWNER_EXECUTE
                           GROUP_READ GROUP_WRITE GROUP_EXECUTE
                           WORLD_READ WORLD_WRITE WORLD_EXECUTE
-  ) # install src dir
-  install(DIRECTORY DESTINATION /var/lib/diffkemp/view/diffs
-    DIRECTORY_PERMISSIONS OWNER_READ OWNER_WRITE OWNER_EXECUTE
-                          GROUP_READ GROUP_WRITE GROUP_EXECUTE
-                          WORLD_READ WORLD_WRITE WORLD_EXECUTE
-  ) # install diffs dir
-  # Creating diffkemp-out.yaml
-  # and setting its permission to 666 to make able edit its content by `diffkemp view`.
-  install(CODE "file(TOUCH /var/lib/diffkemp/view/diffkemp-out.yaml)")
-  install(CODE "file(CHMOD /var/lib/diffkemp/view/diffkemp-out.yaml
-                           PERMISSIONS OWNER_READ OWNER_WRITE
-                                       GROUP_READ GROUP_WRITE
-                                       WORLD_READ WORLD_WRITE
-  )") # install - file chmod
+  ) # install `data` dir
 endif () # ${BUILD_VIEWER}
 
 add_subdirectory(tests/unit_tests/simpll)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -54,11 +54,11 @@ if (EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/view/build)
     FILE_PERMISSIONS OWNER_READ OWNER_WRITE
                      GROUP_READ
                      WORLD_READ
-    # Setting 711 for directories to make it possible 
+    # Setting 755 for directories to make it possible
     # to access files/folders in the directory. 
     DIRECTORY_PERMISSIONS OWNER_READ OWNER_WRITE OWNER_EXECUTE
-                          GROUP_EXECUTE
-                          WORLD_EXECUTE
+                          GROUP_READ GROUP_EXECUTE
+                          WORLD_READ WORLD_EXECUTE
     # Do not install files describing results of comparison.
     PATTERN "diffkemp-out.yaml" EXCLUDE
     PATTERN "src" EXCLUDE

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -48,10 +48,10 @@ if (${BUILD_VIEWER})
     WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/view
   )
   install(DIRECTORY view/build/ DESTINATION /var/lib/diffkemp/view
-    # Setting 755 for files.
-    FILE_PERMISSIONS OWNER_READ OWNER_WRITE OWNER_EXECUTE
-                     GROUP_READ GROUP_EXECUTE
-                     WORLD_READ WORLD_EXECUTE
+    # Setting 644 for files.
+    FILE_PERMISSIONS OWNER_READ OWNER_WRITE
+                     GROUP_READ
+                     WORLD_READ
     # Setting 777 for directories to make it possible to create
     # `src` and `diffs` folder by user (`diffkemp view`).
     DIRECTORY_PERMISSIONS OWNER_READ OWNER_WRITE OWNER_EXECUTE

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -47,6 +47,8 @@ if (${BUILD_VIEWER})
     COMMAND ${NPM} run build
     WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/view
   )
+endif () # ${BUILD_VIEWER}
+if (EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/view/build)
   install(DIRECTORY view/build/ DESTINATION /var/lib/diffkemp/view
     # Setting 644 for files.
     FILE_PERMISSIONS OWNER_READ OWNER_WRITE
@@ -82,6 +84,6 @@ if (${BUILD_VIEWER})
                                        GROUP_READ GROUP_WRITE
                                        WORLD_READ WORLD_WRITE
   )") # install - file chmod
-endif () # ${BUILD_VIEWER}
+endif () # if (EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/view/build)
 
 add_subdirectory(tests/unit_tests/simpll)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -47,8 +47,6 @@ if (${BUILD_VIEWER})
     COMMAND ${NPM} run build
     WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/view
   )
-endif () # ${BUILD_VIEWER}
-if (EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/view/build)
   install(DIRECTORY view/build/ DESTINATION /var/lib/diffkemp/view
     # Setting 644 for files.
     FILE_PERMISSIONS OWNER_READ OWNER_WRITE
@@ -84,6 +82,6 @@ if (EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/view/build)
                                        GROUP_READ GROUP_WRITE
                                        WORLD_READ WORLD_WRITE
   )") # install - file chmod
-endif () # if (EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/view/build)
+endif () # ${BUILD_VIEWER}
 
 add_subdirectory(tests/unit_tests/simpll)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -57,12 +57,10 @@ if (${BUILD_VIEWER})
     DIRECTORY_PERMISSIONS OWNER_READ OWNER_WRITE OWNER_EXECUTE
                      GROUP_READ GROUP_WRITE GROUP_EXECUTE
                      WORLD_READ WORLD_WRITE WORLD_EXECUTE
-    # Making it possible to remove `diffkemp-out.yaml`
-    # by a user (`diffkemp view`) if it existed during installation.
-    PATTERN "diffkemp-out.yaml"
-         PERMISSIONS OWNER_READ OWNER_WRITE OWNER_EXECUTE
-                     GROUP_READ GROUP_WRITE GROUP_EXECUTE
-                     WORLD_READ WORLD_WRITE WORLD_EXECUTE
+    # Do not install files describing results of comparison.
+    PATTERN "diffkemp-out.yaml" EXCLUDE
+    PATTERN "src" EXCLUDE
+    PATTERN "diffs" EXCLUDE
   ) # install
 endif ()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -47,7 +47,7 @@ if (${BUILD_VIEWER})
     COMMAND ${NPM} run build
     WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/view
   )
-  install(DIRECTORY view/build DESTINATION /var/lib/diffkemp/view
+  install(DIRECTORY view/build/ DESTINATION /var/lib/diffkemp/view
     # Setting 755 for files.
     FILE_PERMISSIONS OWNER_READ OWNER_WRITE OWNER_EXECUTE
                      GROUP_READ GROUP_EXECUTE
@@ -65,4 +65,5 @@ if (${BUILD_VIEWER})
                      WORLD_READ WORLD_WRITE WORLD_EXECUTE
   ) # install
 endif ()
+
 add_subdirectory(tests/unit_tests/simpll)

--- a/diffkemp/diffkemp.py
+++ b/diffkemp/diffkemp.py
@@ -619,7 +619,8 @@ def view(args):
     # View directory does not exist
     else:
         sys.stderr.write(
-            "Error: directory with the viewer was not found\n")
+            "Error: the viewer was not found.\n" +
+            "The viewer was probably not installed.\n")
         sys.exit(errno.ENOENT)
 
     # Preparing source directory

--- a/diffkemp/diffkemp.py
+++ b/diffkemp/diffkemp.py
@@ -571,16 +571,6 @@ def view(args):
     View the compare differences. Prepares files for the visualisation
     and runs viewer.
     """
-    def rmtree_without_parent(path):
-        """
-        Recursively removes files and dirs in `path` directory
-        without the parent dir.
-        """
-        for dirpath, dirnames, filenames in os.walk(path, topdown=False):
-            for dirname in dirnames:
-                os.rmdir(os.path.join(dirpath, dirname))
-            for filename in filenames:
-                os.remove(os.path.join(dirpath, filename))
     # Load yaml describing results
     YAML_FILE_NAME = "diffkemp-out.yaml"
     yaml_path = os.path.join(args.compare_output_dir, YAML_FILE_NAME)
@@ -623,13 +613,18 @@ def view(args):
             "The viewer was probably not installed.\n")
         sys.exit(errno.ENOENT)
 
+    # Dir for storing necessary data for a visualisation of a compared project.
+    data_directory = os.path.join(public_directory, "data")
+    if not os.path.exists(data_directory):
+        os.mkdir(data_directory)
+
     # Preparing source directory
-    source_directory = os.path.join(public_directory, "src")
+    source_directory = os.path.join(data_directory, "src")
     if not os.path.exists(source_directory):
         os.mkdir(source_directory)
     # Preparing diff directory
-    diff_directory = os.path.join(public_directory, "diffs")
-    if not os.path.isdir(diff_directory):
+    diff_directory = os.path.join(data_directory, "diffs")
+    if not os.path.exists(diff_directory):
         os.mkdir(diff_directory)
 
     # Prepare source and diff files to view directory
@@ -685,7 +680,7 @@ def view(args):
             definition["diff"] = False
 
     # save YAML
-    with open(os.path.join(public_directory, YAML_FILE_NAME), "w") as file:
+    with open(os.path.join(data_directory, YAML_FILE_NAME), "w") as file:
         yaml.dump(yaml_result, file, sort_keys=False)
 
     if args.devel:
@@ -704,8 +699,6 @@ def view(args):
             except KeyboardInterrupt:
                 httpd.shutdown()
     # Cleaning
-    rmtree_without_parent(source_directory)
-    rmtree_without_parent(diff_directory)
-    # Cleaning content of yaml file.
-    with open(os.path.join(public_directory, YAML_FILE_NAME), "w"):
-        pass
+    shutil.rmtree(source_directory)
+    shutil.rmtree(diff_directory)
+    os.remove(os.path.join(data_directory, YAML_FILE_NAME))

--- a/diffkemp/diffkemp.py
+++ b/diffkemp/diffkemp.py
@@ -593,15 +593,15 @@ def view(args):
 
     # Determine the view_directory.
     # The manually built one has priority over the installed one.
-    # PUBLIC_DIRECTORY: Path to folder which viewer can access.
+    # public_directory: Path to folder which viewer can access.
     view_directory = os.path.join(os.path.dirname(__file__), "../view")
     # Manually build one
     if os.path.exists(view_directory):
         if args.devel:
-            PUBLIC_DIRECTORY = os.path.join(view_directory, "public")
+            public_directory = os.path.join(view_directory, "public")
         else:
-            PUBLIC_DIRECTORY = os.path.join(view_directory, "build")
-            if not os.path.isdir(PUBLIC_DIRECTORY):
+            public_directory = os.path.join(view_directory, "build")
+            if not os.path.isdir(public_directory):
                 sys.stderr.write(
                     "Could not find production build of the viewer.\n" +
                     "Use --devel to run a development server " +
@@ -610,7 +610,7 @@ def view(args):
     # Installed one
     elif os.path.exists(VIEW_INSTALL_DIR):
         view_directory = VIEW_INSTALL_DIR
-        PUBLIC_DIRECTORY = VIEW_INSTALL_DIR
+        public_directory = VIEW_INSTALL_DIR
         if args.devel:
             sys.stderr.write(
                 "Error: it is not possible to run the development server " +
@@ -623,13 +623,13 @@ def view(args):
         sys.exit(errno.ENOENT)
 
     # Preparing source directory
-    SOURCE_DIRECTORY = os.path.join(PUBLIC_DIRECTORY, "src")
-    if not os.path.exists(SOURCE_DIRECTORY):
-        os.mkdir(SOURCE_DIRECTORY)
+    source_directory = os.path.join(public_directory, "src")
+    if not os.path.exists(source_directory):
+        os.mkdir(source_directory)
     # Preparing diff directory
-    DIFF_DIRECTORY = os.path.join(PUBLIC_DIRECTORY, "diffs")
-    if not os.path.isdir(DIFF_DIRECTORY):
-        os.mkdir(DIFF_DIRECTORY)
+    diff_directory = os.path.join(public_directory, "diffs")
+    if not os.path.isdir(diff_directory):
+        os.mkdir(diff_directory)
 
     # Prepare source and diff files to view directory
     old_snapshot_dir = yaml_result["old-snapshot"]
@@ -657,7 +657,7 @@ def view(args):
         if old_file not in processed_files:
             processed_files.add(old_file)
 
-            output_file_path = os.path.join(SOURCE_DIRECTORY, old_file)
+            output_file_path = os.path.join(source_directory, old_file)
             output_dir_path = os.path.dirname(output_file_path)
             if not os.path.isdir(output_dir_path):
                 os.makedirs(output_dir_path)
@@ -677,14 +677,14 @@ def view(args):
                 definition["diff"] = False
             else:
                 definition["diff"] = True
-                diff_path = os.path.join(DIFF_DIRECTORY, name + ".diff")
+                diff_path = os.path.join(diff_directory, name + ".diff")
                 with open(diff_path, "w") as file:
                     file.write(diff)
         else:
             definition["diff"] = False
 
     # save YAML
-    with open(os.path.join(PUBLIC_DIRECTORY, YAML_FILE_NAME), "w") as file:
+    with open(os.path.join(public_directory, YAML_FILE_NAME), "w") as file:
         yaml.dump(yaml_result, file, sort_keys=False)
 
     if args.devel:
@@ -692,7 +692,7 @@ def view(args):
         os.system("npm install")
         os.system("npm start")
     else:
-        os.chdir(PUBLIC_DIRECTORY)
+        os.chdir(public_directory)
         handler = SimpleHTTPRequestHandler
         handler.log_message = lambda *_, **__: None
         with HTTPServer(("localhost", 3000), handler) as httpd:
@@ -703,8 +703,8 @@ def view(args):
             except KeyboardInterrupt:
                 httpd.shutdown()
     # Cleaning
-    rmtree_without_parent(SOURCE_DIRECTORY)
-    rmtree_without_parent(DIFF_DIRECTORY)
+    rmtree_without_parent(source_directory)
+    rmtree_without_parent(diff_directory)
     # Cleaning content of yaml file.
-    with open(os.path.join(PUBLIC_DIRECTORY, YAML_FILE_NAME), "w"):
+    with open(os.path.join(public_directory, YAML_FILE_NAME), "w"):
         pass

--- a/diffkemp/diffkemp.py
+++ b/diffkemp/diffkemp.py
@@ -571,6 +571,16 @@ def view(args):
     View the compare differences. Prepares files for the visualisation
     and runs viewer.
     """
+    def rmtree_without_parent(path):
+        """
+        Recursively removes files and dirs in `path` directory
+        without the parent dir.
+        """
+        for dirpath, dirnames, filenames in os.walk(path, topdown=False):
+            for dirname in dirnames:
+                os.rmdir(os.path.join(dirpath, dirname))
+            for filename in filenames:
+                os.remove(os.path.join(dirpath, filename))
     # Load yaml describing results
     YAML_FILE_NAME = "diffkemp-out.yaml"
     yaml_path = os.path.join(args.compare_output_dir, YAML_FILE_NAME)
@@ -692,3 +702,9 @@ def view(args):
                 httpd.serve_forever()
             except KeyboardInterrupt:
                 httpd.shutdown()
+    # Cleaning
+    rmtree_without_parent(SOURCE_DIRECTORY)
+    rmtree_without_parent(DIFF_DIRECTORY)
+    # Cleaning content of yaml file.
+    with open(os.path.join(PUBLIC_DIRECTORY, YAML_FILE_NAME), "w"):
+        pass

--- a/diffkemp/diffkemp.py
+++ b/diffkemp/diffkemp.py
@@ -614,14 +614,12 @@ def view(args):
 
     # Preparing source directory
     SOURCE_DIRECTORY = os.path.join(PUBLIC_DIRECTORY, "src")
-    if os.path.isdir(SOURCE_DIRECTORY):
-        shutil.rmtree(SOURCE_DIRECTORY)
-    os.mkdir(SOURCE_DIRECTORY)
+    if not os.path.exists(SOURCE_DIRECTORY):
+        os.mkdir(SOURCE_DIRECTORY)
     # Preparing diff directory
     DIFF_DIRECTORY = os.path.join(PUBLIC_DIRECTORY, "diffs")
-    if os.path.isdir(DIFF_DIRECTORY):
-        shutil.rmtree(DIFF_DIRECTORY)
-    os.mkdir(DIFF_DIRECTORY)
+    if not os.path.isdir(DIFF_DIRECTORY):
+        os.mkdir(DIFF_DIRECTORY)
 
     # Prepare source and diff files to view directory
     old_snapshot_dir = yaml_result["old-snapshot"]

--- a/view/src/App.jsx
+++ b/view/src/App.jsx
@@ -15,14 +15,18 @@
 //         - `DiffViewWrapper`: The visualisation of the selected function
 //                              made possible by react-diff-view package.
 
+import path from 'path-browserify';
 import ResultViewer from './components/ResultViewer';
+
+/** Directory which contains files necessary for a visualisation of results. */
+const DATA_DIR = 'data';
 
 /**
  * Returns Promise with content of the file as string.
  * @param {string} filePath Path to the file.
  */
 async function getFileWithAjax(filePath) {
-  const response = await fetch(filePath);
+  const response = await fetch(path.join(DATA_DIR, filePath));
   return response.text();
 }
 


### PR DESCRIPTION
This PR makes it possible to run the result viewer when DiffKemp is installed to system (see #277).

Build of the viewer is installed directly to `/var/lib/diffkemp/view/build`, originally I wanted to use `CMAKE_INSTALL_LOCALSTATEDIR`  (= `var`) variable, but the problem would be in locating the directory when running `diffkemp view` because the exact location would be dependant on `CMAKE_INSTALL_PREFIX` variable.

When DiffKemp is installed, `diffkemp view` runs `serve` directly via `npx`, the impact is that when first running `diffkemp view` the user will be asked if it is ok to install `serve` package (if it is not installed).

Also, I was thinking (probably overthinking) when copying src files of a compared project to `build` directory for the result viewer, if the copied files should not have read permission only for the user -- so it cannot be read by other users (for security reasons). Right now the copied files have the same permissions as the original ones.
