### PR TITLE
Match PHI nodes on first use, not based on their order in a basic block

### DIFF
--- a/diffkemp/simpll/DifferentialFunctionComparator.cpp
+++ b/diffkemp/simpll/DifferentialFunctionComparator.cpp
@@ -1579,7 +1579,7 @@ int DifferentialFunctionComparator::cmpPHIs(const PHINode *PhiL,
         bool match = false;
         for (unsigned j = 0; j < PhiR->getNumIncomingValues(); ++j) {
             auto BBL_sn = sn_mapL[PhiL->getIncomingBlock(i)];
-            auto BBR_sn = sn_mapR[PhiR->getIncomingBlock(i)];
+            auto BBR_sn = sn_mapR[PhiR->getIncomingBlock(j)];
             if (BBL_sn == BBR_sn
                 && cmpValues(PhiL->getIncomingValue(i),
                              PhiR->getIncomingValue(j))

--- a/tests/regression/test_specs/rhel-80-81-patterns.yaml
+++ b/tests/regression/test_specs/rhel-80-81-patterns.yaml
@@ -8,10 +8,9 @@ custom_pattern_config:
 functions:
   ipmi_set_gets_events: equal
   vfree: equal
+  scnprintf: equal
 
 syntax_diffs:
-  - function: scnprintf
-    equal_symbol: NR_PAGEFLAGS
   - function: set_user_nice
     equal_symbol: dequeue_task
   - function: set_user_nice


### PR DESCRIPTION
After some refactorings, PHI nodes may get reordered. Currently, we do not handle this since PHI nodes are matched in the order in which they appear at the beginning of a basic block.

This simple PR solves the problem by using the following approach:
- During `cmpBasicBlocks`, all comparisons of PHI nodes are skipped.
- When a pair of PHI nodes is used for the first time (by some non-PHI instructions), it is matched.
- After all non-PHI instructions are compared, the matched pairs of PHI nodes are compared.

The PR also fixes a bug in `cmpPHIs` which could cause `cmpPHIs` to compare invalid pairs of PHI-incoming values/blocks. The bug caused the `scnprintf` function to be compared as non-equal between RHEL 8.0 and RHEL 8.1.


