### PR TITLE
Extend statistics

### DIFF
--- a/diffkemp/cli.py
+++ b/diffkemp/cli.py
@@ -105,6 +105,10 @@ def make_argument_parser():
     compare_ap.add_argument("--report-stat",
                             help="report statistics of the analysis",
                             action="store_true")
+    compare_ap.add_argument("--extended-stat",
+                            help="report detailed statistics about the "
+                                 "analysis (may be more expensive to compute)",
+                            action="store_true")
     compare_ap.add_argument("--source-dirs",
                             nargs=2,
                             help="specify root dirs for the compared projects")

--- a/diffkemp/config.py
+++ b/diffkemp/config.py
@@ -111,6 +111,7 @@ class Config:
         custom_pattern_config=None,
         builtin_patterns=BuiltinPatterns(),
         print_asm_diffs=False,
+        extended_stat=False,
         verbosity=0,
         use_ffi=False,
         semdiff_tool=None,
@@ -125,6 +126,7 @@ class Config:
         :param custom_pattern_config: Valid custom pattern configuration.
         :param builtin_patterns: Configuration of built-in patterns.
         :param print_asm_diffs: Print assembly differences.
+        :param extended_stat: Gather extended statistics.
         :param verbosity: Verbosity level (currently boolean).
         :param use_ffi: Use Python FFI to call SimpLL.
         :param semdiff_tool: Tool to use for semantic diff.
@@ -138,6 +140,7 @@ class Config:
         self.custom_pattern_config = custom_pattern_config
         self.builtin_patterns = builtin_patterns
         self.print_asm_diffs = print_asm_diffs
+        self.extended_stat = extended_stat
         self.verbosity = verbosity
         self.use_ffi = use_ffi
 
@@ -187,6 +190,7 @@ class Config:
             builtin_patterns=builtin_patterns,
             output_llvm_ir=args.output_llvm_ir,
             print_asm_diffs=args.print_asm_diffs,
+            extended_stat=args.extended_stat,
             verbosity=args.verbose,
             use_ffi=not args.disable_simpll_ffi,
             semdiff_tool=args.semdiff_tool,

--- a/diffkemp/diffkemp.py
+++ b/diffkemp/diffkemp.py
@@ -495,12 +495,12 @@ def compare(args):
     if output_dir is not None and os.path.isdir(output_dir):
         print("Differences stored in {}/".format(output_dir))
 
-    if args.report_stat:
+    if args.report_stat or args.extended_stat:
         print("")
         print("Statistics")
         print("----------")
         result.stop_time = default_timer()
-        result.report_stat(args.show_errors)
+        result.report_stat(args.show_errors, args.extended_stat)
     return 0
 
 

--- a/diffkemp/semdiff/caching.py
+++ b/diffkemp/semdiff/caching.py
@@ -50,12 +50,17 @@ class ComparisonGraph:
             self.inst_cnt = (left.get("inst-cnt", 0), right.get("inst-cnt", 0))
             self.inst_equal_cnt = (left.get("inst-equal-cnt", 0),
                                    right.get("inst-equal-cnt", 0))
+            self.lines_cnt = (left.get("lines-cnt", 0),
+                              right.get("lines-cnt", 0))
 
         def compared_inst_cnt(self):
             return self.inst_cnt[0] + self.inst_cnt[1]
 
         def compared_inst_equal_cnt(self):
             return self.inst_equal_cnt[0] + self.inst_equal_cnt[1]
+
+        def compared_lines_cnt(self):
+            return self.lines_cnt[0] + self.lines_cnt[1]
 
     class Vertex:
         """

--- a/diffkemp/semdiff/result.py
+++ b/diffkemp/semdiff/result.py
@@ -243,6 +243,8 @@ class Result:
         compared = len(self.graph.vertices)
         compared_instructions = sum([v.stats.compared_inst_cnt() for v in
                                      self.graph.vertices.values()])
+        compared_lines = sum([v.stats.compared_lines_cnt() for v in
+                              self.graph.vertices.values()])
         equal_instructions = sum([v.stats.compared_inst_equal_cnt() for v
                                   in self.graph.vertices.values()])
         if compared_instructions > 0:
@@ -267,6 +269,7 @@ class Result:
             print("Elapsed time:            {:.2f} s".format(
                 self.stop_time - self.start_time))
         print("Functions compared:      {}".format(compared))
+        print("Lines compared:          {}".format(compared_lines))
         print("Instructions compared:   {}".format(compared_instructions))
         print("1:1 equal instructions:  {0} ({1:.0f}%)".format(
             equal_instructions, equal_percent))

--- a/diffkemp/semdiff/result.py
+++ b/diffkemp/semdiff/result.py
@@ -241,6 +241,14 @@ class Result:
 
         # Generate counts
         compared = len(self.graph.vertices)
+        compared_instructions = sum([v.stats.compared_inst_cnt() for v in
+                                     self.graph.vertices.values()])
+        equal_instructions = sum([v.stats.compared_inst_equal_cnt() for v
+                                  in self.graph.vertices.values()])
+        if compared_instructions > 0:
+            equal_percent = equal_instructions / compared_instructions * 100
+        else:
+            equal_percent = float('nan')
         total = len(unique_diffs)
         functions = len([r for r in unique_diffs
                          if r.res.first.diff_kind == "function"])
@@ -259,6 +267,10 @@ class Result:
             print("Elapsed time:            {:.2f} s".format(
                 self.stop_time - self.start_time))
         print("Functions compared:      {}".format(compared))
+        print("Instructions compared:   {}".format(compared_instructions))
+        print("1:1 equal instructions:  {0} ({1:.0f}%)".format(
+            equal_instructions, equal_percent))
+        print("")
         print("Total differences:       {}".format(total))
         if total == 0:
             return
@@ -273,8 +285,9 @@ class Result:
         print("Empty diffs:             {0} ({1:.0f}%)".format(empty,
               empty / total * 100))
 
-    def report_stat(self, show_errors=False):
+    def report_stat(self, show_errors=False, extended_stat=False):
         """Reports all statistics."""
         self.report_symbol_stat(show_errors)
-        print("")
-        self.report_object_stat()
+        if extended_stat:
+            print("")
+            self.report_object_stat()

--- a/diffkemp/simpll/Config.cpp
+++ b/diffkemp/simpll/Config.cpp
@@ -44,13 +44,14 @@ Config::Config(std::string FirstFunName,
                bool OutputLlvmIR,
                bool PrintAsmDiffs,
                bool PrintCallStacks,
+               bool ExtendedStat,
                int Verbosity)
         : FirstFunName(FirstFunName), SecondFunName(SecondFunName),
           First(FirstModule), Second(SecondModule), FirstOutFile(FirstOutFile),
           SecondOutFile(SecondOutFile), CacheDir(CacheDir),
           CustomPatternConfigPath(CustomPatternConfigPath), Patterns(Patterns),
           OutputLlvmIR(OutputLlvmIR), PrintAsmDiffs(PrintAsmDiffs),
-          PrintCallStacks(PrintCallStacks) {
+          PrintCallStacks(PrintCallStacks), ExtendedStat(ExtendedStat) {
     refreshFunctions();
 
     if (!Variable.empty()) {

--- a/diffkemp/simpll/Config.h
+++ b/diffkemp/simpll/Config.h
@@ -77,6 +77,8 @@ class Config {
     bool PrintAsmDiffs;
     // Show call stacks for non-equal functions
     bool PrintCallStacks;
+    // Track more advanced statistics (e.g. line count)
+    bool ExtendedStat;
 
     Config(std::string FirstFunName,
            std::string SecondFunName,
@@ -91,6 +93,7 @@ class Config {
            bool OutputLlvmIR = false,
            bool PrintAsmDiffs = true,
            bool PrintCallStacks = true,
+           bool ExtendedStat = false,
            int Verbosity = 0);
 
     // Constructor without module loading (for tests).

--- a/diffkemp/simpll/DifferentialFunctionComparator.cpp
+++ b/diffkemp/simpll/DifferentialFunctionComparator.cpp
@@ -724,6 +724,8 @@ void DifferentialFunctionComparator::undoLastInstCompare(
     sn_mapL.erase(&*InstL);
     sn_mapR.erase(&*InstR);
     mappedValuesBySn.erase(sn_mapL.size());
+    ComparedInstL--;
+    ComparedInstR--;
 }
 
 /// Does additional comparisons based on the C source to determine whether two
@@ -835,10 +837,14 @@ int DifferentialFunctionComparator::cmpBasicBlocks(
         // been analyzed by the pattern function comparator and have already
         // been mapped according to the pattern.
         if (isPartOfPattern(&*InstL) || isPartOfPattern(&*InstR)) {
-            while (InstL != InstLE && isPartOfPattern(&*InstL))
+            while (InstL != InstLE && isPartOfPattern(&*InstL)) {
                 InstL++;
-            while (InstR != InstRE && isPartOfPattern(&*InstR))
+                ComparedInstL++;
+            }
+            while (InstR != InstRE && isPartOfPattern(&*InstR)) {
                 InstR++;
+                ComparedInstR++;
+            }
             continue;
         }
 
@@ -963,6 +969,8 @@ int DifferentialFunctionComparator::cmpBasicBlocks(
             if (Res)
                 return Res;
         } else {
+            InstEqual++;
+
             if (Reloc.status == RelocationInfo::Stored) {
                 // If there is a dependency between the skipped instruction and
                 // the relocated code, fail the comparison
@@ -1605,6 +1613,9 @@ int DifferentialFunctionComparator::cmpPHIs(const PHINode *PhiL,
 int DifferentialFunctionComparator::cmpOperationsWithOperands(
         const Instruction *L, const Instruction *R) const {
     PREP_LOG("instruction", L, R);
+
+    ComparedInstR++;
+    ComparedInstL++;
 
     // Contains code copied out of the original cmpBasicBlocks since it is more
     // convenient to have the code in a separate function.

--- a/diffkemp/simpll/DifferentialFunctionComparator.cpp
+++ b/diffkemp/simpll/DifferentialFunctionComparator.cpp
@@ -856,6 +856,16 @@ int DifferentialFunctionComparator::cmpBasicBlocks(
             CurrentLocR = &InstR->getDebugLoc();
         else
             CurrentLocR = nullptr;
+        if (config.ExtendedStat) {
+            if (CurrentLocL && InstL->getDebugLoc().get())
+                ComparedLinesL.emplace(
+                        InstL->getDebugLoc()->getFilename().str(),
+                        InstL->getDebugLoc().getLine());
+            if (CurrentLocR && InstR->getDebugLoc().get())
+                ComparedLinesR.emplace(
+                        InstR->getDebugLoc()->getFilename().str(),
+                        InstR->getDebugLoc()->getLine());
+        }
 
         if (int Res = cmpOperationsWithOperands(&*InstL, &*InstR)) {
             // Detect a difference caused by a field access change that does

--- a/diffkemp/simpll/DifferentialFunctionComparator.h
+++ b/diffkemp/simpll/DifferentialFunctionComparator.h
@@ -62,6 +62,10 @@ class DifferentialFunctionComparator : public FunctionComparator {
     mutable unsigned ComparedInstR = 0;
     /// The number of instruction matching 1:1 when comparing F1 and F2.
     mutable unsigned InstEqual = 0;
+    /// A set containing pairs of (file, line number) that were compared in F1.
+    mutable std::set<std::pair<std::string, unsigned>> ComparedLinesL;
+    /// A set containing pairs of (file, line number) that were compared in F2.
+    mutable std::set<std::pair<std::string, unsigned>> ComparedLinesR;
 
   protected:
     /// Initialize relocation info

--- a/diffkemp/simpll/DifferentialFunctionComparator.h
+++ b/diffkemp/simpll/DifferentialFunctionComparator.h
@@ -56,6 +56,12 @@ class DifferentialFunctionComparator : public FunctionComparator {
     /// Storing pointers to instructions in which functions started to differ.
     mutable std::pair<const Instruction *, const Instruction *>
             DifferingInstructions;
+    /// The number of instructions compared in F1.
+    mutable unsigned ComparedInstL = 0;
+    /// The number of instructions compared in F2.
+    mutable unsigned ComparedInstR = 0;
+    /// The number of instruction matching 1:1 when comparing F1 and F2.
+    mutable unsigned InstEqual = 0;
 
   protected:
     /// Initialize relocation info

--- a/diffkemp/simpll/ModuleComparator.cpp
+++ b/diffkemp/simpll/ModuleComparator.cpp
@@ -27,8 +27,11 @@ void ModuleComparator::updateStats(
         Result &result, const DifferentialFunctionComparator &fComp) {
     result.First.stats.instCnt = fComp.ComparedInstL;
     result.First.stats.instEqualCnt = fComp.InstEqual;
+    result.First.stats.linesCnt = fComp.ComparedLinesL.size();
+
     result.Second.stats.instCnt = fComp.ComparedInstR;
     result.Second.stats.instEqualCnt = fComp.InstEqual;
+    result.Second.stats.linesCnt = fComp.ComparedLinesR.size();
 }
 
 /// Semantic comparison of functions.

--- a/diffkemp/simpll/ModuleComparator.cpp
+++ b/diffkemp/simpll/ModuleComparator.cpp
@@ -22,6 +22,15 @@
 #include <llvm/Support/raw_ostream.h>
 #include <llvm/Transforms/Utils/Cloning.h>
 
+/// Updates the statistics based on the results of function comparison.
+void ModuleComparator::updateStats(
+        Result &result, const DifferentialFunctionComparator &fComp) {
+    result.First.stats.instCnt = fComp.ComparedInstL;
+    result.First.stats.instEqualCnt = fComp.InstEqual;
+    result.Second.stats.instCnt = fComp.ComparedInstR;
+    result.Second.stats.instEqualCnt = fComp.InstEqual;
+}
+
 /// Semantic comparison of functions.
 /// Function declarations are equal if they have the same name.
 /// Functions with body are compared using custom FunctionComparator that
@@ -104,6 +113,7 @@ void ModuleComparator::compareFunctions(Function *FirstFun,
     DifferentialFunctionComparator fComp(
             FirstFun, SecondFun, config, DI, &CustomPatterns, this);
     int result = fComp.compare();
+    updateStats(ComparedFuns.at({FirstFun, SecondFun}), fComp);
 
     LOG_UNINDENT();
     if (result == 0) {
@@ -160,6 +170,7 @@ void ModuleComparator::compareFunctions(Function *FirstFun,
             DifferentialFunctionComparator fCompSecond(
                     FirstFun, SecondFun, config, DI, &CustomPatterns, this);
             result = fCompSecond.compare();
+            updateStats(ComparedFuns.at({FirstFun, SecondFun}), fCompSecond);
 
             // If the functions are equal after the inlining and there is a
             // call to the inlined function, mark it as weak.

--- a/diffkemp/simpll/ModuleComparator.h
+++ b/diffkemp/simpll/ModuleComparator.h
@@ -93,6 +93,9 @@ class ModuleComparator {
     InliningResult tryToInline(CallInst *InlinedCall,
                                Program program,
                                bool FunctionSplitsEnabled) const;
+
+    static void updateStats(Result &result,
+                            const DifferentialFunctionComparator &fComp);
 };
 
 #endif // DIFFKEMP_SIMPLL_MODULECOMPARATOR_H

--- a/diffkemp/simpll/Output.cpp
+++ b/diffkemp/simpll/Output.cpp
@@ -36,6 +36,18 @@ template <> struct MappingTraits<CallInfo> {
 // callees).
 LLVM_YAML_IS_SEQUENCE_VECTOR(CallInfo)
 
+// FunctionStats to YAML
+namespace llvm {
+namespace yaml {
+template <> struct MappingTraits<FunctionStats> {
+    static void mapping(IO &io, FunctionStats &functionStats) {
+        io.mapOptional("inst-cnt", functionStats.instCnt, 0);
+        io.mapOptional("inst-equal-cnt", functionStats.instEqualCnt, 0);
+    }
+};
+} // namespace yaml
+} // namespace llvm
+
 // FunctionInfo to YAML
 namespace llvm {
 namespace yaml {
@@ -45,6 +57,7 @@ template <> struct MappingTraits<FunctionInfo> {
         io.mapRequired("function", name);
         io.mapOptional("file", info.file);
         io.mapOptional("line", info.line, 0);
+        io.mapOptional("stats", info.stats);
         auto calls =
                 std::vector<CallInfo>(info.calls.begin(), info.calls.end());
         io.mapOptional("calls", calls);

--- a/diffkemp/simpll/Output.cpp
+++ b/diffkemp/simpll/Output.cpp
@@ -43,6 +43,7 @@ template <> struct MappingTraits<FunctionStats> {
     static void mapping(IO &io, FunctionStats &functionStats) {
         io.mapOptional("inst-cnt", functionStats.instCnt, 0);
         io.mapOptional("inst-equal-cnt", functionStats.instEqualCnt, 0);
+        io.mapOptional("lines-cnt", functionStats.linesCnt, 0);
     }
 };
 } // namespace yaml

--- a/diffkemp/simpll/Result.h
+++ b/diffkemp/simpll/Result.h
@@ -28,6 +28,7 @@ using namespace llvm;
 struct FunctionStats {
     unsigned instCnt = 0;
     unsigned instEqualCnt = 0;
+    unsigned linesCnt = 0;
 
     // Default constructor needed for YAML serialisation.
     FunctionStats() {}

--- a/diffkemp/simpll/Result.h
+++ b/diffkemp/simpll/Result.h
@@ -24,6 +24,15 @@
 
 using namespace llvm;
 
+/// Encapsulates statistics about analysis of a single function.
+struct FunctionStats {
+    unsigned instCnt = 0;
+    unsigned instEqualCnt = 0;
+
+    // Default constructor needed for YAML serialisation.
+    FunctionStats() {}
+};
+
 /// Type for function call information: contains the called function and its
 /// call location (file and line).
 struct CallInfo {
@@ -49,6 +58,7 @@ struct FunctionInfo {
     std::string name;
     std::string file;
     int line;
+    FunctionStats stats;
     std::set<CallInfo> calls;
 
     // Default constructor is needed for YAML serialisation so that the struct

--- a/diffkemp/simpll/SimpLL.cpp
+++ b/diffkemp/simpll/SimpLL.cpp
@@ -71,6 +71,10 @@ cl::opt<bool> PrintAsmDiffsOpt(
         cl::desc("Print raw differences in inline assembly code "
                  "(does not apply to macros)."),
         cl::cat(SimpLLCategory));
+cl::opt<bool> ExtendedStats("extended-stat",
+                            cl::desc("Track extended statistics "
+                                     "(may be more expensive to compute)."),
+                            cl::cat(SimpLLCategory));
 
 cl::OptionCategory BuiltinPatternsCategory("SimpLL pattern options",
                                            "Options for configuring built-in "
@@ -178,6 +182,7 @@ int main(int argc, const char **argv) {
                   OutputLlvmIROpt,
                   PrintAsmDiffsOpt,
                   PrintCallstacksOpt,
+                  ExtendedStats,
                   VerbosityOpt);
 
     // Run transformations and the comparison.

--- a/diffkemp/simpll/library/FFI.cpp
+++ b/diffkemp/simpll/library/FFI.cpp
@@ -254,6 +254,7 @@ void runSimpLL(void *ModL,
                   Conf.OutputLlvmIR,
                   Conf.PrintAsmDiffs,
                   Conf.PrintCallStacks,
+                  Conf.ExtendedStat,
                   Conf.Verbosity);
 
     OverallResult Result;

--- a/diffkemp/simpll/library/FFI.h
+++ b/diffkemp/simpll/library/FFI.h
@@ -44,6 +44,7 @@ struct config {
     int OutputLlvmIR;
     int PrintAsmDiffs;
     int PrintCallStacks;
+    int ExtendedStat;
     int Verbosity;
 };
 

--- a/diffkemp/simpll/simpll.py
+++ b/diffkemp/simpll/simpll.py
@@ -67,6 +67,7 @@ def run_simpll(first, second, fun_first, fun_second, var, config, suffix=None,
         conf_struct.BuiltinPatterns = builtin_patterns[0]
         conf_struct.OutputLlvmIR = config.output_llvm_ir
         conf_struct.PrintAsmDiffs = config.print_asm_diffs
+        conf_struct.ExtendedStat = config.extended_stat
         conf_struct.PrintCallStacks = True
         conf_struct.Verbosity = config.verbosity
         conf_struct.Variable = variable
@@ -154,6 +155,9 @@ def run_simpll(first, second, fun_first, fun_second, var, config, suffix=None,
 
             if config.print_asm_diffs:
                 simpll_command.append("--print-asm-diffs")
+
+            if config.extended_stat:
+                simpll_command.append("--extended-stat")
 
             if config.verbosity > 0:
                 simpll_command.extend(["--verbosity", str(config.verbosity)])


### PR DESCRIPTION
This PR adds the following statistics:
 - number of instructions compared
 - number of instructions where 1:1 comparison was used (i.e. semantic preserving pattern was not used)
 - number of C code lines analyzed

Tracking the lines analyzed requires a set and the calculations on top of this data-structure resulted in a 10 second (260 -> 270) increase when analyzing the RHEL KABI. This feels quite significant, therefore it has to be explicitly enabled using `--extended-stat` option. The other statistics are just simple counters, therefore, they are included in the base statistics.

Example output comparing RHEL8 kernels:
```
Lines compared:          36537
Instructions compared:   109760
1:1 equal instructions:  107380 (98%)
```