### PR TITLE
CI speedup: move CScope db build to the cache-kernels job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,9 +27,19 @@ jobs:
           key: kernels-${{ env.KERNELS }}
           lookup-only: true
 
+      - name: Delete unused software
+        if: steps.kernel-cache.outputs.cache-hit != 'true'
+        # This is necessary for running CScope database build as it takes
+        # a lot of disk space and the runners die silently when out of space.
+        run: |
+          sudo rm -rf /usr/local/lib/android
+          sudo rm -rf /usr/share/dotnet
+          sudo rm -rf /opt/ghc
+          sudo rm -rf /opt/hostedtoolcache/CodeQL
+
       - name: Install Dependencies
         if: steps.kernel-cache.outputs.cache-hit != 'true'
-        run: sudo apt-get install gcc-7 libelf-dev
+        run: sudo apt-get install gcc-7 libelf-dev cscope
 
       - name: Set GCC Version for Kernel Builds
         if: steps.kernel-cache.outputs.cache-hit != 'true'
@@ -44,6 +54,7 @@ jobs:
           pip3 install -r rhel-kernel-get/requirements.txt
           for k in $KERNELS; do
             rhel-kernel-get/rhel-kernel-get $k --output-dir kernel
+            make -C kernel/linux-$k cscope
           done
 
   build-and-test:
@@ -77,6 +88,8 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: Delete unused software
+        # This is necessary for running CScope database build as it takes
+        # a lot of disk space and the runners die silently when out of space.
         run: |
           sudo rm -rf /usr/local/lib/android
           sudo rm -rf /usr/share/dotnet

--- a/tests/unit_tests/kernel_llvm_source_builder_test.py
+++ b/tests/unit_tests/kernel_llvm_source_builder_test.py
@@ -56,9 +56,17 @@ def test_find_llvm_with_symbol_use(builder):
 def test_build_cscope_database(builder):
     """Test building CScope database."""
     builder._build_cscope_database()
-    for file in ["cscope.files", "cscope.in.out", "cscope.out",
-                 "cscope.po.out"]:
-        assert os.path.isfile(os.path.join(builder.source_dir, file))
+    # Some files have alternative namings so check that at least one file in
+    # each group exists.
+    expected_files = [
+        ["cscope.files"],
+        ["cscope.out"],
+        ["cscope.in.out", "cscope.out.in"],
+        ["cscope.po.out", "cscope.out.po"]
+    ]
+    for files in expected_files:
+        assert any([os.path.isfile(os.path.join(builder.source_dir, file)) for
+                    file in files])
 
 
 @pytest.mark.parametrize("builder", versions, indirect=True)


### PR DESCRIPTION
When running regression tests on freshly downloaded kernels, it is usually very slow b/c it needs to build the CScope database for each used kernel version.
    
In CI, this is done for every job in the matrix, despite the fact that building CScope database does not depend on LLVM version.
    
To speed things up, this PR moves building of the CScope db to the 'cache-kernels' job which downloads and caches the kernels. This is done by running `make cscope` for each downloaded kernel.
    
Adding some comparison of CI runtimes below.
    
```
Current master:
- with cached kernels:    30m 56s
- without cached kernels: 43m 43s (11m 18s in cache-kernels)
    
This PR:
- with cached kernels:    19m 2s
- without cached kernels: 40m 8s (21m 4s in cache-kernels)
```
    
When considering some measurement errors, we can see that it takes roughly the same time when CI needs to refetch the kernels but there's a significant speedup when using pre-cached kernels.

This also required a small change in one unit test.