### PR TITLE
Update name of rhel-kernel-get script

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,7 +43,7 @@ jobs:
           git clone https://github.com/viktormalik/rhel-kernel-get.git
           pip3 install -r rhel-kernel-get/requirements.txt
           for k in $KERNELS; do
-            rhel-kernel-get/rhel-kernel-get.py $k --output-dir kernel
+            rhel-kernel-get/rhel-kernel-get $k --output-dir kernel
           done
 
   build-and-test:

--- a/README.md
+++ b/README.md
@@ -221,7 +221,7 @@ The required configuration of each kernel can be done by running:
     make prepare
     make modules_prepare
     
-The [rhel-kernel-get.py](https://github.com/viktormalik/rhel-kernel-get) script can also be used
+The [rhel-kernel-get](https://github.com/viktormalik/rhel-kernel-get) script can also be used
 to download and configure the aforementioned kernels.
 
 The result viewer contains unit tests and integration tests


### PR DESCRIPTION
I discovered a few places where was used the old name (with `.py` extension) of `rhel-kernel-get` script, the most problematic is in `ci.yml`. This PR updates the name. 