### PR TITLE
Built-in pattern matching reordered commutative operations

### DIFF
--- a/diffkemp/cli.py
+++ b/diffkemp/cli.py
@@ -151,7 +151,8 @@ def make_argument_parser():
                         "relocations",
                         "type-casts",
                         "control-flow-only",
-                        "inverse-conditions"]
+                        "inverse-conditions",
+                        "reordered-bin-ops"]
 
     # Semantic patterns options.
     compare_ap.add_argument("--enable-pattern",

--- a/diffkemp/config.py
+++ b/diffkemp/config.py
@@ -22,6 +22,7 @@ class BuiltinPatterns:
         type_casts=False,
         control_flow_only=False,
         inverse_conditions=True,
+        reordered_bin_ops=True,
     ):
         """
         Create a configuration of built-in patterns.
@@ -39,6 +40,7 @@ class BuiltinPatterns:
         :param type_casts: Changes in type casts.
         :param control_flow_only: Consider control-flow changes only.
         :param inverse_conditions: Inverted branch conditions.
+        :param reordered_bin_ops: Match reordered binary operations.
         """
         self.settings = {
             "struct-alignment": struct_alignment,
@@ -51,6 +53,7 @@ class BuiltinPatterns:
             "type-casts": type_casts,
             "control-flow-only": control_flow_only,
             "inverse-conditions": inverse_conditions,
+            "reordered-bin-ops": reordered_bin_ops,
         }
         self.resolve_dependencies()
 
@@ -97,6 +100,7 @@ class BuiltinPatterns:
         ffi_struct.TypeCasts = self.settings["type-casts"]
         ffi_struct.ControlFlowOnly = self.settings["control-flow-only"]
         ffi_struct.InverseConditions = self.settings["inverse-conditions"]
+        ffi_struct.ReorderedBinOps = self.settings["reordered-bin-ops"]
         return ffi_struct
 
 

--- a/diffkemp/simpll/Config.h
+++ b/diffkemp/simpll/Config.h
@@ -37,6 +37,7 @@ struct BuiltinPatterns {
     bool TypeCasts = false;
     bool ControlFlowOnly = false;
     bool InverseConditions = true;
+    bool ReorderedBinOps = true;
 };
 
 /// Tool configuration parsed from CLI options.

--- a/diffkemp/simpll/DifferentialFunctionComparator.h
+++ b/diffkemp/simpll/DifferentialFunctionComparator.h
@@ -148,7 +148,9 @@ class DifferentialFunctionComparator : public FunctionComparator {
     mutable std::vector<std::pair<const PHINode *, const PHINode *>>
             phisToCompare;
     mutable std::unordered_map<const Value *, const Value *>
-            ignoredInstructions;
+            replacedInstructions;
+    mutable std::unordered_set<const Value *> ignoredInstructions;
+
     /// Contains pairs of values mapped by synchronisation maps. Enables
     /// retrieval of mapped values based on assigned numbers.
     mutable std::unordered_map<int, std::pair<const Value *, const Value *>>

--- a/diffkemp/simpll/DifferentialFunctionComparator.h
+++ b/diffkemp/simpll/DifferentialFunctionComparator.h
@@ -230,6 +230,11 @@ class DifferentialFunctionComparator : public FunctionComparator {
     /// ignorable loads are stored inside the ignored instructions map.
     bool maySkipLoad(const LoadInst *Load) const;
 
+    /// Check whether the given reorderable binary operator can be skipped.
+    /// It can only be skipped if all its users are binary operations
+    /// of the same kind.
+    bool maySkipReorderableBinaryOp(const Instruction *Op) const;
+
     /// Retrive the replacement for the given value from the ignored
     /// instructions map. Try to generate the replacement if a bitcast is given.
     const Value *
@@ -265,6 +270,15 @@ class DifferentialFunctionComparator : public FunctionComparator {
     /// (any instruction within it) access the same pointer and one of the
     /// accesses is a store and the other one is a load.
     bool isDependingOnReloc(const Instruction &Inst) const;
+
+    /// Recursively collect operands of reorderable binary operators.
+    /// Leafs must be constants or already synchronized values.
+    /// Return false if a non-synchronized non-constant leaf is found.
+    bool collectBinaryOperands(const Value *Val,
+                               Instruction::BinaryOps Opcode,
+                               std::multiset<int> &SNs,
+                               std::multiset<int64_t> &Constants,
+                               DenseMap<const Value *, int> &sn_map) const;
 };
 
 #endif // DIFFKEMP_SIMPLL_DIFFERENTIALFUNCTIONCOMPARATOR_H

--- a/diffkemp/simpll/SimpLL.cpp
+++ b/diffkemp/simpll/SimpLL.cpp
@@ -111,6 +111,10 @@ cl::opt<bool>
         InverseConditionsOpt("inverse-conditions",
                              cl::desc("Enable inverse conditions pattern."),
                              cl::cat(BuiltinPatternsCategory));
+cl::opt<bool> ReorderedBinOpsOpt(
+        "reordered-bin-ops",
+        cl::desc("Enable reordered binary operations pattern."),
+        cl::cat(BuiltinPatternsCategory));
 
 /// Add suffix to the file name.
 /// \param File Original file name.
@@ -157,7 +161,8 @@ int main(int argc, const char **argv) {
                              .Relocations = RelocationsOpt,
                              .TypeCasts = TypeCastsOpt,
                              .ControlFlowOnly = ControlFlowOnlyOpt,
-                             .InverseConditions = InverseConditionsOpt};
+                             .InverseConditions = InverseConditionsOpt,
+                             .ReorderedBinOps = ReorderedBinOpsOpt};
 
     // Parse --fun option
     auto FunName = parseFunOption();

--- a/diffkemp/simpll/Utils.cpp
+++ b/diffkemp/simpll/Utils.cpp
@@ -260,7 +260,9 @@ bool isLogicalNot(const Instruction *Inst) {
 /// Get value of the given constant as a string
 std::string valueAsString(const Constant *Val) {
     if (auto *IntVal = dyn_cast<ConstantInt>(Val)) {
-        return std::to_string(IntVal->getSExtValue());
+        SmallString<16> StrVal;
+        IntVal->getValue().toString(StrVal, 10, true);
+        return StrVal.str().str();
     }
     return "";
 }

--- a/diffkemp/simpll/Utils.h
+++ b/diffkemp/simpll/Utils.h
@@ -106,6 +106,11 @@ bool isZeroGEP(const Value *Val);
 /// Returns true if the given instruction is a boolean negation operation
 bool isLogicalNot(const Instruction *Inst);
 
+/// Returns true if the given instruction is a reorderable binary operation,
+/// i.e., it is commutative and associative. Note that IEEE 754 floating-point
+/// addition/multiplication is NOT associative.
+bool isReorderableBinaryOp(const Instruction *Inst);
+
 /// Run simplification passes on the function
 ///  - simplify CFG
 ///  - dead code elimination

--- a/diffkemp/simpll/library/FFI.cpp
+++ b/diffkemp/simpll/library/FFI.cpp
@@ -72,6 +72,7 @@ BuiltinPatterns BuiltinPatternsFromC(builtin_patterns PatternsC) {
             .TypeCasts = (bool)PatternsC.TypeCasts,
             .ControlFlowOnly = (bool)PatternsC.ControlFlowOnly,
             .InverseConditions = (bool)PatternsC.InverseConditions,
+            .ReorderedBinOps = (bool)PatternsC.ReorderedBinOps,
     };
 }
 

--- a/diffkemp/simpll/library/FFI.h
+++ b/diffkemp/simpll/library/FFI.h
@@ -34,6 +34,7 @@ struct builtin_patterns {
     int TypeCasts;
     int ControlFlowOnly;
     int InverseConditions;
+    int ReorderedBinOps;
 };
 
 struct config {


### PR DESCRIPTION
This PR adds a pattern that can match reordered commutative binary instructions, such as:
```llvm
;old
%tmp = add i8 0,    i8 1
%res = add i8 %tmp, i8 2
;new
%tmp = add i8 1,    i8 2
%res = add i8 %tmp, i8 0
```
I also fixed two minor issues that would sometimes lead to problems for this pattern and for the upcoming structure refactoring pattern; see commit messages for details.

I assume that this pattern can be safely removed once such refactorings are covered with an SMT solver.

Tests should cover the most basic use cases.