### PR TITLE
CI: fix rhel-kernel-get version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,6 +41,7 @@ jobs:
         run: |
           mkdir -p ${{ github.workspace }}/kernel
           git clone https://github.com/viktormalik/rhel-kernel-get.git
+          git -C rhel-kernel-get/ checkout v0.1
           pip3 install -r rhel-kernel-get/requirements.txt
           for k in $KERNELS; do
             rhel-kernel-get/rhel-kernel-get $k --output-dir kernel


### PR DESCRIPTION
[viktormalik/rhel-kernel-get](https://github.com/viktormalik/rhel-kernel-get) now has [v0.1](https://github.com/viktormalik/rhel-kernel-get/releases/tag/v0.1) released so let's use that in the CI. The advantage is that we can now develop rhel-kernel-get independently, without accidentally breaking DiffKemp's CI.