### PR TITLE
Do not ignore safeToRemove instructions with no users

### DIFF
--- a/diffkemp/simpll/DifferentialFunctionComparator.cpp
+++ b/diffkemp/simpll/DifferentialFunctionComparator.cpp
@@ -517,6 +517,7 @@ bool DifferentialFunctionComparator::maySkipInstruction(
         return true;
     }
     if (config.Patterns.GroupVars && Inst->isSafeToRemove()
+        && Inst->user_begin() != Inst->user_end()
         && allUsersAreExtraMemInsts(Inst)) {
         // If this is a safe instruction (not a store, call, or a terminator),
         // it can be ignored if its users are extra memory instructions, i.e.,


### PR DESCRIPTION
Apparently, I made a huge mistake by misinterpreting what `Instruction.isSafeToRemove()` does.
It does not, e.g., return `false` for all `store` instructions.

This is a quick fix to prevent false negatives, I'll think about a more comprehensive solution later.