### PR TITLE
Add a pattern which detects local variable refactorings

### DIFF
--- a/diffkemp/cli.py
+++ b/diffkemp/cli.py
@@ -152,7 +152,8 @@ def make_argument_parser():
                         "type-casts",
                         "control-flow-only",
                         "inverse-conditions",
-                        "reordered-bin-ops"]
+                        "reordered-bin-ops",
+                        "group-vars"]
 
     # Semantic patterns options.
     compare_ap.add_argument("--enable-pattern",

--- a/diffkemp/config.py
+++ b/diffkemp/config.py
@@ -23,6 +23,7 @@ class BuiltinPatterns:
         control_flow_only=False,
         inverse_conditions=True,
         reordered_bin_ops=True,
+        group_vars=True,
     ):
         """
         Create a configuration of built-in patterns.
@@ -41,6 +42,7 @@ class BuiltinPatterns:
         :param control_flow_only: Consider control-flow changes only.
         :param inverse_conditions: Inverted branch conditions.
         :param reordered_bin_ops: Match reordered binary operations.
+        :param group_vars: Grouping of local variables.
         """
         self.settings = {
             "struct-alignment": struct_alignment,
@@ -54,6 +56,7 @@ class BuiltinPatterns:
             "control-flow-only": control_flow_only,
             "inverse-conditions": inverse_conditions,
             "reordered-bin-ops": reordered_bin_ops,
+            "group-vars": group_vars,
         }
         self.resolve_dependencies()
 
@@ -101,6 +104,7 @@ class BuiltinPatterns:
         ffi_struct.ControlFlowOnly = self.settings["control-flow-only"]
         ffi_struct.InverseConditions = self.settings["inverse-conditions"]
         ffi_struct.ReorderedBinOps = self.settings["reordered-bin-ops"]
+        ffi_struct.GroupVars = self.settings["group-vars"]
         return ffi_struct
 
 

--- a/diffkemp/simpll/Config.h
+++ b/diffkemp/simpll/Config.h
@@ -38,6 +38,7 @@ struct BuiltinPatterns {
     bool ControlFlowOnly = false;
     bool InverseConditions = true;
     bool ReorderedBinOps = true;
+    bool GroupVars = true;
 };
 
 /// Tool configuration parsed from CLI options.

--- a/diffkemp/simpll/SimpLL.cpp
+++ b/diffkemp/simpll/SimpLL.cpp
@@ -115,6 +115,9 @@ cl::opt<bool> ReorderedBinOpsOpt(
         "reordered-bin-ops",
         cl::desc("Enable reordered binary operations pattern."),
         cl::cat(BuiltinPatternsCategory));
+cl::opt<bool> GroupVarsOpt("group-vars",
+                           cl::desc("Enable variable grouping pattern."),
+                           cl::cat(BuiltinPatternsCategory));
 
 /// Add suffix to the file name.
 /// \param File Original file name.
@@ -162,7 +165,8 @@ int main(int argc, const char **argv) {
                              .TypeCasts = TypeCastsOpt,
                              .ControlFlowOnly = ControlFlowOnlyOpt,
                              .InverseConditions = InverseConditionsOpt,
-                             .ReorderedBinOps = ReorderedBinOpsOpt};
+                             .ReorderedBinOps = ReorderedBinOpsOpt,
+                             .GroupVars = GroupVarsOpt};
 
     // Parse --fun option
     auto FunName = parseFunOption();

--- a/diffkemp/simpll/Utils.h
+++ b/diffkemp/simpll/Utils.h
@@ -203,4 +203,26 @@ StructType *getTypeByName(const Module &Mod, StringRef Name);
 /// Retrieve information about a structured type being pointed to by a value
 TypeInfo getPointeeStructTypeInfo(const Value *Val, const DataLayout *Layout);
 
+/// Given an instruction and a pointer value, try to determine whether the
+/// instruction may store to the memory pointed to by the pointer. This is
+/// currently implemented only as a set of heuristics - if they do not suffice,
+/// we return true.
+bool mayStoreTo(const Instruction *Inst, const Value *Ptr);
+
+/// Given two pointer values, try do determine whether they may alias. The
+/// function currently supports only simple aliasing of local memory.
+bool mayAlias(const Value *PtrL, const Value *PtrR);
+
+/// Given a pointer value, return the instruction which allocated the memory
+/// where the pointer points. Return a null pointer if the alloca is not found.
+const AllocaInst *getAllocaFromPtr(const Value *Ptr);
+
+/// Return the alloca instruction that was used to allocate the variable into
+/// which the pointer operand of the given instruction (e.g., load) points.
+/// If such an alloca cannot be found, return nullptr.
+template <typename InstType>
+const AllocaInst *getAllocaOp(const InstType *Inst) {
+    return getAllocaFromPtr(Inst->getPointerOperand());
+}
+
 #endif // DIFFKEMP_SIMPLL_UTILS_H

--- a/diffkemp/simpll/library/FFI.cpp
+++ b/diffkemp/simpll/library/FFI.cpp
@@ -73,6 +73,7 @@ BuiltinPatterns BuiltinPatternsFromC(builtin_patterns PatternsC) {
             .ControlFlowOnly = (bool)PatternsC.ControlFlowOnly,
             .InverseConditions = (bool)PatternsC.InverseConditions,
             .ReorderedBinOps = (bool)PatternsC.ReorderedBinOps,
+            .GroupVars = (bool)PatternsC.GroupVars,
     };
 }
 

--- a/diffkemp/simpll/library/FFI.h
+++ b/diffkemp/simpll/library/FFI.h
@@ -35,6 +35,7 @@ struct builtin_patterns {
     int ControlFlowOnly;
     int InverseConditions;
     int ReorderedBinOps;
+    int GroupVars;
 };
 
 struct config {


### PR DESCRIPTION
The pattern works as follows:
- Differing allocas of local memory and stores to such memory are ignored.
- When there is a load from such memory, identifying the replacement works the same as with repetitive loads, i.e., a suitable store has to be found in all backward CFG paths from the load.

Similar to the repetitive loads, this approach is limited by possibly conflicting stores and function calls. Further improvements may be possible using pointer alias analysis (maybe using LLVM's `MemoryDependenceAnalysis` pass?).

In the process of implementing this, I found multiple bugs in the repetitive load skipping implementation; see the first commit.

I'm not really sure about the pattern name; maybe something like `local-memory` would be more suitable?