### PR TITLE
Do not skip current instruction when matching custom patterns

### DIFF
--- a/diffkemp/simpll/CustomPatternComparator.cpp
+++ b/diffkemp/simpll/CustomPatternComparator.cpp
@@ -236,3 +236,43 @@ void CustomPatternComparator::processPatternMatch(
         AllInstMatches.insert(InstPair.second);
     }
 }
+
+/// Populate the comparator maps with a given set of patterns.
+void CustomPatternComparator::addPatternSet(const CustomPatternSet *PatternSet,
+                                            const llvm::Function *FnL,
+                                            const llvm::Function *FnR) {
+    for (auto &InstPattern : PatternSet->InstPatterns) {
+        addInstPattern(InstPattern, FnL, FnR);
+    }
+    for (auto &ValuePattern : PatternSet->ValuePatterns) {
+        addValuePattern(ValuePattern, FnL, FnR);
+    }
+}
+
+/// Add an instruction pattern to the instruction pattern comparator map.
+void CustomPatternComparator::addInstPattern(const InstPattern &Pattern,
+                                             const Function *FnL,
+                                             const Function *FnR) {
+    auto PatternFunCompL = std::make_unique<InstPatternComparator>(
+            FnL, Pattern.PatternL, &Pattern);
+    auto PatternFunCompR = std::make_unique<InstPatternComparator>(
+            FnR, Pattern.PatternR, &Pattern);
+
+    InstPatternComps.try_emplace(&Pattern,
+                                 std::make_pair(std::move(PatternFunCompL),
+                                                std::move(PatternFunCompR)));
+}
+
+/// Add a value pattern to the value pattern comparator map.
+void CustomPatternComparator::addValuePattern(const ValuePattern &Pattern,
+                                              const Function *FnL,
+                                              const Function *FnR) {
+    auto PatternFunCompL = std::make_unique<ValuePatternComparator>(
+            FnL, Pattern.PatternL, &Pattern);
+    auto PatternFunCompR = std::make_unique<ValuePatternComparator>(
+            FnR, Pattern.PatternR, &Pattern);
+
+    ValuePatternComps.try_emplace(&Pattern,
+                                  std::make_pair(std::move(PatternFunCompL),
+                                                 std::move(PatternFunCompR)));
+}

--- a/diffkemp/simpll/CustomPatternComparator.h
+++ b/diffkemp/simpll/CustomPatternComparator.h
@@ -43,29 +43,7 @@ class CustomPatternComparator {
             const Function *FnL,
             const Function *FnR)
             : DiffFunctionComp(DiffFunctionComp) {
-        // Populate both pattern function comparator maps.
-        for (auto &InstPattern : Patterns->InstPatterns) {
-            auto PatternFunCompL = std::make_unique<InstPatternComparator>(
-                    FnL, InstPattern.PatternL, &InstPattern);
-            auto PatternFunCompR = std::make_unique<InstPatternComparator>(
-                    FnR, InstPattern.PatternR, &InstPattern);
-
-            InstPatternComps.try_emplace(
-                    &InstPattern,
-                    std::make_pair(std::move(PatternFunCompL),
-                                   std::move(PatternFunCompR)));
-        }
-        for (auto &ValuePattern : Patterns->ValuePatterns) {
-            auto PatternFunCompL = std::make_unique<ValuePatternComparator>(
-                    FnL, ValuePattern.PatternL, &ValuePattern);
-            auto PatternFunCompR = std::make_unique<ValuePatternComparator>(
-                    FnR, ValuePattern.PatternR, &ValuePattern);
-
-            ValuePatternComps.try_emplace(
-                    &ValuePattern,
-                    std::make_pair(std::move(PatternFunCompL),
-                                   std::move(PatternFunCompR)));
-        }
+        addPatternSet(Patterns, FnL, FnR);
     };
 
     /// Individual matched instructions, combined for all matched patterns.
@@ -83,6 +61,11 @@ class CustomPatternComparator {
     /// Tries to match a pair of values to a value pattern. Returns true if a
     /// valid match is found.
     bool matchValues(const Value *L, const Value *R);
+
+    /// Populate the comparator maps with a given set of patterns.
+    void addPatternSet(const CustomPatternSet *PatternSet,
+                       const Function *FnL,
+                       const Function *FnR);
 
   private:
     /// Pair of corresponding instruction pattern function comparators.
@@ -103,6 +86,16 @@ class CustomPatternComparator {
     /// patterns and the currently compared functions.
     DenseMap<const ValuePattern *, ValuePatternComparatorPair>
             ValuePatternComps;
+
+    /// Add an instruction pattern to the instruction pattern comparator map.
+    void addInstPattern(const InstPattern &Pattern,
+                        const Function *FnL,
+                        const Function *FnR);
+
+    /// Add a value pattern to the value pattern comparator map.
+    void addValuePattern(const ValuePattern &Pattern,
+                         const Function *FnL,
+                         const Function *FnR);
 
     /// Tries to match one of the loaded instruction patterns. Returns true
     /// if a valid match is found.

--- a/diffkemp/simpll/CustomPatternSet.h
+++ b/diffkemp/simpll/CustomPatternSet.h
@@ -174,11 +174,22 @@ class CustomPatternSet {
     /// Set of loaded value difference patterns.
     std::unordered_set<ValuePattern> ValuePatterns;
 
-    CustomPatternSet(std::string ConfigPath);
+    /// Create a new pattern set based on the given configuration, which can be
+    /// either a YAML config file or a single LLVM IR file.
+    CustomPatternSet(std::string ConfigPath = "");
 
     /// Retrieves pattern metadata attached to the given instruction.
     std::optional<CustomPatternMetadata>
             getPatternMetadata(const Instruction &Inst) const;
+
+    /// Load the given LLVM IR based difference pattern YAML configuration.
+    void addPatternsFromConfig(std::string &ConfigPath);
+
+    /// Load a pattern from the given LLVM IR module file.
+    void addPatternFromFile(std::string &Path);
+
+    /// Load a pattern from an LLVM module.
+    void addPatternFromModule(std::unique_ptr<Module> PatternModule);
 
   private:
     /// Basic information about the output instruction mapping present on one
@@ -191,12 +202,6 @@ class CustomPatternSet {
     LLVMContext PatternContext;
     /// Vector of loaded pattern modules.
     std::vector<std::unique_ptr<Module>> PatternModules;
-
-    /// Load the given configuration file.
-    void loadConfig(std::string &ConfigPath);
-
-    /// Add a new difference pattern.
-    void addPattern(std::string &Path);
 
     /// Finds the pattern type associated with the given pattern functions.
     CustomPatternType getPatternType(const Function *FnL, const Function *FnR);

--- a/diffkemp/simpll/DifferentialFunctionComparator.cpp
+++ b/diffkemp/simpll/DifferentialFunctionComparator.cpp
@@ -1002,8 +1002,7 @@ int DifferentialFunctionComparator::cmpBasicBlocks(
             if (CustomPatternComp.matchPattern(&*InstL, &*InstR)) {
                 undoLastInstCompare(InstL, InstR);
                 createPatternMapping();
-                if (isPartOfPattern(&*InstL) || isPartOfPattern(&*InstR))
-                    continue;
+                continue;
             }
 
             // Try to find a match by moving one of the instruction iterators

--- a/diffkemp/simpll/DifferentialFunctionComparator.h
+++ b/diffkemp/simpll/DifferentialFunctionComparator.h
@@ -37,11 +37,10 @@ class DifferentialFunctionComparator : public FunctionComparator {
                                    const DebugInfo *DI,
                                    const CustomPatternSet *PS,
                                    ModuleComparator *MC)
-            : FunctionComparator(F1, F2, nullptr), config(config), DI(DI),
-              LayoutL(F1->getParent()->getDataLayout()),
-              LayoutR(F2->getParent()->getDataLayout()),
+            : FunctionComparator(F1, F2, nullptr),
               CustomPatternComp(CustomPatternComparator(PS, this, F1, F2)),
-              ModComparator(MC) {}
+              config(config), DI(DI), LayoutL(F1->getParent()->getDataLayout()),
+              LayoutR(F2->getParent()->getDataLayout()), ModComparator(MC) {}
 
     int compare() override;
     /// Compares values by their synchronisation. The comparison is unsuccessful
@@ -134,6 +133,8 @@ class DifferentialFunctionComparator : public FunctionComparator {
                                   BasicBlock::const_iterator &InstR,
                                   Program prog_to_search) const;
 
+    mutable CustomPatternComparator CustomPatternComp;
+
   private:
     friend class CustomPatternComparator;
 
@@ -178,7 +179,6 @@ class DifferentialFunctionComparator : public FunctionComparator {
     };
     mutable RelocationInfo Reloc;
 
-    mutable CustomPatternComparator CustomPatternComp;
     ModuleComparator *ModComparator;
 
     /// Try to find a syntax difference that could be causing the semantic

--- a/diffkemp/simpll/InstPatternComparator.cpp
+++ b/diffkemp/simpll/InstPatternComparator.cpp
@@ -263,6 +263,8 @@ int InstPatternComparator::cmpBasicBlocks(const BasicBlock *ModBB,
     jumpToInst(ModInst, ModPosition);
     jumpToInst(PatInst, PatPosition);
 
+    auto FirstModInst = ModInst;
+
     while (ModInst != ModInstE && PatInst != PatInstE) {
         ModPosition = &*ModInst;
         PatPosition = &*PatInst;
@@ -294,8 +296,10 @@ int InstPatternComparator::cmpBasicBlocks(const BasicBlock *ModBB,
             eraseNewlyMapped();
 
             // When in an instruction group, do not allow module instruction
-            // skipping.
-            if (GroupDepth > 0)
+            // skipping. Also do not skip the initial module instruction; we
+            // want a pattern match that starts with it. Any patterns starting
+            // with later instructions will be matched later if necessary.
+            if (GroupDepth > 0 || ModInst == FirstModInst)
                 return Res;
 
             // Skip the module instruction.

--- a/tests/unit_tests/simpll/DifferentialFunctionComparatorTest.cpp
+++ b/tests/unit_tests/simpll/DifferentialFunctionComparatorTest.cpp
@@ -147,6 +147,11 @@ class TestComparator : public DifferentialFunctionComparator {
 
     size_t getLeftSnMapSize() { return sn_mapL.size(); }
     size_t getRightSnMapSize() { return sn_mapR.size(); }
+
+    /// Extend the set of custom patterns.
+    void addCustomPatternSet(const CustomPatternSet *PatternSet) {
+        CustomPatternComp.addPatternSet(PatternSet, FnL, FnR);
+    }
 };
 
 /// Test fixture providing contexts, modules, functions, a Config object,

--- a/tests/unit_tests/simpll/DifferentialFunctionComparatorTest.cpp
+++ b/tests/unit_tests/simpll/DifferentialFunctionComparatorTest.cpp
@@ -13,6 +13,7 @@
 //===----------------------------------------------------------------------===//
 
 #include <Config.h>
+#include <CustomPatternSet.h>
 #include <DebugInfo.h>
 #include <DifferentialFunctionComparator.h>
 #include <ModuleComparator.h>
@@ -2048,6 +2049,102 @@ TEST_F(DifferentialFunctionComparatorTest, ReorderedBinaryOperationNeedLeaf) {
     // Return the result of the operation
     auto RetL = ReturnInst::Create(CtxL, ResL, BBL);
     auto RetR = ReturnInst::Create(CtxR, ResR, BBR);
+
+    ASSERT_EQ(DiffComp->compare(), 0);
+}
+
+TEST_F(DifferentialFunctionComparatorTest, CustomPatternSkippingInstruction) {
+    // Test custom pattern matching and skipping of instructions therein.
+    //
+    // ; Old side of the pattern:
+    // define i8 @diffkemp.old.pattern() {
+    //     %1 = sub i8 0, 1
+    //     ret %1
+    // }
+    //
+    // ; New side of the pattern:
+    // define i8 @diffkemp.new.pattern() {
+    //     %1 = sub i8 1, 0
+    //     %2 = sdiv i8 %1, %1
+    //     ret %3
+    // }
+    //
+    // ; Old compared function:
+    // define i8 @old.function() {
+    //     %1 = sub i8 0, 1        ; matched
+    //     call void @old.function ; skipped
+    //     ret %1
+    // }
+    //
+    // ; New compared function:
+    // define i8 @new.function() {
+    //     %1 = sub i8 1, 0        ; matched
+    //     call void @new.function ; skipped
+    //     %3 = sdiv i8 %1, %1     ; matched
+    //     ret %3
+    // }
+
+    // Initialize a module that will define the pattern
+    LLVMContext PatCtx;
+    auto PatMod = std::make_unique<Module>("PatternMod", PatCtx);
+
+    auto PatFL = Function::Create(
+            FunctionType::get(Type::getInt8Ty(PatCtx), {}, false),
+            GlobalValue::ExternalLinkage,
+            "diffkemp.old.pattern",
+            PatMod.get());
+    auto PatFR = Function::Create(
+            FunctionType::get(Type::getInt8Ty(PatCtx), {}, false),
+            GlobalValue::ExternalLinkage,
+            "diffkemp.new.pattern",
+            PatMod.get());
+
+    BasicBlock *PatBBL = BasicBlock::Create(PatCtx, "", PatFL);
+    BasicBlock *PatBBR = BasicBlock::Create(PatCtx, "", PatFR);
+
+    Constant *PatConstL1 = ConstantInt::get(Type::getInt8Ty(PatCtx), 0);
+    Constant *PatConstL2 = ConstantInt::get(Type::getInt8Ty(PatCtx), 1);
+    Constant *PatConstR1 = ConstantInt::get(Type::getInt8Ty(PatCtx), 0);
+    Constant *PatConstR2 = ConstantInt::get(Type::getInt8Ty(PatCtx), 1);
+
+    auto PatSubL = BinaryOperator::Create(
+            BinaryOperator::Sub, PatConstL1, PatConstL2, "", PatBBL);
+    auto PatSubR = BinaryOperator::Create(
+            BinaryOperator::Sub, PatConstR2, PatConstR1, "", PatBBR);
+
+    auto PatDivR = BinaryOperator::Create(
+            BinaryOperator::SDiv, PatSubR, PatSubR, "", PatBBR);
+
+    ReturnInst::Create(PatCtx, PatSubL, PatBBL);
+    ReturnInst::Create(PatCtx, PatDivR, PatBBR);
+
+    // Fill in the functions to compare
+    BasicBlock *BBL = BasicBlock::Create(CtxL, "", FL);
+    BasicBlock *BBR = BasicBlock::Create(CtxR, "", FR);
+
+    Constant *ConstL1 = ConstantInt::get(Type::getInt8Ty(CtxL), 0);
+    Constant *ConstL2 = ConstantInt::get(Type::getInt8Ty(CtxL), 1);
+    Constant *ConstR1 = ConstantInt::get(Type::getInt8Ty(CtxR), 0);
+    Constant *ConstR2 = ConstantInt::get(Type::getInt8Ty(CtxR), 1);
+
+    auto SubL = BinaryOperator::Create(
+            BinaryOperator::Sub, ConstL1, ConstL2, "", BBL);
+    auto SubR = BinaryOperator::Create(
+            BinaryOperator::Sub, ConstR2, ConstR1, "", BBR);
+
+    CallInst::Create(FL->getFunctionType(), FL, "", BBL);
+    CallInst::Create(FR->getFunctionType(), FR, "", BBR);
+
+    auto DivR =
+            BinaryOperator::Create(BinaryOperator::SDiv, SubR, SubR, "", BBR);
+
+    ReturnInst::Create(CtxL, SubL, BBL);
+    ReturnInst::Create(CtxR, DivR, BBR);
+
+    // Create a pattern set with the pattern module and add it to the comparator
+    CustomPatternSet PatSet;
+    PatSet.addPatternFromModule(std::move(PatMod));
+    DiffComp->addCustomPatternSet(&PatSet);
 
     ASSERT_EQ(DiffComp->compare(), 0);
 }


### PR DESCRIPTION
When matching custom patterns, we should not skip the currently compared instruction, i.e., the one that caused the semantic difference.

Imagine the following situation with two custom patterns:
```llvm
; Pattern 1
!0 = !{ !"pattern-start" }
declare void @diffkemp.new.skippable_1(ptr, i32)

define void @diffkemp.old.pattern_1(i8) {
  ret void
}

define void @diffkemp.new.pattern_1(i8) {
  %3 = alloca i32
  call void @diffkemp.new.skippable_1(ptr %3, i32 4), !diffkemp.pattern !0
  ret void
}
```
```llvm
; Pattern 2
!0 = !{ !"pattern-start" }
declare void @diffkemp.new.skippable_2(ptr)

define void @diffkemp.old.pattern_2(i8) {
  ret void
}

define void @diffkemp.new.pattern_2(i8) {
  %3 = alloca i32
  call void @diffkemp.new.skippable_2(ptr %3), !diffkemp.pattern !0
  ret void
}
```
The old version of the code does not contain the skippable function calls, whereas the new version contains both:
```llvm
; New version of the code
...
%1 = alloca i32
%2 = alloca i32
...
call void skippable_1(ptr %1, i32 4) ; currently compared instruction
...
call void skippable_2(ptr %2)
...
```
When the call to `skippable_1` is encountered and pattern matching starts, the behavior differs depending on which pattern we start matching first. If we start matching the second pattern first and skipping is enabled for the current module instruction, the pattern gets matched successfully against the call to `skippable_2`. However, the comparison itself fails immediately afterwards because we haven't matched the call to `skippable_1`.

Unfortunately, instruction skipping during pattern matching is not covered by any tests; when I disabled it completely, current regression tests still succeeded. @PSilling, do you remember any interesting cases which could be converted to regression tests, or even unit tests?
