### PR TITLE
Fix: system z3 being prioritized over local

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,7 +10,7 @@ include_directories(SYSTEM ${LLVM_INCLUDE_DIRS})
 link_directories(${LLVM_LIBRARY_DIRS})
 set(CMAKE_CXX_STANDARD 17)
 
-list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_LIST_DIR}/cmake)
+list(PREPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_LIST_DIR}/cmake)
 
 include(GNUInstallDirs)
 

--- a/cmake/FindZ3.cmake
+++ b/cmake/FindZ3.cmake
@@ -5,7 +5,7 @@
 #  Z3_CXX_INCLUDE_DIRS - the z3 C++ include directory
 #  Z3_LIBRARIES - Link these to use libbpf
 
-find_path (Z3_CXX_INCLUDE_DIRS z3++.h)
+find_path (Z3_CXX_INCLUDE_DIRS z3++.h PATH_SUFFIXES z3)
 
 find_library (Z3_LIBRARIES z3)
 

--- a/diffkemp/simpll/CMakeLists.txt
+++ b/diffkemp/simpll/CMakeLists.txt
@@ -34,11 +34,11 @@ execute_process(COMMAND llvm-config --system-libs
                 OUTPUT_VARIABLE system_libs
                 OUTPUT_STRIP_TRAILING_WHITESPACE)
 
-# Try to find system-wide Z3 (e.g. local build)
-find_package(Z3 CONFIG)
+# Use our FindZ3.cmake (e.g. nix build)
+find_package(Z3 MODULE)
 if (NOT ${Z3_FOUND})
-    # Use our FindZ3.cmake (e.g. nix build)
-    find_package(Z3 REQUIRED MODULE)
+  # Try to find system-wide Z3 (e.g. local build)
+  find_package(Z3 REQUIRED CONFIG)
 endif()
 
 add_library(simpll-lib ${srcs} ${passes} ${library})

--- a/tests/unit_tests/simpll/CMakeLists.txt
+++ b/tests/unit_tests/simpll/CMakeLists.txt
@@ -21,11 +21,11 @@ execute_process(COMMAND llvm-config --system-libs
                 OUTPUT_VARIABLE system_libs
                 OUTPUT_STRIP_TRAILING_WHITESPACE)
 
-# Try to find system-wide Z3 (e.g. local build)
-find_package(Z3 CONFIG)
+# Use our FindZ3.cmake (e.g. nix build)
+find_package(Z3 MODULE)
 if (NOT ${Z3_FOUND})
-    # Use our FindZ3.cmake (e.g. nix build)
-    find_package(Z3 REQUIRED MODULE)
+  # Try to find system-wide Z3 (e.g. local build)
+  find_package(Z3 REQUIRED CONFIG)
 endif()
 
 target_include_directories(simpllTests PRIVATE ${Z3_CXX_INCLUDE_DIRS})


### PR DESCRIPTION
Fixes #383

Changes:
Prioritize `MODULE` over `CONFIG`: prioritize local z3 library instead of host.

`PREPEND` in `CMAKE_MODULE_PATH`: When exporting custom LLVM paths (like `llvm19`, to test the compilation outside of Nix), LLVM's internal `FindZ3.cmake` was hijacking our own, causing missing header issues. Prepending ensures our script takes priority in the CMake list.

Update `FindZ3.cmake`: Added `PATH_SUFFIXES z3` so CMake correctly finds the header on standard Linux distributions where it is nested (e.g., `/usr/include/z3/z3++.h`).