### PR TITLE
Viewer: Use relative paths in builded viewer

### DIFF
--- a/view/vite.config.js
+++ b/view/vite.config.js
@@ -4,7 +4,7 @@ import eslint from 'vite-plugin-eslint';
 
 export default defineConfig({
   plugins: [react(), eslint()],
-  base: '/',
+  base: './',
   build: {
     outDir: 'build',
   },


### PR DESCRIPTION
With migration to Vite from CRA (Create React App) [1], I wrongly set the configuration and the builded viewer uses absolute paths instead of relative paths. This is a problem when running server from different than the `build` directory.
This commit fixes it by building the viewer with relative paths.

Note:
- This was previsouly fixed in [2], but I broke it when migrating to Vite.

[1] https://github.com/diffkemp/diffkemp/pull/388
[2] https://github.com/diffkemp/diffkemp/pull/379