### PR TITLE
Fixes in `getPointeeStructTypeInfo` functions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,7 @@ jobs:
             asan: OFF
             regression-tests: true
 
-          - llvm: 14
+          - llvm: 17
             env:
               CC: gcc-9
               CXX: g++-9

--- a/diffkemp/simpll/DifferentialFunctionComparator.cpp
+++ b/diffkemp/simpll/DifferentialFunctionComparator.cpp
@@ -522,8 +522,10 @@ int DifferentialFunctionComparator::cmpAllocs(const CallInst *CL,
             isa<BitCastInst>(CR->getNextNode()) ? CR->getNextNode() : CR;
 
     // Retrieve type names and sizes
-    TypeInfo TypeInfoL = getPointeeStructTypeInfo(ValL, &LayoutL);
-    TypeInfo TypeInfoR = getPointeeStructTypeInfo(ValR, &LayoutR);
+    TypeInfo TypeInfoL =
+            getPointeeStructTypeInfo(ValL, &LayoutL, FnL->getName());
+    TypeInfo TypeInfoR =
+            getPointeeStructTypeInfo(ValR, &LayoutR, FnR->getName());
     if (TypeInfoL.Name.empty() || TypeInfoR.Name.empty()) {
         PREP_LOG("pointee type not found", ValL, ValR);
         LOG_KEEP(1);
@@ -1796,8 +1798,10 @@ int DifferentialFunctionComparator::cmpMemset(const CallInst *CL,
                                 ? dyn_cast<BitCastInst>(destR)->getOperand(0)
                                 : destR;
 
-    TypeInfo TypeInfoL = getPointeeStructTypeInfo(ValL, &LayoutL);
-    TypeInfo TypeInfoR = getPointeeStructTypeInfo(ValR, &LayoutR);
+    TypeInfo TypeInfoL =
+            getPointeeStructTypeInfo(ValL, &LayoutL, FnL->getName());
+    TypeInfo TypeInfoR =
+            getPointeeStructTypeInfo(ValR, &LayoutR, FnR->getName());
     if (TypeInfoL.Name.empty() || TypeInfoR.Name.empty()) {
         PREP_LOG("pointee type not found", ValL, ValR);
         LOG_KEEP(1);

--- a/diffkemp/simpll/Utils.h
+++ b/diffkemp/simpll/Utils.h
@@ -201,7 +201,9 @@ std::string makeYellow(std::string text);
 StructType *getTypeByName(const Module &Mod, StringRef Name);
 
 /// Retrieve information about a structured type being pointed to by a value
-TypeInfo getPointeeStructTypeInfo(const Value *Val, const DataLayout *Layout);
+TypeInfo getPointeeStructTypeInfo(const Value *Val,
+                                  const DataLayout *Layout,
+                                  const StringRef &FunName);
 
 /// Given an instruction and a pointer value, try to determine whether the
 /// instruction may store to the memory pointed to by the pointer. This is


### PR DESCRIPTION
This PR tries to fix 2 problems with `getPointeeStructTypeInfo` function which we are using in the `cmpMemset` and `cmpAllocs` methods when the set/allocated size is not the same in both compared functions. With the help of this function, we check that the set/allocated type names are equal and the set/allocated size corresponds to the size of the type. For LLVM 15 and above (when opaque pointers became enabled by default), we use debug intrinsics and debug metadata to get the info about the type to which the pointer passed to `memset`/`allocs` points.

In the case of LLVM 15+ there were problems:
- When the pointer passed down to the `memset`/`allocs` was of `void *` type. It tried to extract the type of the structure from the debug info which it did not contain. This caused assert by trying to `dyn_cast` a `nullptr`.
- If there were multiple debug data describing the pointer passed down to the `memset`/`allocs`. Some of the debug data does not have to contain information about the pointee type because it does not have to belong to scope of currently analysed function but e.g. to stdlib C `memset` function itself which was 'inlined' into the currently analysed function and does not contain info about the type because it uses `void *` instead.

This PR tries to fix (see commit messages for more details).

The PR also contains tests for these scenarios. I did not figure out a way how to simplify the writing of the debug info in the unit tests so the tests are not very pleasant to read.
Note: I am thinking that similarly as we are using kernel for regression/end-to-end testing, we could create our own test functions written in C with some YAML file describing the result of comparison and options that should be used for creating the snapshots from the functions (e.g. `-O2` and `-g` in this case). But I am note sure if it is a good idea because we would lose a level of testing detail (end-to-end test instead of unit testing of `cmpMemset` method).

While trying to solve this problem I also discovered that we are not handling situation when the pointee type is `typedef`ed, for now, I opened an issue #363 for this. I will try to fix this and open PR for it in the future.

I need to yet check if I did not break something -- I will compare the security libraries using this PR and if I will not discover a problem then I will move this PR out of draft.