### PR TITLE
SimpLL unit test improvements

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -135,7 +135,7 @@ jobs:
       - name: Run Unit Tests
         working-directory: ${{ github.workspace }}
         run: |
-          tests/unit_tests/simpll/runTests
+          build/tests/unit_tests/simpll/runTests
 
       - name: Run Regression Tests
         if: matrix.regression-tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -120,7 +120,7 @@ jobs:
         env: ${{ matrix.env }}
         working-directory: ${{ github.workspace }}/build
         shell: bash
-        run: cmake $GITHUB_WORKSPACE -GNinja -DSANITIZE_ADDRESS=${{ matrix.asan }}
+        run: cmake $GITHUB_WORKSPACE -GNinja -DSANITIZE_ADDRESS=${{ matrix.asan }} -DVENDOR_GTEST=On
 
       - name: Build
         env: ${{ matrix.env }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -132,10 +132,9 @@ jobs:
         working-directory: ${{ github.workspace }}
         run: pip3 install -e .
 
-      - name: Run Unit Tests
+      - name: Run SimpLL Unit Tests
         working-directory: ${{ github.workspace }}
-        run: |
-          build/tests/unit_tests/simpll/runTests
+        run: ninja test -C build
 
       - name: Run Regression Tests
         if: matrix.regression-tests

--- a/rpm/diffkemp.spec
+++ b/rpm/diffkemp.spec
@@ -56,7 +56,7 @@ pathfix.py -pni "%{__python3} %{py3_shbang_opts}" %{buildroot}%{_bindir}/diffkem
 
 %check
 # Run SimpLL unit tests
-tests/unit_tests/simpll/runTests
+build/tests/unit_tests/simpll/runTests
 
 
 %files

--- a/rpm/diffkemp.spec
+++ b/rpm/diffkemp.spec
@@ -56,7 +56,7 @@ pathfix.py -pni "%{__python3} %{py3_shbang_opts}" %{buildroot}%{_bindir}/diffkem
 
 %check
 # Run SimpLL unit tests
-build/tests/unit_tests/simpll/runTests
+%ninja_test -C build
 
 
 %files

--- a/tests/unit_tests/simpll/CMakeLists.txt
+++ b/tests/unit_tests/simpll/CMakeLists.txt
@@ -1,3 +1,5 @@
+OPTION(VENDOR_GTEST "Vendor Google Test libraries" OFF)
+if (${VENDOR_GTEST})
 # Download and unpack googletest at configure time
 configure_file(CMakeLists.txt.in googletest-download/CMakeLists.txt)
 execute_process(COMMAND "${CMAKE_COMMAND}" -G "${CMAKE_GENERATOR}" .
@@ -10,6 +12,7 @@ execute_process(COMMAND "${CMAKE_COMMAND}" --build .
 add_subdirectory("${CMAKE_CURRENT_BINARY_DIR}/googletest-src"
                  "${CMAKE_CURRENT_BINARY_DIR}/googletest-build"
                  EXCLUDE_FROM_ALL)
+ endif(${VENDOR_GTEST})
 
 # Disable RTTI to link with SimpLL correctly.
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fno-rtti -fvisibility=hidden")

--- a/tests/unit_tests/simpll/CMakeLists.txt
+++ b/tests/unit_tests/simpll/CMakeLists.txt
@@ -30,9 +30,6 @@ file(GLOB pass_tests passes/*.cpp)
 add_executable(runTests SimpLLTest.cpp DifferentialFunctionComparatorTest.cpp
                FieldAccessUtilsTest.cpp ${pass_tests})
 
-set_target_properties(runTests
-  PROPERTIES
-  RUNTIME_OUTPUT_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
 exec_program(llvm-config ARGS --libs irreader passes support OUTPUT_VARIABLE llvm_libs)
 exec_program(llvm-config ARGS --system-libs OUTPUT_VARIABLE system_libs)
 string(STRIP ${system_libs} system_libs)

--- a/tests/unit_tests/simpll/CMakeLists.txt
+++ b/tests/unit_tests/simpll/CMakeLists.txt
@@ -38,3 +38,9 @@ target_link_libraries(runTests gtest simpll-lib ${llvm_libs})
 if (NOT ${system_libs} STREQUAL "")
 	target_link_libraries(runTests gtest ${system_libs})
 endif()
+
+include(GoogleTest)
+gtest_discover_tests(runTests)
+add_custom_target(test
+  COMMAND ${CMAKE_CTEST_COMMAND} --output-on-failure
+  DEPENDS runTests)


### PR DESCRIPTION
While working on another feature (better development environment), a couple of small improvements for SimpLL unit tests popped up and I realized that they can be useful in general, so posting them straight away.

The list of improvements (see commits for details):
- make vendoring of GoogleTest optional via the `-DVENDOR_GTEST` option of CMake,
- move `runTests` binary back to its default location (i.e. inside the build directory),
- add a new target `ninja test` for conveniently running the unit tests.