### PR TITLE
Introduce Nix-based builds and environments

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -121,8 +121,9 @@ jobs:
         if: matrix.regression-tests
         shell: bash
         run: >
-          nix develop .#diffkemp-llvm${{ matrix.llvm }} --command
-          pytest tests -v
+          nix develop .#diffkemp-llvm${{ matrix.llvm }} --command bash -c
+          "setuptoolsShellHook &&
+           pytest tests -v"
 
   code-style:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,8 +17,12 @@ env:
 
 jobs:
   cache-kernels:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v3
+      - uses: DeterminateSystems/nix-installer-action@v4
+      - uses: DeterminateSystems/magic-nix-cache-action@v2
+
       - name: Cache Linux Kernels
         id: kernel-cache
         uses: actions/cache@v3
@@ -37,30 +41,20 @@ jobs:
           sudo rm -rf /opt/ghc
           sudo rm -rf /opt/hostedtoolcache/CodeQL
 
-      - name: Install Dependencies
-        if: steps.kernel-cache.outputs.cache-hit != 'true'
-        run: sudo apt-get install gcc-7 libelf-dev cscope
-
-      - name: Set GCC Version for Kernel Builds
-        if: steps.kernel-cache.outputs.cache-hit != 'true'
-        run: sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-7 100
-
-      - name: Obtain Linux Kernels
+      - name: Get Linux Kernels
         if: steps.kernel-cache.outputs.cache-hit != 'true'
         working-directory: ${{ github.workspace }}
         run: |
-          mkdir -p ${{ github.workspace }}/kernel
-          git clone https://github.com/viktormalik/rhel-kernel-get.git
-          git -C rhel-kernel-get/ checkout v0.1
-          pip3 install -r rhel-kernel-get/requirements.txt
+          mkdir kernel
           for k in $KERNELS; do
-            rhel-kernel-get/rhel-kernel-get $k --output-dir kernel
-            make -C kernel/linux-$k cscope
+            nix develop .#test-kernel-buildenv --command bash -c \
+              "rhel-kernel-get $k --output-dir kernel && \
+               make -C kernel/linux-$k cscope"
           done
 
   build-and-test:
     needs: cache-kernels
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     strategy:
       matrix:
         llvm: [9, 10, 11, 12, 13, 14, 15, 16]
@@ -87,6 +81,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
+      - uses: DeterminateSystems/nix-installer-action@v4
+      - uses: DeterminateSystems/magic-nix-cache-action@v2
 
       - name: Delete unused software
         # This is necessary for running CScope database build as it takes
@@ -96,27 +92,6 @@ jobs:
           sudo rm -rf /usr/share/dotnet
           sudo rm -rf /opt/ghc
           sudo rm -rf /opt/hostedtoolcache/CodeQL
-
-      - name: Setup Python
-        uses: actions/setup-python@v4
-        with:
-          python-version: 3.9
-
-      - name: Install Dependencies
-        working-directory: ${{ github.workspace }}
-        shell: bash
-        run: |
-          sudo apt-get install bc cscope libelf-dev ninja-build
-          pip install -r requirements.txt
-
-      - name: Install LLVM
-        run: |
-          wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add -
-          sudo add-apt-repository "deb http://apt.llvm.org/focal/ llvm-toolchain-focal-${{ matrix.llvm }} main"
-          sudo apt-get update
-          sudo apt-get install llvm-${{ matrix.llvm }} llvm-${{ matrix.llvm }}-dev clang-${{ matrix.llvm }}
-          sudo ln -s /usr/lib/llvm-${{ matrix.llvm }} /usr/local/lib/llvm
-          echo "/usr/lib/llvm-${{ matrix.llvm }}/bin" >> $GITHUB_PATH
 
       - name: Restore Kernels
         uses: actions/cache/restore@v3
@@ -130,31 +105,24 @@ jobs:
         run: |
           mkdir -p ${{ github.workspace }}/build
 
-      - name: CMake
+      - name: Configure and Build
         env: ${{ matrix.env }}
-        working-directory: ${{ github.workspace }}/build
-        shell: bash
-        run: cmake $GITHUB_WORKSPACE -GNinja -DSANITIZE_ADDRESS=${{ matrix.asan }} -DVENDOR_GTEST=On
-
-      - name: Build
-        env: ${{ matrix.env }}
-        working-directory: ${{ github.workspace }}/build
-        run: ninja
-
-      - name: Install
-        env: ${{ matrix.env }}
-        working-directory: ${{ github.workspace }}
-        run: pip3 install -e .
+        run: >
+          nix develop .#diffkemp-llvm${{ matrix.llvm }} --command bash -c
+          "cmake -B build ${{ github.workspace }} -GNinja -DSANITIZE_ADDRESS=${{ matrix.asan }} &&
+           ninja -C build"
 
       - name: Run SimpLL Unit Tests
-        working-directory: ${{ github.workspace }}
-        run: ninja test -C build
+        run: >
+          nix develop .#diffkemp-llvm${{ matrix.llvm }} --command
+          ninja test -C build
 
-      - name: Run Regression Tests
+      - name: Run Tests
         if: matrix.regression-tests
-        working-directory: ${{ github.workspace }}
-        run: |
-          pytest tests
+        shell: bash
+        run: >
+          nix develop .#diffkemp-llvm${{ matrix.llvm }} --command
+          pytest tests -v
 
   code-style:
     runs-on: ubuntu-latest

--- a/.gitignore
+++ b/.gitignore
@@ -133,3 +133,6 @@ diff-*/
 
 # Debugger files
 .gdb_history
+
+# Nix
+result

--- a/README.md
+++ b/README.md
@@ -176,6 +176,8 @@ simplicity. SimpLL performs several important steps:
 
 ## Development
 
+### Docker
+
 For a better developer experience, there is a development container image
 prepared that can be retrieved from DockerHub:
 [https://hub.docker.com/r/viktormalik/diffkemp-devel/](https://hub.docker.com/r/viktormalik/diffkemp-devel/)
@@ -200,6 +202,44 @@ directory, you need to specify where DiffKemp is located using the
 
 By default, the DockerHub image is used, but a custom image may be set using
 the `--image` option.
+
+### Nix
+
+In addition to container environment, we provide [Nix
+flakes](https://nixos.wiki/wiki/Flakes) for building and testing DiffKemp.
+
+First, it is necessary to [install Nix](https://nixos.org/download.html) and
+enable flakes:
+```
+$ mkdir -p ~/.config/nix
+$ echo "experimental-features = nix-command flakes" >> ~/.config/nix/nix.conf
+```
+
+Then, building DiffKemp is as simple as running one of the following commands:
+```
+$ nix build                    # <- uses latest LLVM
+$ nix build .#diffkemp-llvm14
+```
+This will create a new folder `result/` containing the pre-built DiffKemp which
+can be then executed by:
+```
+$ result/bin/diffkemp ...
+```
+
+Similarly, it is also possible to use Nix as a development environment:
+```
+$ nix develop                   # <- uses latest LLVM
+$ nix develop .#diffkemp-llvm14
+```
+This will enter a development shell with all DiffKemp dependencies
+pre-installed. You can then follow the [standard build
+instructions](#install-from-source) to build and install DiffKemp. The only
+difference is that it is not possible to run `pip install` inside Nix shell
+(because of the way Nix works) and it is necessary to use the built-in
+`setuptoolsShellHook` function instead.
+
+We also provide a special Nix environment for retrieving and preparing kernel
+versions necessary for running regression tests (see below for details).
 
 ### Tests
 
@@ -228,6 +268,14 @@ The required configuration of each kernel can be done by running:
     
 The [rhel-kernel-get](https://github.com/viktormalik/rhel-kernel-get) script can also be used
 to download and configure the aforementioned kernels.
+
+Since CentOS 7 kernels require a rather old GCC 7, the most convenient way to
+download the kernels is to use the prepared Nix environment by running
+```
+$ nix develop .#test-kernel-buildenv
+```
+and using `rhel-kernel-get` inside the environment to retrieve the above
+kernels.
 
 The result viewer contains unit tests and integration tests
 which can be run by:

--- a/diffkemp/building/CMakeLists.txt
+++ b/diffkemp/building/CMakeLists.txt
@@ -1,26 +1,29 @@
-# Try to find RPython as:
-# - standalone executable (rpython)
-# - Python2 module (python2 -m rpython)
-find_program(RPYTHON rpython)
-if (NOT RPYTHON)
-  execute_process(COMMAND python2 -m rpython --help
-                  RESULT_VARIABLE HAVE_RPYTHON_MODULE
-                  OUTPUT_QUIET ERROR_QUIET)
-  if (${HAVE_RPYTHON_MODULE} EQUAL 0)
-    set(RPYTHON python2 -m rpython)
-  endif ()
-endif ()
 set(CC_WRAPPER_SOURCE "${CMAKE_SOURCE_DIR}/diffkemp/building/cc_wrapper.py")
 add_custom_target(cc-wrapper-source ALL DEPENDS ${CC_WRAPPER_SOURCE})
 install(PROGRAMS ${CC_WRAPPER_SOURCE} RENAME diffkemp-cc-wrapper.py DESTINATION ${CMAKE_INSTALL_BINDIR})
-if (NOT RPYTHON)
-  message(WARNING "RPython not found, not building compiler wrapper")
-else ()
-  set(CC_WRAPPER "${CMAKE_BINARY_DIR}/cc_wrapper-c")
-  add_custom_target(cc-wrapper ALL DEPENDS ${CC_WRAPPER})
-  add_custom_command(OUTPUT ${CC_WRAPPER}
-                     DEPENDS ${CC_WRAPPER_SOURCE}
-                     COMMAND ${RPYTHON} ${CC_WRAPPER_SOURCE} "--output=${CC_WRAPPER}"
-                     WORKING_DIRECTORY ${CMAKE_BINARY_DIR})
-  install(PROGRAMS ${CC_WRAPPER} RENAME diffkemp-cc-wrapper DESTINATION ${CMAKE_INSTALL_BINDIR})
+
+# Try to find RPython as:
+# - standalone executable (rpython)
+# - Python2 module (python2 -m rpython)
+if (NOT DEFINED ENV{WITHOUT_RPYTHON})
+  find_program(RPYTHON rpython)
+  if (NOT RPYTHON)
+    execute_process(COMMAND python2 -m rpython --help
+                    RESULT_VARIABLE HAVE_RPYTHON_MODULE
+                    OUTPUT_QUIET ERROR_QUIET)
+    if (${HAVE_RPYTHON_MODULE} EQUAL 0)
+      set(RPYTHON python2 -m rpython)
+    endif ()
+  endif ()
+  if (NOT RPYTHON)
+    message(WARNING "RPython not found, not building compiler wrapper")
+  else ()
+    set(CC_WRAPPER "${CMAKE_BINARY_DIR}/cc_wrapper-c")
+    add_custom_target(cc-wrapper ALL DEPENDS ${CC_WRAPPER})
+    add_custom_command(OUTPUT ${CC_WRAPPER}
+                       DEPENDS ${CC_WRAPPER_SOURCE}
+                       COMMAND ${RPYTHON} ${CC_WRAPPER_SOURCE} "--output=${CC_WRAPPER}"
+                       WORKING_DIRECTORY ${CMAKE_BINARY_DIR})
+    install(PROGRAMS ${CC_WRAPPER} RENAME diffkemp-cc-wrapper DESTINATION ${CMAKE_INSTALL_BINDIR})
+  endif ()
 endif ()

--- a/diffkemp/llvm_ir/kernel_llvm_source_builder.py
+++ b/diffkemp/llvm_ir/kernel_llvm_source_builder.py
@@ -345,7 +345,8 @@ class KernelLlvmSourceBuilder(LlvmSourceFinder):
         """
         output_file = None
         command = ["clang", "-S", "-emit-llvm", "-O1", "-Xclang",
-                   "-disable-llvm-passes", "-g", "-fdebug-macro"]
+                   "-disable-llvm-passes", "-g", "-fdebug-macro",
+                   "-Wno-format-security"]
         for param in gcc_command.split():
             if (param == "gcc" or
                     (param.startswith("-W") and "-MD" not in param) or

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,27 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1694761223,
+        "narHash": "sha256-F6tsKD2V6FpG1aiGgttEKKjPodRy3Uu2kufqVs5GCS8=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "d728a45aa5c68f8f819bf7b65633ef120baabdfa",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "release-23.05",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -55,5 +55,45 @@
             install -m 0755 bin/diffkemp $out/bin/diffkemp
           '';
         };
+
+      devShells.${system} = {
+        default = with pkgs;
+          let
+            rhel_kernel_get = python3Packages.buildPythonApplication {
+              pname = "rhel-kernel-get";
+              version = "0.1";
+              src = fetchFromGitHub {
+                owner = "viktormalik";
+                repo = "rhel-kernel-get";
+                rev = "v0.1";
+                sha256 = "0ci5hdkzc2aq7s8grnkqc9ni7zajyndj7b9r5fqqxvbjqvm7lqi7";
+              };
+              propagatedBuildInputs = [ python3Packages.progressbar ];
+            };
+          in
+          mkShell {
+            inputsFrom = [ self.packages.${system}.default ];
+
+            buildInputs = [
+              bc
+              bison
+              bzip2
+              cpio
+              flex
+              gdb
+              gmp
+              kmod
+              openssl
+              rhel_kernel_get
+              rpm
+              xz
+            ];
+
+            propagatedBuildInputs = with python3Packages; [
+              pytest
+              pytest-mock
+            ];
+          };
+      };
     };
 }

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,59 @@
+{
+  description = "Static analyser of semantic differences in large C projects";
+
+  inputs = { nixpkgs.url = "github:NixOS/nixpkgs/release-23.05"; };
+
+  outputs = { self, nixpkgs, ... }:
+    let
+      system = "x86_64-linux";
+      pkgs = import nixpkgs { inherit system; };
+    in
+    {
+      formatter.${system} = pkgs.nixpkgs-fmt;
+
+      packages.${system}.default = with pkgs;
+        python3Packages.buildPythonPackage {
+          pname = "diffkemp";
+          version = "0.5.0";
+
+          src = self;
+
+          nativeBuildInputs = with llvmPackages_16; [ cmake gcc libllvm ninja ];
+
+          buildInputs = with llvmPackages_16; [
+            clangNoLibcxx
+            cscope
+            diffutils
+            gtest
+            gnumake
+          ];
+
+          propagatedBuildInputs = with python3Packages; [
+            cffi
+            pyyaml
+            setuptools
+          ];
+
+          # Including cmake in nativeBuildInputs automatically runs it during
+          # configurePhase so we just need to set correct flags.
+          cmakeFlags = [ "-DCMAKE_BUILD_TYPE=Debug" "-GNinja" ];
+
+          # We're mixing Ninja and Python build here so we need to manually define
+          # buildPhase and installPhase to make sure both are built. CMake has
+          # switched dir to build/ so let's switch back and define ninjaFlags.
+          ninjaFlags = [ "-C" "build" ];
+
+          buildPhase = ''
+            cd ..
+            ninjaBuildPhase
+            setuptoolsBuildPhase
+          '';
+
+          installPhase = ''
+            ninjaInstallPhase
+            pipInstallPhase
+            install -m 0755 bin/diffkemp $out/bin/diffkemp
+          '';
+        };
+    };
+}

--- a/flake.nix
+++ b/flake.nix
@@ -33,6 +33,8 @@
               setuptools
             ];
 
+            WITHOUT_RPYTHON = true;
+
             # Including cmake in nativeBuildInputs automatically runs it during
             # configurePhase so we just need to set correct flags.
             cmakeFlags = [ "-DCMAKE_BUILD_TYPE=Debug" "-GNinja" ];
@@ -94,6 +96,8 @@
               pytest
               pytest-mock
             ];
+
+            WITHOUT_RPYTHON = true;
 
             # Running setuptoolsShellHook by default is confusing because it
             # will fail if SimpLL hasn't been built before.
@@ -169,6 +173,8 @@
             ];
 
             propagatedBuildInputs = default.propagatedBuildInputs;
+
+            WITHOUT_RPYTHON = true;
 
             dontUseSetuptoolsShellHook = true;
           };

--- a/flake.nix
+++ b/flake.nix
@@ -21,7 +21,13 @@
 
             src = self;
 
-            nativeBuildInputs = with llvmPackages; [ cmake gcc libllvm ninja ];
+            nativeBuildInputs = with llvmPackages; [
+              cmake
+              gcc
+              libllvm
+              ninja
+              nodejs_20
+            ];
 
             buildInputs = with llvmPackages; [
               clangNoLibcxx

--- a/flake.nix
+++ b/flake.nix
@@ -94,6 +94,19 @@
               pytest
               pytest-mock
             ];
+
+            # Running setuptoolsShellHook by default is confusing because it
+            # will fail if SimpLL hasn't been built before.
+            dontUseSetuptoolsShellHook = true;
+
+            # On the other hand, we want to allow running it from CLI using
+            # `nix develop --command bash -c setuptoolsShellHook` inside CI.
+            # This is normally not possible (as setuptoolsShellHook is a Bash
+            # function) so we workaround this with the below hack which exports
+            # the function (and all functions it uses) as commands.
+            shellHook = ''
+              export -f setuptoolsShellHook runHook _eval _callImplicitHook
+            '';
           };
     in
     {


### PR DESCRIPTION
This introduces new build and development environments based on [Nix flakes](https://nixos.wiki/wiki/Flakes). In short, Nix is a package manager with focus on replicability and consistency.

This provides several Nix flakes:
- Flake for building DiffKemp with `nix build` or `nix build .#diffkemp-llvm14` for building with a specific LLVM version. This creates a new directory `result/` containing DiffKemp with all dependencies managed by Nix. You can then run it with `result/bin/diffkemp ...`.
- Flake for development environment which can be entered by `nix develop` or `nix develop .#diffkemp-llvm14` (or any other supported LLVM version). This enters a new shell with all dependencies required for building and running DiffKemp, as well as dependencies for building and analysing reasonably modern Linux kernels.
- Flake for development environment suitable for building CentOS 7 kernels which are needed for regression tests. Can be entered by `nix develop .#test-kernel-buildenv`.

The main aim is to replace the Docker container as the default development environment. The workflow with Nix is:

1. Install Nix (see instructions in updated README).
2. Download kernels for tests:
```
[localhost]$ nix develop .#test-kernel-buildenv
[test-kernel-buildenv]$ rhel-kernel-get 3.10.0-514.el7 --output-dir kernel --kabi
[...] # repeat for all necessary kernels
[test-kernel-buildenv]$ exit
```
3. Build DiffKemp and run tests, either in the development flake or even on localhost (I believe that the latter requires the same version of glibc as is in Nix).
```
[localhost]$ nix develop        # sometimes not even necessary
[diffkemp-llvm16/localhost]$    # build DiffKemp
[diffkemp-llvm16/localhost]$ pytest tests
```
I'd love if someone could try and confirm that this works.

See commit messages for more implementation details.

I've also update CI to use Nix. The advantage is that we no longer depend on Ubuntu 20.04 which was the last version featuring GCC 7 necessary for building kernels for tests. Another big advantage is that the CI should be now deterministic and fully replicable, and therefore much easier to debug. The disadvantage is that tests runtime with Nix is remarkably slower, CI running 30+ minutes with caching (roughly the same time before #291. I'll try to debug that but I feel like the advantages slightly overrule the slowdown in this case.