### PR TITLE
Logger: logging function name instead of its body

### DIFF
--- a/diffkemp/simpll/Logger.cpp
+++ b/diffkemp/simpll/Logger.cpp
@@ -90,7 +90,12 @@ llvm::raw_ostream &operator<<(llvm::raw_ostream &out,
         out << *(value.type);
         break;
     case value.llvmValue:
-        out << *(value.value);
+        // In case the value is a function, log its name instead of its body.
+        if (auto *fun = dyn_cast<Function>(value.value)) {
+            out << fun->getName();
+        } else {
+            out << *(value.value);
+        }
         break;
     }
     return out;


### PR DESCRIPTION
This PR solves issue #260 .
For methods like cmpValues in Simpll DifferentialFunctionComparator, if the value was llvm::Function, the logger dumped the entire body of the function (which polluted the output), this PR changes it and logs only the function name.

DiffKemp compare output with logger enabled (`-d` set)
- [before the change](https://github.com/viktormalik/diffkemp/files/14478290/old-output.log)
- [after the change](https://github.com/viktormalik/diffkemp/files/14478332/new-output.log)
