### PR TITLE
SimpLL: Inverse condition pattern fixes

### DIFF
--- a/diffkemp/simpll/DifferentialFunctionComparator.cpp
+++ b/diffkemp/simpll/DifferentialFunctionComparator.cpp
@@ -331,6 +331,8 @@ int DifferentialFunctionComparator::cmpOperations(
                                         BranchR->getCondition());
             if (inverseConditions.find(conds) != inverseConditions.end()) {
                 // Swap successors of one of the branches
+                PREP_LOG("swap-branches", L, R);
+                LOG_KEEP_FORCE(0);
                 BranchInst *BranchNew = const_cast<BranchInst *>(BranchR);
                 auto *tmpSucc = BranchNew->getSuccessor(0);
                 BranchNew->setSuccessor(0, BranchNew->getSuccessor(1));
@@ -378,6 +380,9 @@ int DifferentialFunctionComparator::cmpOperations(
             // operands are compared in cmpBasicBlocks.
             if (CmpL->getPredicate() == CmpR->getInversePredicate()) {
                 if (checkInverseCondUsers(L) && checkInverseCondUsers(R)) {
+                    PREP_LOG("inv-cond-add", L, R);
+                    LOG_KEEP_FORCE(0);
+
                     inverseConditions.emplace(L, R);
                     return 0;
                 }
@@ -986,6 +991,15 @@ int DifferentialFunctionComparator::cmpBasicBlocks(
                 size_t erased = inverseConditions.erase(prevCondPair);
                 if (!erased)
                     inverseConditions.insert(condPair);
+
+                LOG_VERBOSE_EXTRA((erased ? "Removed" : " Added")
+                                  << " inverse condition\n");
+                auto &pairToLog = (erased) ? prevCondPair : condPair;
+                LOG_INDENT();
+                LOG_VERBOSE_EXTRA("L: " << (*(pairToLog.first)) << "\n");
+                LOG_VERBOSE_EXTRA("R: " << (*(pairToLog.second)) << "\n");
+                LOG_UNINDENT();
+
                 continue;
             }
 

--- a/diffkemp/simpll/DifferentialFunctionComparator.h
+++ b/diffkemp/simpll/DifferentialFunctionComparator.h
@@ -279,6 +279,13 @@ class DifferentialFunctionComparator : public FunctionComparator {
                                std::multiset<int> &SNs,
                                std::multiset<int64_t> &Constants,
                                DenseMap<const Value *, int> &sn_map) const;
+
+    /// Recursively check if users of the instruction with an inverse condition
+    /// are only branch or not instructions.
+    /// This is done to prevent false negatives.
+    /// Return true if the users are acceptable for inverse conditions pattern,
+    /// false otherwise.
+    bool checkInverseCondUsers(const Instruction *inst) const;
 };
 
 #endif // DIFFKEMP_SIMPLL_DIFFERENTIALFUNCTIONCOMPARATOR_H

--- a/diffkemp/simpll/Logger.h
+++ b/diffkemp/simpll/Logger.h
@@ -90,6 +90,7 @@
  *      - details about index alignment in debug information analysis
  *      - details about replacements in passes
  *      - details about dependency slicing pass
+ *      - details about inverse conditions pattern
  */
 
 #ifndef DIFFKEMP_SIMPLL_LOGGER_H


### PR DESCRIPTION
This PR fixes multiple problems with the inverse condition pattern:
1. The pattern could cause a false negative in a code with a combined condition because it always "skiped" a compare instruction with an inverse condition regardless of what the instruction users were. Example which caused false negative:
    ```c
    // old
    void f() {                                                               
        if (5 == 5 || 10 == 10) {                                            
            return true;                                                     
        }                                                                    
        else return false
    }
    // new
    void f() {                                                               
        if (5 != 5 || 10 != 10) {                                            
            return true;                                                     
        }                                                                    
        else return false
    }
    ```
2. It did not correctly handle inverse conditions with negations, because it searched for the current matching pair in the inverse condition list instead of the previous one when deciding if to add the pair to the list or remove it (more in [bc6abbe](https://github.com/viktormalik/diffkemp/commit/bc6abbe0f702c3b37687d3da8c5a76615dbeaa4e)). Eg it did not handle a case described in [212993d](https://github.com/viktormalik/diffkemp/commit/212993d):
    ```
    %2 = icmp eq %0, %1  | %2 = icmp ne %0, %
                         | %3 = xor %2, true
    br %2 %T %F          | br %3 %T %F
    ```
3. It did not check if an inverse condition pattern is enabled before checking if `not` instruction could not be a case of an inverse condition pattern.

* This PR also adds logging for the inverse condition pattern.

* Note: There is a problem with multiple `not` instructions which it does not handle properly because it would be necessary to find the original cmp instruction in the version of the function which does not have `not` instructions. It could be possible to fix it, but when I tried to compile programs to include the `not` (respectively `xor`) instruction -- I was unable to get such a program because the compiler usually just inverse the condition in the compare instruction `!(a!=b) -> a==b` or just swapped the branches. 

* While experimenting with it, I found out that it also has not been able to handle (with `-O1` optimisation and passes which are used for build-kernel) cases when the condition is saved to a variable, eg something like this:
    ```c
    // old
    bool a(int b, int c, int d) {
	int e=b<0;	
	if (e) {
		return false;
	}
	else {
		return true;
	}
    }
    // new
    bool a(int b, int c, int d) {
	int e=!(b<0);	
	if (e) {
		return true;
	}
	else {
		return false;
	}
    }
    ```
    The problem are `store` and `load` instructions.