### PR TITLE
Module parameters comparison

### DIFF
--- a/diffkemp/building/build_kernel.py
+++ b/diffkemp/building/build_kernel.py
@@ -5,8 +5,10 @@ from diffkemp.snapshot import Snapshot
 from diffkemp.building.build_utils import (
     generate_from_function_list,
     add_funcs_for_globvar,
+    add_funcs_for_globvar_from_module,
     read_symbol_list,
     EMSG_EMPTY_SYMBOL_LIST)
+from pathlib import Path
 import errno
 import os
 import sys
@@ -32,6 +34,8 @@ def build_kernel(args):
     # Generate snapshot contents
     if args.sysctl:
         generate_from_sysctl_list(snapshot, symbol_list)
+    elif args.module_params:
+        generate_from_module_param_list(snapshot, symbol_list)
     else:
         generate_from_function_list(snapshot, symbol_list)
 
@@ -46,7 +50,12 @@ def _generate_snapshot(args):
         sys.exit(errno.EINVAL)
 
     source = KernelSourceTree(args.source_dir, source_finder)
-    list_kind = "sysctl" if args.sysctl else "function"
+    if args.sysctl:
+        list_kind = "sysctl"
+    elif args.module_params:
+        list_kind = "module:param"
+    else:
+        list_kind = "function"
 
     return Snapshot.create_from_source(source,
                                        args.output_dir,
@@ -100,6 +109,26 @@ def generate_from_sysctl_list(snapshot, sysctl_list):
             # Adds functions which use the sysctl data variable
             data = sysctl_mod.get_data(sysctl)
             add_funcs_for_globvar(snapshot, sysctl, data, proc_fun)
+
+
+def generate_from_module_param_list(snapshot, module_param_list):
+    """
+    Generate a snapshot from a list of pairs path:param.
+    :param snapshot: Existing Snapshot object to fill
+    :param module_param_list: List of pairs path_to_module:parameter_name.
+    """
+    for pair in module_param_list:
+        try:
+            path_str, param = pair.split(":")
+            path = Path(path_str)
+            module = snapshot.source_tree.get_kernel_module(str(path.parent),
+                                                            path.name)
+            data = module.find_param_var(param)
+        except (ValueError, SourceNotFoundException):
+            print("{}: modul:param not supported".format(pair))
+            continue
+
+        add_funcs_for_globvar_from_module(snapshot, data.name, data, module)
 
 
 def _add_proc_handler(snapshot, sysctl, proc_fun):

--- a/diffkemp/building/build_utils.py
+++ b/diffkemp/building/build_utils.py
@@ -57,8 +57,9 @@ def generate_from_function_list(snapshot, fun_list):
 def add_funcs_for_globvar(snapshot, name, data, skip_fun=None):
     functions_added = False
     if not data:
-        return functions_added
+        return False
 
+    functions_added = False
     for module in \
             snapshot.source_tree.get_modules_using_symbol(data.name):
         # For now, we only support the x86 architecture in kernel
@@ -66,21 +67,30 @@ def add_funcs_for_globvar(snapshot, name, data, skip_fun=None):
                 "/arch/x86/" not in module.llvm:
             continue
 
-        curr_mod_path = os.path.relpath(module.llvm,
-                                        snapshot.source_tree.source_dir)
-        for func in module.get_functions_using_param(data):
-            if skip_fun is not None and func == skip_fun:
-                continue
+        functions_added |= add_funcs_for_globvar_from_module(snapshot, name,
+                                                             data, module,
+                                                             skip_fun)
+    return functions_added
 
-            functions_added = True
-            snapshot.add_fun(
-                name=func,
-                llvm_mod=module,
-                glob_var=data.name,
-                tag="using global variable \"{}\"".format(data.name),
-                group=name)
-            print("  {}: {} (using global variable \"{}\")".format(
-                func,
-                curr_mod_path,
-                data.name))
+
+def add_funcs_for_globvar_from_module(snapshot, name, data,
+                                      module, skip_fun=None):
+    functions_added = False
+    curr_mod_path = os.path.relpath(module.llvm,
+                                    snapshot.source_tree.source_dir)
+    for func in module.get_functions_using_param(data):
+        if skip_fun is not None and func == skip_fun:
+            continue
+
+        functions_added = True
+        snapshot.add_fun(
+            name=func,
+            llvm_mod=module,
+            glob_var=data.name,
+            tag="using global variable \"{}\"".format(data.name),
+            group=name)
+        print("  {}: {} (using global variable \"{}\")".format(
+            func,
+            curr_mod_path,
+            data.name))
     return functions_added

--- a/diffkemp/cli.py
+++ b/diffkemp/cli.py
@@ -85,6 +85,11 @@ def make_argument_parser():
         action="store_true",
         help="interpret symbol list as a list of sysctl parameters")
     build_kernel_ap.add_argument(
+        "--module-params",
+        action="store_true",
+        help="interpret symbol list as a list of kernel module parameters in \
+        the form module_path:parameter")
+    build_kernel_ap.add_argument(
         "--no-source-dir",
         action="store_true",
         help="do not store path to the source kernel directory in snapshot")

--- a/diffkemp/snapshot.py
+++ b/diffkemp/snapshot.py
@@ -226,15 +226,13 @@ class Snapshot:
             groups = yaml_dict["list"]
 
         for g in groups:
-            if "sysctl" in g:
-                group = g["sysctl"]
-                functions = g["functions"]
-            elif "glob_var" in g:
-                group = g["glob_var"]
-                functions = g["functions"]
-            else:
-                group = None
-                functions = g
+            group = None
+            functions = g
+            for list_kind in ["sysctl", "glob_var", "module:param"]:
+                if list_kind in g:
+                    group = g[list_kind]
+                    functions = g["functions"]
+                    break
             for f in functions:
                 self.add_fun(f["name"],
                              LlvmModule(

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -102,6 +102,16 @@ once such as:
 Currently, these sysctl option groups are supported: `kernel.*`,
 `vm.*`, `fs.*`, `net.core.*`, `net.ipv4.conf.*`.
 
+#### Comparing kernel modules
+
+Another supported mode of comparison is comparison of kernel modules. Similarly
+to sysctl option comparison, the list of module parameters to compare can be
+passed via `SYMBOL_LIST` to the `build-kernel` command together with the
+`--module-params` switch. Each entry in `SYMBOL_LIST` should have the form
+`module_path:parameter`. For each module parameter, DiffKemp compares semantics
+of all functions using the global variable corresponding to the parameter.
+Again, the `compare` command is used in the normal way.
+
 #### Options
 
 - `KERNEL_DIR`: Path to a kernel's root directory.
@@ -111,6 +121,8 @@ Currently, these sysctl option groups are supported: `kernel.*`,
   In case `--sysctl` is used, the list is interpreted as a list of sysctl
   parameters.
 - `--sysctl`: Compares sysctl option.
+- `--module-params`: Compares semantics of all functions from a given module
+  using the global variable corresponding to a given module parameter.
 - `--no-source-dir`: Does not store the path to the source kernel directory in
   the snapshot. This is useful if the comparison is done on a different system
   than building the snapshot (i.e. the path to the original kernel tree does


### PR DESCRIPTION
Adds the CLI option --module-params. When used, the symbol list is
interpreted as a list of pairs in the form
`path_to_module:parameter`. For each pair, all functions from the
module using the global variable corresponding to the module
parameter are compared.

This PR is built on top of the commits from the
[Add comparison of global variables](https://github.com/diffkemp/diffkemp/pull/432)
PR, because both modify the same functions in
[diffkemp/building/build_utils.py](https://github.com/davidkre525/diffkemp/blob/module-parameters-comparison/diffkemp/building/build_utils.py).

Since the mentioned PR has not been merged yet, its commits are also
visible here.