### PR TITLE
Release 0.5.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_policy(SET CMP0048 NEW)
 cmake_minimum_required(VERSION 3.5)
 project(diffkemp
-    VERSION 0.4.0)
+    VERSION 0.5.0)
 
 find_package(LLVM REQUIRED CONFIG)
 message(STATUS "Found LLVM ${LLVM_PACKAGE_VERSION}")

--- a/README.md
+++ b/README.md
@@ -238,6 +238,7 @@ order:
 - Tomáš Vojnar
 - Petr Šilling
 - Pavol Žáčik
+- Lukáš Petr
 - Tatiana Malecová
 - Jakub Rozek
 

--- a/docker/diffkemp-rpm-testing/Dockerfile
+++ b/docker/diffkemp-rpm-testing/Dockerfile
@@ -6,10 +6,10 @@
 #   docker build --build-arg REL=37 -t diffkemp-rpm-testing:f37 .
 #
 #   Testing RPM from Copr:
-#     docker run diffkemp-rpm-testing:f37
+#     docker run --network host diffkemp-rpm-testing:f37
 #
 #   Testing local RPM:
-#     docker run -v <dir-with-rpm>:/rpm --env DIFFKEMP_RPM=/rpm/<rpm-file> diffkemp-rpm-testing:f37
+#     docker run --network host -v <dir-with-rpm>:/rpm --env DIFFKEMP_RPM=/rpm/<rpm-file> diffkemp-rpm-testing:f37
 #
 ARG REL
 FROM fedora:$REL
@@ -37,10 +37,12 @@ RUN dnf install -y \
     xz
 RUN dnf copr enable -y viktormalik/diffkemp
 RUN git clone https://github.com/viktormalik/rhel-kernel-get.git && \
-    pip3 install -r rhel-kernel-get/requirements.txt
+    cd rhel-kernel-get && \
+    pip3 install -r requirements.txt && \
+    pip3 install .
 RUN mkdir kernel
-RUN /rhel-kernel-get/rhel-kernel-get.py 4.18.0-80.el8 --output-dir kernel --kabi
-RUN /rhel-kernel-get/rhel-kernel-get.py 4.18.0-147.el8 --output-dir kernel --kabi
+RUN rhel-kernel-get 8.0 --output-dir kernel --kabi
+RUN rhel-kernel-get 8.1 --output-dir kernel --kabi
 RUN mkdir snap
 RUN echo __alloc_pages_nodemask > list
 
@@ -48,6 +50,6 @@ ENV DIFFKEMP_RPM=diffkemp
 ENTRYPOINT dnf install -y $DIFFKEMP_RPM && \
     diffkemp build-kernel kernel/linux-4.18.0-80.el8 snap/80 list && \
     diffkemp build-kernel kernel/linux-4.18.0-147.el8 snap/147 list && \
-    diffkemp compare snap/80 snap/147 --stdout --show-diff && \
+    diffkemp compare snap/80 snap/147 && \
     /bin/bash
 

--- a/rpm/diffkemp.spec
+++ b/rpm/diffkemp.spec
@@ -1,5 +1,5 @@
 Name:           diffkemp
-Version:        0.4.0
+Version:        0.5.0
 Release:        1%{?dist}
 Summary:        A tool for analyzing semantic differences in C projects
 
@@ -18,7 +18,6 @@ Requires:       cscope
 Requires:       clang llvm-devel
 Requires:       make
 Requires:       diffutils
-Requires:       python3-setuptools
 
 %{?python_enable_dependency_generator}
 
@@ -38,14 +37,14 @@ PYTHONPATH=$PWD/rpython-0.2.1:$PWD/py-1.11.0:$PYTHONPATH
 export PYTHONPATH
 mkdir build
 # SimpLL (C++ part)
-%cmake -S . -B build -GNinja
+%cmake -S . -B build -GNinja -DBUILD_VIEWER=On
 %ninja_build -C build
 # Python part
 %py3_build
 
 
 %install
-# SimpLL (C++ part)
+# SimpLL (C++ part) + Viewer
 %ninja_install -C build
 mkdir -p %{buildroot}/%{_bindir}
 install -m 0755 bin/%{name} %{buildroot}/%{_bindir}/%{name}
@@ -70,9 +69,18 @@ tests/unit_tests/simpll/runTests
 # SimpLL (C++ part)
 %{_bindir}/%{name}
 %{_libdir}/libsimpll-lib.so
+# Viewer
+%{_sharedstatedir}/diffkemp/view/
 
 
 %changelog
+* Mon Sep 04 2023 Viktor Malik <vmalik@redhat.com> - 0.5.0-1
+- New web-based viewer of found differences
+- CLI options for built-in patterns
+- Improved logging and debugging
+- Support for LLVM 16
+- Move to C++17
+
 * Wed Nov 23 2022 Viktor Malik <vmalik@redhat.com> - 0.4.0-1
 - Reworked CLI interface (generate split into multiple commands)
 - New command for analysing any Makefile-based projects

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ import os
 import subprocess
 
 setup(name="diffkemp",
-      version="0.4.0",
+      version="0.5.0",
       description="A tool for semantic difference analysis of kernel functions",
       author="Viktor Malik",
       author_email="vmalik@redhat.com",


### PR DESCRIPTION
Changelog:
- New web-based viewer of found differences
- CLI options for built-in patterns
- Improved logging and debugging
- Support for LLVM 16
- Move to C++17

Also update `rpm/diffkemp-rpm-testing/Dockerfile` with recent changes of [rhel-kernel-get](https://github.com/viktormalik/rhel-kernel-get) and some tweaks to be able to test the result viewer.

Add @PLukas2018 (author of the result viewer) to contributors.
