### PR TITLE
Bitcode continuance

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,7 +61,7 @@ jobs:
         if: matrix.regression-tests
         with:
           path: tests/regression/test_data
-          key: test-data-llvm${{ matrix.llvm }}-${{ hashFiles('tests/regression/test_specs/*') }}
+          key: test-data-llvm${{ matrix.llvm }}-bc-${{ hashFiles('tests/regression/test_specs/*') }}
 
       # Download kernel sources:
       # - if test_data is cached, we only need the kernel for unit tests
@@ -112,4 +112,4 @@ jobs:
         uses: actions/cache@v4
         with:
           path: tests/regression/test_data
-          key: test-data-llvm${{ matrix.llvm }}-${{ hashFiles('tests/regression/test_specs/*') }}
+          key: test-data-llvm${{ matrix.llvm }}-bc-${{ hashFiles('tests/regression/test_specs/*') }}

--- a/.gitignore
+++ b/.gitignore
@@ -108,7 +108,8 @@ cmake-build-debug/
 Testing/
 
 # Temporary files from regression tests. Used for debugging purposes only.
-*.ll
+*.bc
+*.bcw
 *.smt2
 *.pdf
 

--- a/diffkemp/building/cc_wrapper/cc_wrapper.cpp
+++ b/diffkemp/building/cc_wrapper/cc_wrapper.cpp
@@ -103,17 +103,17 @@ int wrapper(int argc, char *argv[]) {
         containsSource = containsSource || isSourceFile;
         if (i > 0 && wrapperArgs.cFlags[i - 1] == "-o") {
             if (isObjFile && !linking) {
-                // Compiling to object file: swap .o with .ll
-                arg = arg.substr(0, arg.rfind('.')) + ".ll";
+                // Compiling to object file: swap .o with .bc
+                arg = arg.substr(0, arg.rfind('.')) + ".bc";
             }
             if (!isObjFile && linking) {
-                // Linking: add a .llw suffix (LLVM IR whole)
-                arg = arg + ".llw";
+                // Linking: add a .bcw suffix (LLVM IR whole)
+                arg = arg + ".bcw";
             }
             outputFile = arg;
         } else if (isObjFile && linking) {
-            // Input to linking phase: change suffix to .ll
-            arg = arg.substr(0, arg.rfind('.')) + ".ll";
+            // Input to linking phase: change suffix to .bc
+            arg = arg.substr(0, arg.rfind('.')) + ".bc";
             clangBin = wrapperArgs.llvmLink;
         } else if (isSourceFile && linking) {
             // Mark as linking with sources to detect hybrid mode
@@ -130,19 +130,19 @@ int wrapper(int argc, char *argv[]) {
         std::copy_if(clangArgv.begin(),
                      clangArgv.end(),
                      std::back_inserter(tmp),
-                     [](const auto &arg) { return !endsWith(arg, ".ll"); });
+                     [](const auto &arg) { return !endsWith(arg, ".bc"); });
         clangArgv = std::move(tmp);
     }
 
-    // Do not continue if output is not .ll or .llw
+    // Do not continue if output is not .bc or .bcw
     // Note: this means that this is netiher compilation nor linking
     if (outputFile.empty()
-        || (!endsWith(outputFile, ".ll") && !endsWith(outputFile, ".llw"))) {
+        || (!endsWith(outputFile, ".bc") && !endsWith(outputFile, ".bcw"))) {
         return 0;
     }
 
     // Do not run clang on conftest files
-    if (outputFile == "conftest.ll" || outputFile == "conftest.llw"
+    if (outputFile == "conftest.bc" || outputFile == "conftest.bcw"
         || isInVector("conftest.c", wrapperArgs.cFlags)) {
         return 0;
     }
@@ -163,7 +163,7 @@ int wrapper(int argc, char *argv[]) {
         for (const std::string &arg : clangArgv) {
             if (!endsWith(arg, ".c")) {
                 fs::path p(arg);
-                p.replace_extension(".ll");
+                p.replace_extension(".bc");
                 dbEntries.push_back("o:" + (fs::current_path() / p).string());
             }
         }
@@ -184,7 +184,7 @@ int wrapper(int argc, char *argv[]) {
         // Keep only arguments with input files (and llvm-link itself)
         std::vector<std::string> tempArgs;
         for (const auto &arg : clangArgv) {
-            if (endsWith(arg, ".ll") || endsWith(arg, ".llw") || arg == "-o") {
+            if (endsWith(arg, ".bc") || endsWith(arg, ".bcw") || arg == "-o") {
                 tempArgs.push_back(arg);
             }
         }

--- a/diffkemp/building/cc_wrapper/cc_wrapper_utils.cpp
+++ b/diffkemp/building/cc_wrapper/cc_wrapper_utils.cpp
@@ -28,7 +28,7 @@ bool endsWith(const std::string &str, const std::string &suffix) noexcept {
 // in diffkemp/llvm_ir/compiler.py
 std::vector<std::string> getClangDefaultOptions(bool defaultOptim) {
     std::vector<std::string> options = {
-            "-S", "-emit-llvm", "-g", "-fdebug-macro", "-Wno-format-security"};
+            "-c", "-emit-llvm", "-g", "-fdebug-macro", "-Wno-format-security"};
     if (defaultOptim) {
         options.push_back("-O1");
         options.push_back("-Xclang");

--- a/diffkemp/llvm_ir/compiler.py
+++ b/diffkemp/llvm_ir/compiler.py
@@ -8,7 +8,7 @@ Functions for compilation of c files to LLVM IR.
 def get_clang_default_options(default_optim=True):
     """Returns clang options for compiling c files to LLVM IR.
     :param default_optim: By default adds also optimization flags."""
-    opts = ["-S", "-emit-llvm", "-g", "-fdebug-macro", "-Wno-format-security"]
+    opts = ["-c", "-emit-llvm", "-g", "-fdebug-macro", "-Wno-format-security"]
     if default_optim:
         opts.extend(["-O1", "-Xclang", "-disable-llvm-passes"])
     return opts

--- a/diffkemp/llvm_ir/kernel_llvm_source_builder.py
+++ b/diffkemp/llvm_ir/kernel_llvm_source_builder.py
@@ -70,7 +70,7 @@ class KernelLlvmSourceBuilder(LlvmSourceFinder):
                 llvm_filename = self._build_source_to_llvm(source_path)
                 if os.path.isfile(llvm_filename):
                     mod = LlvmModule(llvm_filename)
-                    if mod.has_function(symbol) or mod.has_global(symbol):
+                    if mod.has_definition(symbol):
                         break
             except BuildException:
                 pass
@@ -395,9 +395,9 @@ class KernelLlvmSourceBuilder(LlvmSourceFinder):
             if param.startswith('-D"DEBUG_HASH2='):
                 param = '-D"DEBUG_HASH2=1"'
 
-            # Output name is given by replacing .c by .ll in source name
+            # Output name is given by replacing .c by .bc in source name
             if param.endswith(".c"):
-                output_file = "{}.ll".format(param[:-2])
+                output_file = "{}.bc".format(param[:-2])
 
             command.append(KernelLlvmSourceBuilder._strip_bash_quotes(param))
         if output_file is None:
@@ -414,10 +414,10 @@ class KernelLlvmSourceBuilder(LlvmSourceFinder):
         :param ld_command: Command to convert
         :return Corresponding llvm-link command.
         """
-        command = ["llvm-link", "-S"]
+        command = ["llvm-link"]
         for param in ld_command.split():
             if param.endswith(".o"):
-                command.append("{}.ll".format(param[:-2]))
+                command.append("{}.bc".format(param[:-2]))
             elif param == "-o":
                 command.append(param)
         return command
@@ -486,8 +486,12 @@ class KernelLlvmSourceBuilder(LlvmSourceFinder):
 
     @staticmethod
     def _get_build_source(command):
-        """Get name of the object file built by the command."""
-        return command[command.index("-c") + 1]
+        """
+        Get name of the source file built by the command.
+        The commands start with 'clang -c -emit-llvm' to avoid linking
+        and the source file follows '-c' later in the command.
+        """
+        return command[command.index("-c", 3) + 1]
 
     def _kbuild_object_command(self, object_file):
         """
@@ -568,7 +572,7 @@ class KernelLlvmSourceBuilder(LlvmSourceFinder):
         :param source_file: C source to build
         :return: Created LLVM IR file
         """
-        llvm_file = "{}.ll".format(source_file[:-2])
+        llvm_file = "{}.bc".format(source_file[:-2])
         if (not os.path.isfile(llvm_file) or os.path.getmtime(llvm_file) <
                 os.path.getmtime(source_file)):
             cwd = os.getcwd()
@@ -585,9 +589,20 @@ class KernelLlvmSourceBuilder(LlvmSourceFinder):
                     try:
                         check_call(command, stderr=stderr)
                     except CalledProcessError:
-                        os.chdir(cwd)
-                        raise BuildException(
-                            "Could not build {}".format(llvm_file))
+                        # Some sources contain architecture-specific inline
+                        # assembly that newer clang versions reject even when
+                        # only LLVM IR is needed (e.g. for include metadata).
+                        # Retry once with asm statements stripped.
+                        fallback_command = command + [
+                            "-D__asm__(...)=",
+                            "-Dasm(...)=",
+                        ]
+                        try:
+                            check_call(fallback_command, stderr=stderr)
+                        except CalledProcessError:
+                            os.chdir(cwd)
+                            raise BuildException(
+                                "Could not build {}".format(llvm_file))
                 # Run opt with selected optimisations
                 opt_llvm(llvm_file)
             except BuildException:
@@ -627,7 +642,7 @@ class KernelLlvmSourceBuilder(LlvmSourceFinder):
                         obj = self._get_build_object(c)
                         if not os.path.isfile(obj) or built:
                             check_call(c, stderr=stderr)
-            llvm_file = os.path.join(mod_dir, "{}.ll".format(file_name))
+            llvm_file = os.path.join(mod_dir, "{}.bc".format(file_name))
             opt_llvm(llvm_file)
             return llvm_file
         except CalledProcessError:

--- a/diffkemp/llvm_ir/llvm_module.py
+++ b/diffkemp/llvm_ir/llvm_module.py
@@ -9,7 +9,9 @@ from diffkemp.utils import get_opt_command
 import os
 import re
 import shutil
-from subprocess import check_call, CalledProcessError
+from subprocess import check_call, check_output
+from subprocess import CalledProcessError, PIPE, run
+
 
 # Set of standard functions that are supported, so they should not be
 # included in function collecting.
@@ -76,10 +78,10 @@ class LlvmModule:
             return False
 
         if "-linked" not in self.llvm:
-            new_llvm = "{}-linked.ll".format(self.llvm[:-3])
+            new_llvm = "{}-linked.bc".format(self.llvm[:-3])
         else:
             new_llvm = self.llvm
-        link_command = ["llvm-link", "-S", self.llvm]
+        link_command = ["llvm-link", self.llvm]
         link_command.extend([m.llvm for m in link_llvm_modules])
         link_command.extend(["-o", new_llvm])
         opt_command = get_opt_command([("constmerge", "module")], new_llvm)
@@ -112,17 +114,30 @@ class LlvmModule:
         name = self.llvm_module.find_param_var(param)
         return LlvmParam(name, []) if name is not None else None
 
+    def module_has(self, symtype_pattern, symbol):
+        """
+        Check if a module contains matches for a pattern.
+        Used in has_function, has_global and has_definition.
+        """
+        command = ["llvm-nm", self.llvm]
+        source_dir = os.path.dirname(self.llvm)
+        nm_out = check_output(command, cwd=source_dir)
+        pattern = re.compile(rf"{symtype_pattern} {re.escape(symbol)}$",
+                             re.MULTILINE)
+        match = pattern.search(nm_out.decode())
+        return match is not None
+
     def has_function(self, fun):
         """Check if module contains a function definition."""
-        pattern = re.compile(r"^define.*@{}\(".format(fun), flags=re.MULTILINE)
-        with open(self.llvm, "r") as llvm_file:
-            return pattern.search(llvm_file.read()) is not None
+        return self.module_has("[Tt]", fun)
 
     def has_global(self, glob):
         """Check if module contains a global variable with the given name."""
-        pattern = re.compile(r"^@{}\s*=".format(glob), flags=re.MULTILINE)
-        with open(self.llvm, "r") as llvm_file:
-            return pattern.search(llvm_file.read()) is not None
+        return self.module_has("[DdBbCU]", glob)
+
+    def has_definition(self, symbol):
+        """Check if module contains a given symbol definition."""
+        return self.module_has("[DdBbCTt]", symbol)
 
     def is_declaration(self, fun):
         """
@@ -156,16 +171,21 @@ class LlvmModule:
         if self.llvm.startswith(old_root):
             dest_llvm = os.path.join(new_root,
                                      os.path.relpath(self.llvm, old_root))
-            # Copy the .ll file and replace all occurrences of the old root by
-            # the new root. There are usually in debug info.
-            with open(self.llvm, "r") as llvm:
-                with open(dest_llvm, "w") as llvm_new:
-                    for line in llvm.readlines():
-                        if "constant" not in line:
-                            llvm_new.write(line.replace(old_root.strip("/"),
-                                                        new_root.strip("/")))
-                        else:
-                            llvm_new.write(line)
+            # Copy the .bc file and replace all occurrences of the old root by
+            # the new root. There are usually in debug info. Use textual
+            # LLVM IR to find the paths.
+            command = ["llvm-dis", self.llvm, "-o", "-"]
+            source_dir = os.path.dirname(self.llvm)
+            output = check_output(command, cwd=source_dir).decode()
+            new_lines = []
+            for line in output.splitlines():
+                if "constant" not in line:
+                    new_lines.append(line.replace(old_root.strip("/"),
+                                                  new_root.strip("/")))
+                else:
+                    new_lines.append(line)
+            run(["llvm-as", "-o", dest_llvm], input="\n".join(new_lines),
+                stdout=PIPE, stderr=PIPE, text=True, check=True)
             self.llvm = dest_llvm
 
         if self.source and self.source.startswith(old_root):
@@ -178,18 +198,42 @@ class LlvmModule:
     def get_included_sources(self):
         """
         Get the list of source files that this module includes.
-        Requires debugging information.
+        Sources are extracted from the llvm-bcanalyzer output (with --dump).
+        The are located in the first METADATA_BLOCK as STRINGS.
+        The first string is the file name, second is project directory,
+        the includes follow.
         """
-        # Search for all .h files mentioned in the debug info.
-        pattern = re.compile(r"filename:\s*\"([^\"]*)\", "
-                             r"directory:\s*\"([^\"]*)\"")
+        source_dir = ''.join(os.path.split(self.llvm)[0])
+        command = ["llvm-bcanalyzer", self.llvm, "-dump"]
+        bc_out = check_output(command, cwd=source_dir)
         result = set()
-        with open(self.llvm, "r") as llvm:
-            for line in llvm.readlines():
-                s = pattern.search(line)
-                if (s and (s.group(1).endswith(".h") or
-                           s.group(1).endswith(".c"))):
-                    result.add(os.path.join(s.group(2), s.group(1)))
+        in_metadata = False
+        in_strings = False
+        root_dir = ""
+        source_file = ""
+        for line in bc_out.decode().splitlines():
+            line = line.strip()
+            if line.startswith("<METADATA_BLOCK "):
+                in_metadata = True
+            elif in_metadata and line.startswith("<STRINGS "):
+                in_strings = True
+                continue
+            if not in_strings:
+                continue
+            if line == "}":
+                break
+            # Extract paths: 1st path is source file name,
+            # 2nd is project directory
+            string = line[1:-1]
+            if not source_file:
+                source_file = string
+            elif not root_dir:
+                root_dir = string
+                # Add source file when project directory is known
+                result.add(os.path.join(root_dir, source_file))
+            elif (string.endswith(".h") or string.endswith(".c")
+                  ) and not string.startswith("/"):
+                result.add(os.path.join(root_dir, string))
         return result
 
     def get_functions_using_param(self, param):

--- a/diffkemp/llvm_ir/single_c_builder.py
+++ b/diffkemp/llvm_ir/single_c_builder.py
@@ -22,7 +22,7 @@ class SingleCBuilder(SingleLlvmFinder):
         :param default_optim: use default optimalisations flags
             and run LLVM IR simplification passes
         """
-        llvm_file_name = os.path.splitext(c_file_name)[0] + ".ll"
+        llvm_file_name = os.path.splitext(c_file_name)[0] + ".bc"
         SingleLlvmFinder.__init__(self, source_dir, llvm_file_name)
 
         self.c_file_name = c_file_name

--- a/diffkemp/semdiff/caching.py
+++ b/diffkemp/semdiff/caching.py
@@ -333,6 +333,9 @@ class ComparisonGraph:
         the edge used to get to its vertex in the BFS algorithm is recorded, so
         the parent vertex and the call site can be retrieved.
         """
+        if start_fun_name not in self.vertices:
+            return set(), dict()
+
         start_fun = self[start_fun_name]
         original_source_files = start_fun.files
         visited = set()

--- a/diffkemp/simpll/passes/CalledFunctionsAnalysis.cpp
+++ b/diffkemp/simpll/passes/CalledFunctionsAnalysis.cpp
@@ -27,6 +27,9 @@ CalledFunctionsAnalysis::Result CalledFunctionsAnalysis::run(
         AnalysisManager<Module, Function *> & /*mam*/,
         Function *Main) {
     Result result;
+    if (!Main) {
+        return result;
+    }
     collectCalled(Main, result);
     ProcessedValues.clear();
     return result;
@@ -37,6 +40,7 @@ CalledFunctionsAnalysis::Result CalledFunctionsAnalysis::run(
 /// operands to some instructions in Fun are collected.
 void CalledFunctionsAnalysis::collectCalled(const Function *Fun,
                                             Result &Called) {
+
     if (!Called.insert(Fun).second)
         return;
 

--- a/diffkemp/utils.py
+++ b/diffkemp/utils.py
@@ -2,10 +2,12 @@ import os
 import subprocess
 import re
 import sys
+from subprocess import check_output
 
-LLVM_FUNCTION_REGEX = re.compile(r"^define.*@(\w+)\(", flags=re.MULTILINE)
 # Name of YAML output file created by diffkemp compare command.
 CMP_OUTPUT_FILE = "diffkemp-out.yaml"
+LLVM_FUNCTION_REGEX = re.compile(r"^.* [Tt] ([\w\.]+)$",
+                                 flags=re.MULTILINE)
 
 
 def get_simpll_build_dir():
@@ -70,7 +72,7 @@ def get_opt_command(passes, llvm_file, overwrite=True):
         pass_names = map(lambda p: p[0], passes)
         opt_command.extend(map(lambda pass_name: f"-{pass_name}", pass_names))
     if overwrite:
-        opt_command.extend(["-S", "-o", llvm_file])
+        opt_command.extend(["-o", llvm_file])
     return opt_command
 
 
@@ -124,9 +126,10 @@ def get_functions_from_llvm(llvm_files):
             sys.stderr.write(
                 f"Warning: llvm file '{llvm_filename}' does not exist\n")
             continue
-        with open(llvm_filename, 'r') as llvm_file:
-            llvm_file_content = llvm_file.read()
-            matches = LLVM_FUNCTION_REGEX.findall(llvm_file_content)
-            for match in matches:
-                functions[match] = llvm_filename
+        command = ["llvm-nm", llvm_filename]
+        source_dir = ''.join(os.path.split(llvm_filename)[0])
+        nm_out = check_output(command, cwd=source_dir)
+        matches = LLVM_FUNCTION_REGEX.findall(nm_out.decode())
+        for match in matches:
+            functions[match] = llvm_filename
     return functions

--- a/tests/regression/mock_source_tree.py
+++ b/tests/regression/mock_source_tree.py
@@ -22,7 +22,7 @@ class MockSourceTree(SourceTree):
         self.real_source_tree = real_source_tree
 
     def get_module_for_symbol(self, symbol, created_before=None):
-        llvm_file = os.path.join(self.source_dir, "{}.ll".format(symbol))
+        llvm_file = os.path.join(self.source_dir, "{}.bc".format(symbol))
         src_file = os.path.join(self.source_dir, "{}.c".format(symbol))
 
         if not os.path.exists(llvm_file) and self.real_source_tree is not None:
@@ -35,7 +35,7 @@ class MockSourceTree(SourceTree):
         return LlvmModule(llvm_file, src_file)
 
     def get_kernel_module(self, mod_dir, mod_name):
-        llvm_file = os.path.join(self.source_dir, "{}.ll".format(mod_name))
+        llvm_file = os.path.join(self.source_dir, "{}.bc".format(mod_name))
 
         if not os.path.exists(llvm_file):
             assert self.real_source_tree is not None
@@ -45,7 +45,7 @@ class MockSourceTree(SourceTree):
         return LlvmModule(llvm_file)
 
     def get_sysctl_module(self, sysctl):
-        llvm_file = os.path.join(self.source_dir, "{}.ll".format(sysctl))
+        llvm_file = os.path.join(self.source_dir, "{}.bc".format(sysctl))
         table_file = os.path.join(self.source_dir, "table")
 
         if not os.path.exists(llvm_file):

--- a/tests/testing_projects/.gitignore
+++ b/tests/testing_projects/.gitignore
@@ -1,6 +1,6 @@
 *.o
 
 # Files created by the build command
-*.ll
+*.bc
 function_list
 *.so.llw

--- a/tests/testing_projects/make_based/Makefile
+++ b/tests/testing_projects/make_based/Makefile
@@ -6,10 +6,10 @@ CFLAGS = -O2 -std=c99
 
 default: file.o
 
-# Assembly files should not be compiled to `.ll`
+# Assembly files should not be compiled to `.bc`
 with-assembly: default mod.o sub.o
 
-# Compilation with linking, should be compiled to `.llw`
+# Compilation with linking, should be compiled to `.bcw`
 with-linking: default file.so
 
 # Note: mod.o (mod.S) is implicitly compiled using CC, but sub.o (sub.s)
@@ -23,4 +23,4 @@ file.so: file.o
 	$(CC) $(CFLAGS) -o $@ $^ -shared
 
 clean:
-	rm -f *.o *.ll *.so
+	rm -f *.o *.so *.bc

--- a/tests/testing_projects/make_based/mod.S
+++ b/tests/testing_projects/make_based/mod.S
@@ -1,5 +1,5 @@
 // File for testing of building of snapshots,
-// this file should NOT be compiled to .ll and added to db file.
+// this file should NOT be compiled to .bc and added to db file.
 // Note: File was compiled from a C file, trimmed and edited.
     .text
     .p2align 4

--- a/tests/testing_projects/make_based/sub.s
+++ b/tests/testing_projects/make_based/sub.s
@@ -1,5 +1,5 @@
 # File for testing of building of snapshots,
-# this file should NOT be compiled to .ll and added to db file.
+# this file should NOT be compiled to .bc and added to db file.
 # Note: File was compiled from a C file and trimmed.
     .text
     .p2align 4

--- a/tests/unit_tests/build_test.py
+++ b/tests/unit_tests/build_test.py
@@ -5,6 +5,8 @@ import os
 import pytest
 import re
 import yaml
+from subprocess import check_output
+
 
 SINGLE_C_FILE = os.path.abspath("tests/testing_projects/make_based/file.c")
 MAKE_BASED_PROJECT_DIR = os.path.abspath("tests/testing_projects/make_based")
@@ -42,11 +44,12 @@ def get_db_file_content(snapshot_dir):
 
 def get_llvm_fun_body(llvm_file, fun_name):
     """Returns body of fun_name function from llvm_file."""
-    with open(llvm_file, "r") as file:
-        content = file.read()
-        match = re.search(r"define.*@" + re.escape(fun_name) + r"[ (][^}]*",
-                          content, re.MULTILINE)
-        return match.group(0)
+    command = ["llvm-dis", llvm_file, "-o", "-"]
+    source_dir = os.path.dirname(llvm_file)
+    output = check_output(command, cwd=source_dir).decode()
+    match = re.search(r"define.*@" + re.escape(fun_name) + r"[ (][^}]*",
+                      output, re.MULTILINE)
+    return match.group(0)
 
 
 @pytest.mark.parametrize("source",
@@ -61,11 +64,11 @@ def test_build_command(source, tmp_path):
     # Snapshot should contain source file, LLVM file and file with metadata.
     output_files = os.listdir(output_dir)
     assert "file.c" in output_files
-    assert "file.ll" in output_files
+    assert "file.bc" in output_files
     assert "snapshot.yaml" in output_files
 
     # Functions from the source file should be also in the llvm file.
-    llvm_file_path = os.path.join(output_dir, "file.ll")
+    llvm_file_path = os.path.join(output_dir, "file.bc")
     llvm_fun_list = get_functions_from_llvm([llvm_file_path])
     assert "add" in llvm_fun_list
     assert "mul" in llvm_fun_list
@@ -90,14 +93,14 @@ def test_make_based_with_assembly(tmp_path):
     args = Arguments(MAKE_BASED_PROJECT_DIR, output_dir,
                      target=["with-assembly"])
     build(args)
-    # .s, .S files should not be compiled to .ll
+    # .s, .S files should not be compiled to .bc
     src_dir_files = os.listdir(MAKE_BASED_PROJECT_DIR)
-    assert "mod.ll" not in src_dir_files
-    assert "sub.ll" not in src_dir_files
+    assert "mod.bc" not in src_dir_files
+    assert "sub.bc" not in src_dir_files
     # and they should not be added to db file
     db_file_content = get_db_file_content(output_dir)
-    assert "mod.ll" not in db_file_content
-    assert "sub.ll" not in db_file_content
+    assert "mod.bc" not in db_file_content
+    assert "sub.bc" not in db_file_content
 
 
 def test_make_based_with_linking(tmp_path):
@@ -107,11 +110,11 @@ def test_make_based_with_linking(tmp_path):
                      target=["with-linking"])
     build(args)
     # When linking *.o files, appropriate .ll files
-    # should be linked with llvm-link and saved as `.llw`.
-    # Note: The .llw is not copied to snapshot dir.
-    assert "file.so.llw" in os.listdir(MAKE_BASED_PROJECT_DIR)
+    # should be linked with llvm-link and saved as `.bcw`.
+    # Note: The .bcw is not copied to snapshot dir.
+    assert "file.so.bcw" in os.listdir(MAKE_BASED_PROJECT_DIR)
     db_file_content = get_db_file_content(output_dir)
-    assert "file.so.llw" in db_file_content
+    assert "file.so.bcw" in db_file_content
 
 
 def test_build_no_opt_override(tmp_path):
@@ -123,6 +126,6 @@ def test_build_no_opt_override(tmp_path):
     # With --no-opt-override the optimization level which is written
     # in Makefile should be used, because it is -O2 the `add` function
     # should not be called from the `mul` function` (should be "inlined").
-    llvm_file_path = os.path.join(output_dir, "file.ll")
+    llvm_file_path = os.path.join(output_dir, "file.bc")
     body = get_llvm_fun_body(llvm_file_path, "mul")
     assert re.search(r"call.*@add", body) is None

--- a/tests/unit_tests/caching_test.py
+++ b/tests/unit_tests/caching_test.py
@@ -269,14 +269,14 @@ def test_cachability_reset_after_absorb(graph_uncachable):
 
 @pytest.fixture
 def cache_file():
-    yield SimpLLCache.CacheFile(mkdtemp(), "/test/f1/1.ll", "/test/f2/2.ll")
+    yield SimpLLCache.CacheFile(mkdtemp(), "/test/f1/1.bc", "/test/f2/2.bc")
 
 
 def test_cache_file_init(cache_file):
     """Tests the constructor of the SimpLLCache.CacheFile class."""
-    assert cache_file.left_module == "/test/f1/1.ll"
-    assert cache_file.right_module == "/test/f2/2.ll"
-    assert cache_file.filename.endswith("..$f1$1.ll:..$f2$2.ll")
+    assert cache_file.left_module == "/test/f1/1.bc"
+    assert cache_file.right_module == "/test/f2/2.bc"
+    assert cache_file.filename.endswith("..$f1$1.bc:..$f2$2.bc")
 
 
 def test_cache_file_add_function_pairs(cache_file):
@@ -302,27 +302,27 @@ def simpll_cache():
 def vertices():
     yield [ComparisonGraph.Vertex(dup("f"),
                                   Result.Kind.EQUAL,
-                                  ("/test/f1/1.ll", "/test/f2/2.ll")),
+                                  ("/test/f1/1.bc", "/test/f2/2.bc")),
            ComparisonGraph.Vertex(dup("h"),
                                   Result.Kind.NOT_EQUAL,
-                                  ("/test/f1/1.ll", "/test/f2/3.ll")),
+                                  ("/test/f1/1.bc", "/test/f2/3.bc")),
            ComparisonGraph.Vertex(dup("g"),
                                   Result.Kind.NOT_EQUAL,
-                                  ("/test/f1/1.ll", "/test/f2/2.ll"))]
+                                  ("/test/f1/1.bc", "/test/f2/2.bc"))]
 
 
 def test_simpll_cache_update(simpll_cache, vertices):
     """Tests updating of a SimpLL cache with vertices from a graph."""
     simpll_cache.update(vertices)
     assert os.path.exists(os.path.join(simpll_cache.directory,
-                                       "..$f1$1.ll:..$f2$2.ll"))
+                                       "..$f1$1.bc:..$f2$2.bc"))
     assert os.path.exists(os.path.join(simpll_cache.directory,
-                                       "..$f1$1.ll:..$f2$3.ll"))
+                                       "..$f1$1.bc:..$f2$3.bc"))
     with open(os.path.join(simpll_cache.directory,
-                           "..$f1$1.ll:..$f2$2.ll"), "r") as file:
+                           "..$f1$1.bc:..$f2$2.bc"), "r") as file:
         assert file.readlines() == ["f:f\n", "g:g\n"]
     with open(os.path.join(simpll_cache.directory,
-                           "..$f1$1.ll:..$f2$3.ll"), "r") as file:
+                           "..$f1$1.bc:..$f2$3.bc"), "r") as file:
         assert file.readlines() == ["h:h\n"]
 
 

--- a/tests/unit_tests/kernel_llvm_source_builder_test.py
+++ b/tests/unit_tests/kernel_llvm_source_builder_test.py
@@ -38,13 +38,13 @@ def test_find_llvm_with_symbol_def(builder):
     Test building LLVM module from a source containing a function definition.
     """
     llvm_file = builder.find_llvm_with_symbol_def("__alloc_workqueue_key")
-    assert llvm_file == os.path.join(builder.source_dir, "kernel/workqueue.ll")
+    assert llvm_file == os.path.join(builder.source_dir, "kernel/workqueue.bc")
 
 
 def test_find_llvm_with_symbol_use(builder):
     """Test finding sources using a global variable."""
     srcs = builder.find_llvm_with_symbol_use("net_ratelimit_state")
-    assert srcs == {os.path.join(builder.source_dir, "net/core/utils.ll")}
+    assert srcs == {os.path.join(builder.source_dir, "net/core/utils.bc")}
 
 
 def test_build_cscope_database(builder):
@@ -97,7 +97,7 @@ def test_kbuild_module_commands(builder):
 def test_build_src_to_llvm(builder):
     """Building single object into LLVM."""
     llvm_file = builder._build_source_to_llvm("sound/core/init.c")
-    assert (llvm_file == "sound/core/init.ll")
+    assert (llvm_file == "sound/core/init.bc")
     assert os.path.isfile(os.path.join(builder.source_dir, llvm_file))
 
 
@@ -110,7 +110,7 @@ def test_build_src_to_llvm_fail(builder):
 def test_build_mod_to_llvm(builder):
     """Test building kernel module into LLVM"""
     mod_file = os.path.join(builder.source_dir,
-                            "drivers/firewire/firewire-sbp2.ll")
+                            "drivers/firewire/firewire-sbp2.bc")
     if os.path.isfile(mod_file):
         os.unlink(mod_file)
     builder._build_kernel_mod_to_llvm("drivers/firewire", "firewire-sbp2")

--- a/tests/unit_tests/kernel_source_tree_test.py
+++ b/tests/unit_tests/kernel_source_tree_test.py
@@ -18,10 +18,10 @@ def source():
 
 @pytest.mark.parametrize("name, llvm_file, table", [
     ("net.core.message_burst",
-     "net/core/sysctl_net_core.ll",
+     "net/core/sysctl_net_core.bc",
      "net_core_table"),
     ("kernel.usermodehelper.bset",
-     "kernel/kmod.ll",
+     "kernel/kmod.bc",
      "usermodehelper_table")
 ])
 def test_get_sysctl_module(source, name, llvm_file, table):

--- a/tests/unit_tests/snapshot_test.py
+++ b/tests/unit_tests/snapshot_test.py
@@ -51,11 +51,11 @@ def test_load_snapshot_from_dir_functions():
           list_kind: function
           list:
           - glob_var: null
-            llvm: net/core/skbuff.ll
+            llvm: net/core/skbuff.bc
             name: ___pskb_trim
             tag: null
           - glob_var: null
-            llvm: mm/page_alloc.ll
+            llvm: mm/page_alloc.bc
             name: __alloc_pages_nodemask
             tag: null
           llvm_source_finder:
@@ -87,10 +87,10 @@ def test_load_snapshot_from_dir_functions():
             assert f.tag is None
             if name == "___pskb_trim":
                 assert os.path.abspath(f.mod.llvm) == snap_dir + \
-                       "/net/core/skbuff.ll"
+                       "/net/core/skbuff.bc"
             elif name == "__alloc_pages_nodemask":
                 assert os.path.abspath(f.mod.llvm) == snap_dir + \
-                       "/mm/page_alloc.ll"
+                       "/mm/page_alloc.bc"
 
 
 def test_load_snapshot_from_dir_sysctls():
@@ -111,13 +111,13 @@ def test_load_snapshot_from_dir_sysctls():
           list:
           - functions:
             - glob_var: null
-              llvm: kernel/sched/fair.ll
+              llvm: kernel/sched/fair.bc
               name: sched_proc_update_handler
               tag: proc handler
             sysctl: kernel.sched_latency_ns
           - functions:
             - glob_var: null
-              llvm: kernel/sysctl.ll
+              llvm: kernel/sysctl.bc
               name: proc_dointvec_minmax
               tag: proc handler
             sysctl: kernel.timer_migration
@@ -145,12 +145,12 @@ def test_load_snapshot_from_dir_sysctls():
                 assert g.functions.keys() == {"sched_proc_update_handler"}
                 f = g.functions["sched_proc_update_handler"]
                 assert os.path.abspath(f.mod.llvm) == snap_dir + \
-                    "/kernel/sched/fair.ll"
+                    "/kernel/sched/fair.bc"
             elif name == "kernel.timer_migration":
                 assert g.functions.keys() == {"proc_dointvec_minmax"}
                 f = g.functions["proc_dointvec_minmax"]
                 assert os.path.abspath(f.mod.llvm) == snap_dir + \
-                    "/kernel/sysctl.ll"
+                    "/kernel/sysctl.bc"
             assert f.tag == "proc handler"
             assert f.glob_var is None
 
@@ -163,7 +163,7 @@ def test_add_fun_none_group():
     snap = Snapshot.create_from_source(source, output_dir,
                                        "function", True, False)
 
-    mod = LlvmModule("net/core/skbuff.ll")
+    mod = LlvmModule("net/core/skbuff.bc")
     snap.add_fun("___pskb_trim", mod)
 
     assert "___pskb_trim" in snap.fun_groups[None].functions
@@ -181,7 +181,7 @@ def test_add_fun_sysctl_group():
     snap = Snapshot.create_from_source(source, output_dir,
                                        "sysctl", True, False)
 
-    mod = LlvmModule("kernel/sched/debug.ll")
+    mod = LlvmModule("kernel/sched/debug.bc")
     snap.add_fun("sched_debug_header",
                  mod,
                  "sysctl_sched_latency",
@@ -210,16 +210,16 @@ def test_get_modules():
                                        "sysctl", True, False)
 
     snap.add_fun("sched_proc_update_handler",
-                 LlvmModule("kernel/sched/fair.ll"), None,
+                 LlvmModule("kernel/sched/fair.bc"), None,
                  "proc_handler", "kernel.sched_latency_ns")
-    snap.add_fun("proc_dointvec_minmax", LlvmModule("kernel/sysctl.ll"),
+    snap.add_fun("proc_dointvec_minmax", LlvmModule("kernel/sysctl.bc"),
                  None,
                  "proc_handler", "kernel.timer_migration")
 
     modules = snap.modules()
     assert len(modules) == 2
-    assert set([m.llvm for m in modules]) == {"kernel/sched/fair.ll",
-                                              "kernel/sysctl.ll"}
+    assert set([m.llvm for m in modules]) == {"kernel/sched/fair.bc",
+                                              "kernel/sysctl.bc"}
 
 
 def test_get_by_name_functions():
@@ -230,8 +230,8 @@ def test_get_by_name_functions():
     snap = Snapshot.create_from_source(source, output_dir,
                                        "function", True, False)
 
-    mod_buff = LlvmModule("net/core/skbuff.ll")
-    mod_alloc = LlvmModule("mm/page_alloc.ll")
+    mod_buff = LlvmModule("net/core/skbuff.bc")
+    mod_alloc = LlvmModule("mm/page_alloc.bc")
     snap.add_fun("___pskb_trim", mod_buff)
     snap.add_fun("__alloc_pages_nodemask", mod_alloc)
 
@@ -250,9 +250,9 @@ def test_get_by_name_sysctls():
                                        "sysctl", True, False)
 
     mod_fair = LlvmModule(
-        "snapshots-sysctl/linux-3.10.0-957.el7/kernel/sched/fair.ll")
+        "snapshots-sysctl/linux-3.10.0-957.el7/kernel/sched/fair.bc")
     mod_sysctl = LlvmModule(
-        "snapshots-sysctl/linux-3.10.0-957.el7/kernel/sysctl.ll")
+        "snapshots-sysctl/linux-3.10.0-957.el7/kernel/sysctl.bc")
     snap.add_fun("sched_proc_update_handler", mod_fair, None, "proc handler",
                  "kernel.sched_latency_ns")
     snap.add_fun("proc_dointvec_minmax", mod_sysctl, None, "proc handler",
@@ -273,9 +273,9 @@ def test_filter():
     snap = Snapshot.create_from_source(source, output_dir,
                                        "function", True, False)
 
-    snap.add_fun("___pskb_trim", LlvmModule("net/core/skbuff.ll"))
+    snap.add_fun("___pskb_trim", LlvmModule("net/core/skbuff.bc"))
     snap.add_fun("__alloc_pages_nodemask",
-                 LlvmModule("mm/page_alloc.ll"))
+                 LlvmModule("mm/page_alloc.bc"))
 
     snap.filter(["__alloc_pages_nodemask"])
     assert len(snap.fun_groups[None].functions) == 1
@@ -299,9 +299,9 @@ def test_to_yaml_functions():
                                        "function", True, False)
 
     snap.add_fun("___pskb_trim", LlvmModule(
-        "snapshots/linux-3.10.0-957.el7/net/core/skbuff.ll"))
+        "snapshots/linux-3.10.0-957.el7/net/core/skbuff.bc"))
     snap.add_fun("__alloc_pages_nodemask", LlvmModule(
-        "snapshots/linux-3.10.0-957.el7/mm/page_alloc.ll"))
+        "snapshots/linux-3.10.0-957.el7/mm/page_alloc.bc"))
 
     yaml_str = snap.to_yaml()
     yaml_snap = yaml.safe_load(yaml_str)
@@ -318,9 +318,9 @@ def test_to_yaml_functions():
 
     for f in yaml_dict["list"]:
         if f["name"] == "___pskb_trim":
-            assert f["llvm"] == "net/core/skbuff.ll"
+            assert f["llvm"] == "net/core/skbuff.bc"
         elif f["name"] == "__alloc_pages_nodemask":
-            assert f["llvm"] == "mm/page_alloc.ll"
+            assert f["llvm"] == "mm/page_alloc.bc"
 
 
 def test_to_yaml_sysctls():
@@ -341,11 +341,11 @@ def test_to_yaml_sysctls():
     snap.add_fun("sched_proc_update_handler",
                  LlvmModule(
                      "snapshots-sysctl/linux-3.10.0-957.el7/"
-                     "kernel/sched/fair.ll"),
+                     "kernel/sched/fair.bc"),
                  None, "proc handler", "kernel.sched_latency_ns")
     snap.add_fun("proc_dointvec_minmax",
                  LlvmModule(
-                     "snapshots-sysctl/linux-3.10.0-957.el7/kernel/sysctl.ll"),
+                     "snapshots-sysctl/linux-3.10.0-957.el7/kernel/sysctl.bc"),
                  None, "proc handler", "kernel.timer_migration")
 
     yaml_str = snap.to_yaml()
@@ -365,14 +365,14 @@ def test_to_yaml_sysctls():
         if g["sysctl"] == "kernel.sched_latency_ns":
             assert g["functions"][0] == {
                 "name": "sched_proc_update_handler",
-                "llvm": "kernel/sched/fair.ll",
+                "llvm": "kernel/sched/fair.bc",
                 "glob_var": None,
                 "tag": "proc handler"
             }
         elif g["sysctl"] == "kernel.timer_migration":
             assert g["functions"][0] == {
                 "name": "proc_dointvec_minmax",
-                "llvm": "kernel/sysctl.ll",
+                "llvm": "kernel/sysctl.bc",
                 "glob_var": None,
                 "tag": "proc handler"
             }

--- a/tests/unit_tests/source_tree_test.py
+++ b/tests/unit_tests/source_tree_test.py
@@ -30,7 +30,7 @@ def test_get_module_for_symbol(source):
     """
     mod = source.get_module_for_symbol("__alloc_workqueue_key")
     assert mod is not None
-    assert mod.llvm == os.path.join(source.source_dir, "kernel/workqueue.ll")
+    assert mod.llvm == os.path.join(source.source_dir, "kernel/workqueue.bc")
     assert mod.has_function("__alloc_workqueue_key")
 
 
@@ -41,7 +41,7 @@ def test_get_module_for_symbol_built_after(source):
     The LLVM file should not be retrieved.
     """
     before_time = datetime.datetime.now() - datetime.timedelta(minutes=1)
-    llvm_file = os.path.join(source.source_dir, "kernel/workqueue.ll")
+    llvm_file = os.path.join(source.source_dir, "kernel/workqueue.bc")
 
     # Temporarily change mtime of the LLVM IR file to now
     stat = os.stat(llvm_file)
@@ -60,7 +60,7 @@ def test_get_module_for_symbol_built_after(source):
 def test_get_module_for_symbol_fail(source):
     """Test getting LLVM module for a non-existing function definition."""
     with pytest.raises(SourceNotFoundException):
-        source.get_module_for_symbol("__get_user_2")
+        source.get_module_for_symbol("__get_user_3")
 
 
 def test_get_modules_using_symbol(source):
@@ -71,8 +71,8 @@ def test_get_modules_using_symbol(source):
     assert len(mods) == 2
     assert set([m.llvm for m in mods]) == \
         set([os.path.join(source.source_dir, f)
-             for f in ["net/core/sock.ll",
-                       "net/netfilter/ipvs/ip_vs_sync.ll"]])
+             for f in ["net/core/sock.bc",
+                       "net/netfilter/ipvs/ip_vs_sync.bc"]])
 
 
 def test_copy_source_files(source):
@@ -87,8 +87,8 @@ def test_copy_source_files(source):
         assert os.path.isdir(os.path.join(tmp_source.source_dir, d))
 
     # Check that files were successfully copied.
-    for f in ["net/core/utils.c", "net/core/utils.ll", "kernel/workqueue.c",
-              "kernel/workqueue.ll", "include/linux/module.h",
+    for f in ["net/core/utils.c", "net/core/utils.bc", "kernel/workqueue.c",
+              "kernel/workqueue.bc", "include/linux/module.h",
               "include/linux/kernel.h"]:
         assert os.path.isfile(os.path.join(tmp_source.source_dir, f))
 


### PR DESCRIPTION
This PR is a continuation of #382

While finishing the PR, I ran into an issue with the `kernel_module_test` failing when using clang-19. It turns out newer versions of Clang reject certain inline assembly code even when we're just trying to generate LLVM IR. I fixed this in `llvm_ir/kernel_source_builder.py` by adding a fallback `check_call`. If the initial build fails, it retries and strips out the assembly statements using `-D__asm__(...)=` and `-Dasm(...)=`.

This inline assembly is the exact same thing causing the segmentation fault when comparing musl libraries, specifically `dl_start.c`. The inline assembly results in a null pointer dereference. I tried to find a workaround during the build phase, but there doesn't seem to be a complete solution without actually modifying the SimpLL library itself.

As @PLukas2018 pointed out in #382, the best fix is probably to add a check in the SimpLL library to make sure the function isn't nullptr after we get it by name.

Let me know what you think about this approach, or if you have any other feedback.